### PR TITLE
Cluster-wide Import

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -15,7 +15,7 @@ const (
 
 // Node represents a node in the cluster.
 type Node struct {
-	Host string
+	Host string `json:"host"`
 }
 
 // Nodes represents a list of nodes.

--- a/handler_test.go
+++ b/handler_test.go
@@ -293,6 +293,22 @@ func TestHandler_Version(t *testing.T) {
 	}
 }
 
+// Ensure the handler can return a list of nodes for a slice.
+func TestHandler_Slices_Nodes(t *testing.T) {
+	h := NewHandler()
+	h.Cluster = NewCluster(3)
+	h.Cluster.ReplicaN = 2
+
+	w := httptest.NewRecorder()
+	r := MustNewHTTPRequest("GET", "/slices/nodes?slice=0", nil)
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	} else if w.Body.String() != `[{"host":"host2"},{"host":"host0"}]`+"\n" {
+		t.Fatalf("unexpected body: %q", w.Body.String())
+	}
+}
+
 // Ensure the handler can return expvars without panicking.
 func TestHandler_Expvars(t *testing.T) {
 	h := NewHandler()


### PR DESCRIPTION
## Overview

This pull request fixes the `pilosactl import` command to import data files across an entire cluster of machines.

A `pilosactl config` command is also added to provide a default config.

---

/cc @tgruben 
