### PR TITLE
Refactor query tests

### DIFF
--- a/deps.json
+++ b/deps.json
@@ -14,11 +14,6 @@
         "version": "master",
         "type": "git"
     },
-    "goconvey": {
-        "repo": "github.com/smartystreets/goconvey",
-        "version": "master",
-        "type": "git"
-    },
     "gocql": {
         "repo": "github.com/gocql/gocql",
         "version": "f8fb76bb772442ea938e4be46ab1666e542411a5",

--- a/index/storage_test.go
+++ b/index/storage_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestStorage(t *testing.T) {

--- a/query/lexer_test.go
+++ b/query/lexer_test.go
@@ -1,213 +1,279 @@
-package query
+package query_test
 
 import (
+	"reflect"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/umbel/pilosa/query"
 )
 
-func TestLexer(t *testing.T) {
-	Convey("Basic lexical analysis", t, func() {
-		var tokens []Token
-		var err error
+// Ensure a simple function and value can be lexed.
+func TestLexer_Lex_FuncValue(t *testing.T) {
+	if tokens, err := query.Lex("get(10)"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("get(10)")
-		So(err, ShouldBeNil)
-		So(len(tokens), ShouldEqual, 4)
-		So(tokens, ShouldResemble, []Token{
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"10", TYPE_VALUE},
-			{")", TYPE_RP},
-		})
+// Ensure a simple function, keyword, & value can be lexed.
+func TestLexer_Lex_FuncKeywordValue(t *testing.T) {
+	if tokens, err := query.Lex("get(id=10)"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"id", query.TYPE_KEYWORD},
+		{"=", query.TYPE_EQUALS},
+		{"10", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("get(id=10)")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"id", TYPE_KEYWORD},
-			{"=", TYPE_EQUALS},
-			{"10", TYPE_VALUE},
-			{")", TYPE_RP},
-		})
+// Ensure a more complex function can be lexed.
+func TestLexer_Lex_FuncComplex(t *testing.T) {
+	if tokens, err := query.Lex("get(id=10, frame=brand)"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"id", query.TYPE_KEYWORD},
+		{"=", query.TYPE_EQUALS},
+		{"10", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"frame", query.TYPE_KEYWORD},
+		{"=", query.TYPE_EQUALS},
+		{"brand", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("get(id=10, frame=brand)")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"id", TYPE_KEYWORD},
-			{"=", TYPE_EQUALS},
-			{"10", TYPE_VALUE},
-			{",", TYPE_COMMA},
-			{"frame", TYPE_KEYWORD},
-			{"=", TYPE_EQUALS},
-			{"brand", TYPE_VALUE},
-			{")", TYPE_RP},
-		})
+// Ensure that nested functions can be lexed.
+func TestLexer_Lex_FuncNested(t *testing.T) {
+	if tokens, err := query.Lex("union(get(10))"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"union", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("union(get(10))")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"union", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"10", TYPE_VALUE},
-			{")", TYPE_RP},
-			{")", TYPE_RP},
-		})
+// Ensure that a list of nested functions can be lexed.
+func TestLexer_Lex_FuncNestedList(t *testing.T) {
+	if tokens, err := query.Lex("intersect(get(10), get(11), get(12))"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"intersect", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"11", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"12", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("intersect(get(10), get(11), get(12))")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"intersect", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"10", TYPE_VALUE},
-			{")", TYPE_RP},
-			{",", TYPE_COMMA},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"11", TYPE_VALUE},
-			{")", TYPE_RP},
-			{",", TYPE_COMMA},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"12", TYPE_VALUE},
-			{")", TYPE_RP},
-			{")", TYPE_RP},
-		})
+// Ensure that complex nested functions can be lexed.
+func TestLexer_Lex_FuncNestedComplex(t *testing.T) {
+	if tokens, err := query.Lex("intersect(get(10), get(11), concat(get(12),get(14)))"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"intersect", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"11", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"concat", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"12", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"14", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{")", query.TYPE_RP},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("intersect(get(10), get(11), concat(get(12),get(14)))")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"intersect", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"10", TYPE_VALUE},
-			{")", TYPE_RP},
-			{",", TYPE_COMMA},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"11", TYPE_VALUE},
-			{")", TYPE_RP},
-			{",", TYPE_COMMA},
-			{"concat", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"12", TYPE_VALUE},
-			{")", TYPE_RP},
-			{",", TYPE_COMMA},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"14", TYPE_VALUE},
-			{")", TYPE_RP},
-			{")", TYPE_RP},
-			{")", TYPE_RP},
-		})
+// Ensure that complex nested functions can be lexed.
+func TestLexer_Lex_FuncNestedComplex2(t *testing.T) {
+	if tokens, err := query.Lex("concat(get(1, brand),get(2))"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"concat", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"1", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"brand", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"2", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("concat(get(1, brand),get(2))")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"concat", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"1", TYPE_VALUE},
-			{",", TYPE_COMMA},
-			{"brand", TYPE_VALUE},
-			{")", TYPE_RP},
-			{",", TYPE_COMMA},
-			{"get", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"2", TYPE_VALUE},
-			{")", TYPE_RP},
-			{")", TYPE_RP},
-		})
+// Ensure that a set function can be lexed.
+func TestLexer_Lex_Set1(t *testing.T) {
+	if tokens, err := query.Lex("set(1, 987)"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"set", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"1", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"987", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("set(1, 987)")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"set", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"1", TYPE_VALUE},
-			{",", TYPE_COMMA},
-			{"987", TYPE_VALUE},
-			{")", TYPE_RP},
-		})
+// Ensure that a set function can be lexed.
+func TestLexer_Lex_Set2(t *testing.T) {
+	if tokens, err := query.Lex("set(1, general, 987)"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"set", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"1", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"general", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"987", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("set(1, general, 987)")
-		So(err, ShouldBeNil)
-		So(tokens, ShouldResemble, []Token{
-			{"set", TYPE_FUNC},
-			{"(", TYPE_LP},
-			{"1", TYPE_VALUE},
-			{",", TYPE_COMMA},
-			{"general", TYPE_VALUE},
-			{",", TYPE_COMMA},
-			{"987", TYPE_VALUE},
-			{")", TYPE_RP},
-		})
+// Ensure that a TopN function can be lexed.
+func TestLexer_Lex_TopN1(t *testing.T) {
+	if tokens, err := query.Lex("top-n(get(10), 8)"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"top-n", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"8", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("top-n(get(10), 8)")
-		So(tokens, ShouldResemble, []Token{
-			Token{"top-n", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"get", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"10", TYPE_VALUE},
-			Token{")", TYPE_RP},
-			Token{",", TYPE_COMMA},
-			Token{"8", TYPE_VALUE},
-			Token{")", TYPE_RP},
-		})
+// Ensure that a TopN function can be lexed.
+func TestLexer_Lex_TopN2(t *testing.T) {
+	if tokens, err := query.Lex("top-n(get(10, general), [1,2,3])"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"top-n", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"general", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"[", query.TYPE_LB},
+		{"1", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"2", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"3", query.TYPE_VALUE},
+		{"]", query.TYPE_RB},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("top-n(get(10, general), [1,2,3])")
-		So(tokens, ShouldResemble, []Token{
-			Token{"top-n", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"get", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"10", TYPE_VALUE},
-			Token{",", TYPE_COMMA},
-			Token{"general", TYPE_VALUE},
-			Token{")", TYPE_RP},
-			Token{",", TYPE_COMMA},
-			Token{"[", TYPE_LB},
-			Token{"1", TYPE_VALUE},
-			Token{",", TYPE_COMMA},
-			Token{"2", TYPE_VALUE},
-			Token{",", TYPE_COMMA},
-			Token{"3", TYPE_VALUE},
-			Token{"]", TYPE_RB},
-			Token{")", TYPE_RP},
-		})
+// Ensure that a plugin function can be lexed.
+func TestLexer_Lex_Plugin(t *testing.T) {
+	if tokens, err := query.Lex("plugin(get(10, general), [get(11, general)])"); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(tokens, []query.Token{
+		{"plugin", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"10", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"general", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{",", query.TYPE_COMMA},
+		{"[", query.TYPE_LB},
+		{"get", query.TYPE_FUNC},
+		{"(", query.TYPE_LP},
+		{"11", query.TYPE_VALUE},
+		{",", query.TYPE_COMMA},
+		{"general", query.TYPE_VALUE},
+		{")", query.TYPE_RP},
+		{"]", query.TYPE_RB},
+		{")", query.TYPE_RP},
+	}) {
+		t.Fatalf("unexpected tokens:\n\n%s", spew.Sprint(tokens))
+	}
+}
 
-		tokens, err = Lex("plugin(get(10, general), [get(11, general)])")
-		So(tokens, ShouldResemble, []Token{
-			Token{"plugin", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"get", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"10", TYPE_VALUE},
-			Token{",", TYPE_COMMA},
-			Token{"general", TYPE_VALUE},
-			Token{")", TYPE_RP},
-			Token{",", TYPE_COMMA},
-			Token{"[", TYPE_LB},
-			Token{"get", TYPE_FUNC},
-			Token{"(", TYPE_LP},
-			Token{"11", TYPE_VALUE},
-			Token{",", TYPE_COMMA},
-			Token{"general", TYPE_VALUE},
-			Token{")", TYPE_RP},
-			Token{"]", TYPE_RB},
-			Token{")", TYPE_RP},
-		})
-	})
+// MustLex lexes s and returns a set of tokens. Panic on error.
+func MustLex(s string) []query.Token {
+	a, err := query.Lex(s)
+	if err != nil {
+		panic(err)
+	}
+	return a
 }

--- a/query/query_test.go
+++ b/query/query_test.go
@@ -1,32 +1,36 @@
-package query
+package query_test
 
 import (
+	"reflect"
 	"testing"
 
-	. "github.com/smartystreets/goconvey/convey"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/umbel/pilosa/query"
 )
 
-func TestQuery(t *testing.T) {
-	Convey("Bracketed Lists 1", t, func() {
-		tokens, err := Lex("plugin(get(88, general), [get(12, general), get(13, general)])")
-		So(err, ShouldBeNil)
-		filter, filters := TokensToFilterStrings(tokens)
-		So(filter, ShouldEqual, "get(88,general)")
-		So(filters, ShouldResemble, []string{"get(12,general)", "get(13,general)"})
-	})
-	Convey("Bracketed Lists 2", t, func() {
-		tokens, err := Lex("plugin(intersect(get(88, general, [0]), get(77, b.n)), [get(12, general), get(13, general)])")
-		So(err, ShouldBeNil)
-		filter, filters := TokensToFilterStrings(tokens)
-		So(filter, ShouldEqual, "intersect(get(88,general,[0]),get(77,b.n))")
-		So(filters, ShouldResemble, []string{"get(12,general)", "get(13,general)"})
-	})
-	Convey("Bracketed Lists 3", t, func() {
-		tokens, err := Lex("plugin(intersect(get(88, general, [0]), get(77, b.n)))")
-		So(err, ShouldBeNil)
-		filter, filters := TokensToFilterStrings(tokens)
-		So(filter, ShouldEqual, "intersect(get(88,general,[0]),get(77,b.n))")
-		var empty []string
-		So(filters, ShouldResemble, empty)
-	})
+func TestTokensToFilterStrings1(t *testing.T) {
+	filter, filters := query.TokensToFilterStrings(MustLex("plugin(get(88, general), [get(12, general), get(13, general)])"))
+	if filter != "get(88,general)" {
+		t.Fatalf("unexpected filter: %s", filter)
+	} else if !reflect.DeepEqual(filters, []string{"get(12,general)", "get(13,general)"}) {
+		t.Fatalf("unexpected filters: %s", spew.Sprint(filters))
+	}
+}
+
+func TestTokensToFilterStrings2(t *testing.T) {
+	filter, filters := query.TokensToFilterStrings(MustLex("plugin(intersect(get(88, general, [0]), get(77, b.n)), [get(12, general), get(13, general)])"))
+	if filter != "intersect(get(88,general,[0]),get(77,b.n))" {
+		t.Fatalf("unexpected filter: %s", filter)
+	} else if !reflect.DeepEqual(filters, []string{"get(12,general)", "get(13,general)"}) {
+		t.Fatalf("unexpected filters: %s", spew.Sprint(filters))
+	}
+}
+
+func TestTokensToFilterStrings3(t *testing.T) {
+	filter, filters := query.TokensToFilterStrings(MustLex("plugin(intersect(get(88, general, [0]), get(77, b.n)))"))
+	if filter != "intersect(get(88,general,[0]),get(77,b.n))" {
+		t.Fatalf("unexpected filter: %s", filter)
+	} else if !reflect.DeepEqual(filters, []string(nil)) {
+		t.Fatalf("unexpected filters: %s", spew.Sprint(filters))
+	}
 }


### PR DESCRIPTION
## Overview

This commit refactors the query package tests to use the standard library testing package instead of goconvey. Goconvey is now completely removed from the repository.

/cc @travisturner 
