### PR TITLE
Support uint64 in roaring bitmaps

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -201,8 +201,8 @@ func (f *Fragment) bitmap(bitmapID uint64) *Bitmap {
 
 	// Read bitmap from storage.
 	bm := NewBitmap()
-	f.storage.ForEachRange(uint32(bitmapID)*SliceWidth, uint32(bitmapID+1)*SliceWidth, func(i uint32) {
-		profileID := (f.slice * SliceWidth) + (uint64(i) % SliceWidth)
+	f.storage.ForEachRange(bitmapID*SliceWidth, (bitmapID+1)*SliceWidth, func(i uint64) {
+		profileID := (f.slice * SliceWidth) + (i % SliceWidth)
 		bm.setBit(profileID)
 	})
 
@@ -292,14 +292,14 @@ func (f *Fragment) ClearBit(bitmapID, profileID uint64) error {
 }
 
 // pos translates the bitmap ID and profile ID into a position in the storage bitmap.
-func (f *Fragment) pos(bitmapID, profileID uint64) (uint32, error) {
+func (f *Fragment) pos(bitmapID, profileID uint64) (uint64, error) {
 	// Return an error if the profile ID is out of the range of the fragment's slice.
 	minProfileID := f.slice * SliceWidth
 	if profileID < minProfileID || profileID >= minProfileID+SliceWidth {
 		return 0, errors.New("profile out of bounds")
 	}
 
-	return uint32((bitmapID * SliceWidth) + (profileID % SliceWidth)), nil
+	return (bitmapID * SliceWidth) + (profileID % SliceWidth), nil
 }
 
 func (f *Fragment) TopN(src *Bitmap, n int, categories []uint64) []Pair {

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -13,17 +13,72 @@ import (
 	"github.com/umbel/pilosa/roaring"
 )
 
+// Ensure an empty bitmap returns false if checking for existence.
+func TestBitmap_Contains_Empty(t *testing.T) {
+	if roaring.NewBitmap().Contains(1000) {
+		t.Fatal("expected false")
+	}
+}
+
+// Ensure an empty bitmap does nothing when removing an element.
+func TestBitmap_Remove_Empty(t *testing.T) {
+	roaring.NewBitmap().Remove(1000)
+}
+
+// Ensure a bitmap can return a slice of values.
+func TestBitmap_Slice(t *testing.T) {
+	if a := roaring.NewBitmap(1, 2, 3).Slice(); !reflect.DeepEqual(a, []uint64{1, 2, 3}) {
+		t.Fatalf("unexpected slice: %+v", a)
+	}
+}
+
+// Ensure an empty bitmap returns an empty slice of values.
+func TestBitmap_Slice_Empty(t *testing.T) {
+	if a := roaring.NewBitmap().Slice(); len(a) != 0 {
+		t.Fatalf("unexpected slice: %+v", a)
+	}
+}
+
+// Ensure a bitmap can return a slice of values within a range.
+func TestBitmap_SliceRange(t *testing.T) {
+	if a := roaring.NewBitmap(0, 1000001, 1000002, 1000003).SliceRange(1, 1000003); !reflect.DeepEqual(a, []uint64{1000001, 1000002}) {
+		t.Fatalf("unexpected slice: %+v", a)
+	}
+}
+
+// Ensure a bitmap can loop over a set of values.
+func TestBitmap_ForEach(t *testing.T) {
+	var a []uint64
+	roaring.NewBitmap(1, 2, 3).ForEach(func(v uint64) {
+		a = append(a, v)
+	})
+	if !reflect.DeepEqual(a, []uint64{1, 2, 3}) {
+		t.Fatalf("unexpected values: %+v", a)
+	}
+}
+
+// Ensure a bitmap can loop over a set of values in a range.
+func TestBitmap_ForEachRange(t *testing.T) {
+	var a []uint64
+	roaring.NewBitmap(1, 2, 3, 4).ForEachRange(2, 4, func(v uint64) {
+		a = append(a, v)
+	})
+	if !reflect.DeepEqual(a, []uint64{2, 3}) {
+		t.Fatalf("unexpected values: %+v", a)
+	}
+}
+
 func TestBitmap_Quick_Array1(t *testing.T)     { testBitmapQuick(t, 1000, 1000, 2000) }
 func TestBitmap_Quick_Array2(t *testing.T)     { testBitmapQuick(t, 10000, 0, 1000) }
 func TestBitmap_Quick_Bitmap1(t *testing.T)    { testBitmapQuick(t, 10000, 0, 10000) }
 func TestBitmap_Quick_Bitmap2(t *testing.T)    { testBitmapQuick(t, 10000, 10000, 20000) }
-func TestBitmap_Quick_LargeValue(t *testing.T) { testBitmapQuick(t, 10000, 0, math.MaxUint32) }
+func TestBitmap_Quick_LargeValue(t *testing.T) { testBitmapQuick(t, 10000, 0, math.MaxInt64) }
 
 // Ensure a bitmap can perform basic operations on randomly generated values.
-func testBitmapQuick(t *testing.T, n int, min, max uint32) {
-	quick.Check(func(a []uint32) bool {
+func testBitmapQuick(t *testing.T, n int, min, max uint64) {
+	quick.Check(func(a []uint64) bool {
 		bm := roaring.NewBitmap()
-		m := make(map[uint32]struct{})
+		m := make(map[uint64]struct{})
 
 		// Add values to the bitmap and set.
 		for _, v := range a {
@@ -45,7 +100,7 @@ func testBitmapQuick(t *testing.T, n int, min, max uint32) {
 		}
 
 		// Verify slices are equal.
-		if got, exp := bm.Slice(), uint32SetSlice(m); !reflect.DeepEqual(got, exp) {
+		if got, exp := bm.Slice(), uint64SetSlice(m); !reflect.DeepEqual(got, exp) {
 			t.Fatalf("unexpected values:\n\ngot=%+v\n\nexp=%+v\n\n", got, exp)
 		}
 
@@ -62,64 +117,9 @@ func testBitmapQuick(t *testing.T, n int, min, max uint32) {
 		return true
 	}, &quick.Config{
 		Values: func(values []reflect.Value, rand *rand.Rand) {
-			values[0] = reflect.ValueOf(GenerateUint32Slice(n, min, max, rand))
+			values[0] = reflect.ValueOf(GenerateUint64Slice(n, min, max, rand))
 		},
 	})
-}
-
-// Ensure an empty bitmap returns false if checking for existence.
-func TestBitmap_Contains_Empty(t *testing.T) {
-	if roaring.NewBitmap().Contains(1000) {
-		t.Fatal("expected false")
-	}
-}
-
-// Ensure an empty bitmap does nothing when removing an element.
-func TestBitmap_Remove_Empty(t *testing.T) {
-	roaring.NewBitmap().Remove(1000)
-}
-
-// Ensure a bitmap can return a slice of values.
-func TestBitmap_Slice(t *testing.T) {
-	if a := roaring.NewBitmap(1, 2, 3).Slice(); !reflect.DeepEqual(a, []uint32{1, 2, 3}) {
-		t.Fatalf("unexpected slice: %+v", a)
-	}
-}
-
-// Ensure an empty bitmap returns an empty slice of values.
-func TestBitmap_Slice_Empty(t *testing.T) {
-	if a := roaring.NewBitmap().Slice(); len(a) != 0 {
-		t.Fatalf("unexpected slice: %+v", a)
-	}
-}
-
-// Ensure a bitmap can return a slice of values within a range.
-func TestBitmap_SliceRange(t *testing.T) {
-	if a := roaring.NewBitmap(0, 1000001, 1000002, 1000003).SliceRange(1, 1000003); !reflect.DeepEqual(a, []uint32{1000001, 1000002}) {
-		t.Fatalf("unexpected slice: %+v", a)
-	}
-}
-
-// Ensure a bitmap can loop over a set of values.
-func TestBitmap_ForEach(t *testing.T) {
-	var a []uint32
-	roaring.NewBitmap(1, 2, 3).ForEach(func(v uint32) {
-		a = append(a, v)
-	})
-	if !reflect.DeepEqual(a, []uint32{1, 2, 3}) {
-		t.Fatalf("unexpected values: %+v", a)
-	}
-}
-
-// Ensure a bitmap can loop over a set of values in a range.
-func TestBitmap_ForEachRange(t *testing.T) {
-	var a []uint32
-	roaring.NewBitmap(1, 2, 3, 4).ForEachRange(2, 4, func(v uint32) {
-		a = append(a, v)
-	})
-	if !reflect.DeepEqual(a, []uint32{2, 3}) {
-		t.Fatalf("unexpected values: %+v", a)
-	}
 }
 
 func TestBitmap_Marshal_Quick_Array1(t *testing.T)  { testBitmapMarshalQuick(t, 1000, 1000, 2000) }
@@ -127,20 +127,20 @@ func TestBitmap_Marshal_Quick_Array2(t *testing.T)  { testBitmapMarshalQuick(t, 
 func TestBitmap_Marshal_Quick_Bitmap1(t *testing.T) { testBitmapMarshalQuick(t, 10000, 0, 10000) }
 func TestBitmap_Marshal_Quick_Bitmap2(t *testing.T) { testBitmapMarshalQuick(t, 10000, 10000, 20000) }
 func TestBitmap_Marshal_Quick_LargeValue(t *testing.T) {
-	testBitmapMarshalQuick(t, 100, 0, math.MaxUint32)
+	testBitmapMarshalQuick(t, 100, 0, math.MaxInt64)
 }
 
 // Ensure a bitmap can be marshaled and unmarshaled.
-func testBitmapMarshalQuick(t *testing.T, n int, min, max uint32) {
+func testBitmapMarshalQuick(t *testing.T, n int, min, max uint64) {
 	if testing.Short() {
 		t.Skip("short")
 	}
 
-	quick.Check(func(a0, a1 []uint32) bool {
+	quick.Check(func(a0, a1 []uint64) bool {
 		// Create bitmap with initial values set.
 		bm := roaring.NewBitmap(a0...)
 
-		set := make(map[uint32]struct{})
+		set := make(map[uint64]struct{})
 		for _, v := range a0 {
 			set[v] = struct{}{}
 		}
@@ -173,12 +173,12 @@ func testBitmapMarshalQuick(t *testing.T, n int, min, max uint32) {
 			}
 
 			// Verify the original bitmap has the correct set of values.
-			if exp, got := uint32SetSlice(set), bm.Slice(); !reflect.DeepEqual(exp, got) {
+			if exp, got := uint64SetSlice(set), bm.Slice(); !reflect.DeepEqual(exp, got) {
 				t.Fatalf("mismatch: %s\n\nexp=%+v\n\ngot=%+v\n\n", diff(exp, got), exp, got)
 			}
 
 			// Verify the bitmap loaded with the ops log has the correct set of values.
-			if exp, got := uint32SetSlice(set), bm2.Slice(); !reflect.DeepEqual(exp, got) {
+			if exp, got := uint64SetSlice(set), bm2.Slice(); !reflect.DeepEqual(exp, got) {
 				t.Fatalf("mismatch: %s\n\nexp=%+v\n\ngot=%+v\n\n", diff(exp, got), exp, got)
 			}
 		}
@@ -186,39 +186,39 @@ func testBitmapMarshalQuick(t *testing.T, n int, min, max uint32) {
 		return true
 	}, &quick.Config{
 		Values: func(values []reflect.Value, rand *rand.Rand) {
-			values[0] = reflect.ValueOf(GenerateUint32Slice(n, min, max, rand))
-			values[1] = reflect.ValueOf(GenerateUint32Slice(100, min, max, rand))
+			values[0] = reflect.ValueOf(GenerateUint64Slice(n, min, max, rand))
+			values[1] = reflect.ValueOf(GenerateUint64Slice(100, min, max, rand))
 		},
 	})
 }
 
-// GenerateUint32Slice generates between [0, n) random uint32 numbers between min and max.
-func GenerateUint32Slice(n int, min, max uint32, rand *rand.Rand) []uint32 {
-	a := make([]uint32, rand.Intn(n))
+// GenerateUint64Slice generates between [0, n) random uint64 numbers between min and max.
+func GenerateUint64Slice(n int, min, max uint64, rand *rand.Rand) []uint64 {
+	a := make([]uint64, rand.Intn(n))
 	for i := range a {
-		a[i] = min + uint32(rand.Intn(int(max-min)))
+		a[i] = min + uint64(rand.Int63n(int64(max-min)))
 	}
 	return a
 }
 
-// uint32SetSlice returns the values in a uint32 set.
-func uint32SetSlice(m map[uint32]struct{}) []uint32 {
-	a := make([]uint32, 0, len(m))
+// uint64SetSlice returns the values in a uint64 set.
+func uint64SetSlice(m map[uint64]struct{}) []uint64 {
+	a := make([]uint64, 0, len(m))
 	for v := range m {
 		a = append(a, v)
 	}
-	sort.Sort(uint32Slice(a))
+	sort.Sort(uint64Slice(a))
 	return a
 }
 
-// uint32Slice represents a sortable slice of uint32 numbers.
-type uint32Slice []uint32
+// uint64Slice represents a sortable slice of uint64 numbers.
+type uint64Slice []uint64
 
-func (p uint32Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p uint32Slice) Len() int           { return len(p) }
-func (p uint32Slice) Less(i, j int) bool { return p[i] < p[j] }
+func (p uint64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p uint64Slice) Len() int           { return len(p) }
+func (p uint64Slice) Less(i, j int) bool { return p[i] < p[j] }
 
-func diff(a, b []uint32) string {
+func diff(a, b []uint64) string {
 	if len(a) != len(b) {
 		return fmt.Sprintf("len: %d != %d", len(a), len(b))
 	}


### PR DESCRIPTION
## Overview

This commit refactors the roaring bitmaps to use `uint64` values instead of `uint32` values. This is required for the size of values we need in pilosa.

This change is not backwards compatible with the previous data format so any existing data directories need to be removed before using this code.

/cc @tgruben 
