### PR TITLE
Add bitmap and profile attribute support

### DIFF
--- a/db.go
+++ b/db.go
@@ -1,0 +1,264 @@
+package pilosa
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/boltdb/bolt"
+)
+
+// DB represents a container for frames.
+type DB struct {
+	mu   sync.Mutex
+	path string
+	name string
+
+	// Frames by name.
+	frames map[string]*Frame
+
+	// Profile attribute storage and cache
+	store *bolt.DB
+	attrs map[uint64]map[string]interface{}
+}
+
+// NewDB returns a new instance of DB.
+func NewDB(path, name string) *DB {
+	return &DB{
+		path:   path,
+		name:   name,
+		frames: make(map[string]*Frame),
+		attrs:  make(map[uint64]map[string]interface{}),
+	}
+}
+
+// Name returns name of the database.
+func (db *DB) Name() string { return db.name }
+
+// Path returns the path the database was initialized with.
+func (db *DB) Path() string { return db.path }
+
+// Open opens and initializes the database.
+func (db *DB) Open() error {
+	// Ensure the path exists.
+	if err := os.MkdirAll(db.path, 0777); err != nil {
+		return err
+	}
+
+	if err := db.openFrames(); err != nil {
+		return err
+	}
+
+	if err := db.openStore(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// openFrames opens and initializes the frames inside the database.
+func (db *DB) openFrames() error {
+	f, err := os.Open(db.path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fis, err := f.Readdir(0)
+	if err != nil {
+		return err
+	}
+
+	for _, fi := range fis {
+		if !fi.IsDir() {
+			continue
+		}
+
+		fr := NewFrame(db.FramePath(filepath.Base(fi.Name())), db.name, filepath.Base(fi.Name()))
+		if err := fr.Open(); err != nil {
+			return fmt.Errorf("open frame: name=%s, err=%s", fr.Name(), err)
+		}
+		db.frames[fr.Name()] = fr
+	}
+	return nil
+}
+
+// openStore opens and initializes the attribute store.
+func (db *DB) openStore() error {
+	// Open attribute store.
+	store, err := bolt.Open(filepath.Join(db.path, "data"), 0666, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return err
+	}
+	db.store = store
+
+	// Initialize database.
+	if err := db.store.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists([]byte("attrs")); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		_ = db.Close()
+		return err
+	}
+
+	return nil
+}
+
+// Close closes the database and its frames.
+func (db *DB) Close() error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	// Close the attribute store.
+	if db.store != nil {
+		db.store.Close()
+	}
+
+	// Close all frames.
+	for _, f := range db.frames {
+		f.Close()
+	}
+	db.frames = make(map[string]*Frame)
+
+	return nil
+}
+
+// SliceN returns the max slice in the database.
+func (db *DB) SliceN() uint64 {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	var max uint64
+	for _, f := range db.frames {
+		if slice := f.SliceN(); slice > max {
+			max = slice
+		}
+	}
+	return max
+}
+
+// FramePath returns the path to a frame in the database.
+func (db *DB) FramePath(name string) string { return filepath.Join(db.path, name) }
+
+// Frame returns a frame in the database by name.
+func (db *DB) Frame(name string) *Frame {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.frame(name)
+}
+
+func (db *DB) frame(name string) *Frame { return db.frames[name] }
+
+// CreateFrameIfNotExists returns a frame in the database by name.
+func (db *DB) CreateFrameIfNotExists(name string) (*Frame, error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+	return db.createFrameIfNotExists(name)
+}
+
+func (db *DB) createFrameIfNotExists(name string) (*Frame, error) {
+	// Find frame in cache first.
+	if f := db.frames[name]; f != nil {
+		return f, nil
+	}
+
+	// Initialize and open frame.
+	f := NewFrame(db.FramePath(name), db.name, name)
+	if err := f.Open(); err != nil {
+		return nil, err
+	}
+	db.frames[name] = f
+
+	return f, nil
+}
+
+// ProfileAttrs returns the value of the attribute for a profile.
+func (db *DB) ProfileAttrs(id uint64) (m map[string]interface{}, err error) {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	// Check cache for map.
+	if m = db.attrs[id]; m != nil {
+		return m, nil
+	}
+
+	// Find attributes from storage.
+	if err = db.store.View(func(tx *bolt.Tx) error {
+		m, err = txProfileAttrs(tx, id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Add to cache.
+	db.attrs[id] = m
+
+	return
+}
+
+// SetProfileAttrs sets attribute values for a profile.
+func (db *DB) SetProfileAttrs(id uint64, m map[string]interface{}) error {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	var attr map[string]interface{}
+	if err := db.store.Update(func(tx *bolt.Tx) error {
+		tmp, err := txProfileAttrs(tx, id)
+		if err != nil {
+			return err
+		}
+		attr = tmp
+
+		// Create a new map if it is empty so we don't update emptyMap.
+		if len(attr) == 0 {
+			attr = make(map[string]interface{}, len(m))
+		}
+
+		// Merge attributes with original values.
+		// Nil values should delete keys.
+		for k, v := range m {
+			if v == nil {
+				delete(attr, k)
+			} else {
+				attr[k] = v
+			}
+		}
+
+		// Marshal and save new values.
+		buf, err := json.Marshal(attr)
+		if err != nil {
+			return err
+		}
+		if err := tx.Bucket([]byte("attrs")).Put(u64tob(id), buf); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Swap attributes map in cache.
+	db.attrs[id] = attr
+
+	return nil
+}
+
+// txProfileAttrs returns a map of attributes for a profile.
+func txProfileAttrs(tx *bolt.Tx, id uint64) (map[string]interface{}, error) {
+	if v := tx.Bucket([]byte("attrs")).Get(u64tob(id)); v != nil {
+		m := make(map[string]interface{})
+		if err := json.Unmarshal(v, &m); err != nil {
+			return nil, err
+		}
+		return m, nil
+	}
+	return emptyMap, nil
+}

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,127 @@
+package pilosa_test
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/umbel/pilosa"
+)
+
+// Ensure database can open and retrieve a frame.
+func TestDB_CreateFrameIfNotExists(t *testing.T) {
+	db := MustOpenDB()
+	defer db.Close()
+
+	// Create frame.
+	f, err := db.CreateFrameIfNotExists("f")
+	if err != nil {
+		t.Fatal(err)
+	} else if f == nil {
+		t.Fatal("expected frame")
+	}
+
+	// Retrieve existing frame.
+	other, err := db.CreateFrameIfNotExists("f")
+	if err != nil {
+		t.Fatal(err)
+	} else if f != other {
+		t.Fatal("frame mismatch")
+	}
+
+	if f != db.Frame("f") {
+		t.Fatal("frame mismatch")
+	}
+}
+
+// Ensure database can set and retrieve profile attributes.
+func TestDB_ProfileAttrs(t *testing.T) {
+	db := MustOpenDB()
+	defer db.Close()
+
+	// Set attributes.
+	if err := db.SetProfileAttrs(1, map[string]interface{}{"A": float64(100)}); err != nil {
+		t.Fatal(err)
+	} else if err := db.SetProfileAttrs(2, map[string]interface{}{"A": float64(200)}); err != nil {
+		t.Fatal(err)
+	} else if err := db.SetProfileAttrs(1, map[string]interface{}{"B": "VALUE"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve attributes for profile #1.
+	if m, err := db.ProfileAttrs(1); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": float64(100), "B": "VALUE"}) {
+		t.Fatalf("unexpected attrs(1): %#v", m)
+	}
+
+	// Retrieve attributes for profile #2.
+	if m, err := db.ProfileAttrs(2); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": float64(200)}) {
+		t.Fatalf("unexpected attrs(2): %#v", m)
+	}
+}
+
+// Ensure database returns a non-nil empty map if unset.
+func TestDB_ProfileAttrs_Empty(t *testing.T) {
+	db := MustOpenDB()
+	defer db.Close()
+
+	if m, err := db.ProfileAttrs(100); err != nil {
+		t.Fatal(err)
+	} else if m == nil || len(m) > 0 {
+		t.Fatalf("unexpected attrs: %#v", m)
+	}
+}
+
+// Ensure database can unset attributes if explicitly set to nil.
+func TestDB_ProfileAttrs_Unset(t *testing.T) {
+	db := MustOpenDB()
+	defer db.Close()
+
+	// Set attributes.
+	if err := db.SetProfileAttrs(1, map[string]interface{}{"A": "X", "B": "Y"}); err != nil {
+		t.Fatal(err)
+	} else if err := db.SetProfileAttrs(1, map[string]interface{}{"B": nil}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify attributes.
+	if m, err := db.ProfileAttrs(1); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": "X"}) {
+		t.Fatalf("unexpected attrs: %#v", m)
+	}
+}
+
+// DB represents a test wrapper for pilosa.DB.
+type DB struct {
+	*pilosa.DB
+}
+
+// NewDB returns a new instance of DB d.
+func NewDB() *DB {
+	path, err := ioutil.TempDir("", "pilosa-db-")
+	if err != nil {
+		panic(err)
+	}
+
+	return &DB{DB: pilosa.NewDB(path, "d")}
+}
+
+// MustOpenDB returns a new, opened database at a temporary path. Panic on error.
+func MustOpenDB() *DB {
+	db := NewDB()
+	if err := db.Open(); err != nil {
+		panic(err)
+	}
+	return db
+}
+
+// Close closes the database and removes the underlying data.
+func (db *DB) Close() error {
+	defer os.RemoveAll(db.Path())
+	return db.DB.Close()
+}

--- a/fragment.go
+++ b/fragment.go
@@ -61,6 +61,18 @@ func NewFragment(path, db, frame string, slice uint64) *Fragment {
 	return f
 }
 
+// Path returns the path the fragment was initialized with.
+func (f *Fragment) Path() string { return f.path }
+
+// DB returns the database the fragment was initialized with.
+func (f *Fragment) DB() string { return f.db }
+
+// Frame returns the frame the fragment was initialized with.
+func (f *Fragment) Frame() string { return f.frame }
+
+// Slice returns the slice the fragment was initialized with.
+func (f *Fragment) Slice() uint64 { return f.slice }
+
 // Open opens the underlying storage.
 func (f *Fragment) Open() error {
 	f.mu.Lock()
@@ -173,18 +185,6 @@ func (f *Fragment) closeStorage() error {
 
 	return nil
 }
-
-// Path returns the path the fragment was initialized with.
-func (f *Fragment) Path() string { return f.path }
-
-// DB returns the database the fragment was initialized with.
-func (f *Fragment) DB() string { return f.db }
-
-// Frame returns the frame the fragment was initialized with.
-func (f *Fragment) Frame() string { return f.frame }
-
-// Slice returns the slice the fragment was initialized with.
-func (f *Fragment) Slice() uint64 { return f.slice }
 
 // Bitmap returns a bitmap by ID.
 func (f *Fragment) Bitmap(bitmapID uint64) *Bitmap {

--- a/handler_test.go
+++ b/handler_test.go
@@ -32,7 +32,7 @@ func TestHandler_Query_Args_URL(t *testing.T) {
 	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
 		if db != "db0" {
 			t.Fatalf("unexpected db: %s", db)
-		} else if query.String() != `count(get(id=100))` {
+		} else if query.String() != `Count(Bitmap(id=100))` {
 			t.Fatalf("unexpected query: %s", query.String())
 		} else if !reflect.DeepEqual(slices, []uint64{0, 1}) {
 			t.Fatalf("unexpected slices: %+v", slices)
@@ -41,7 +41,7 @@ func TestHandler_Query_Args_URL(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=db0&slices=0,1", strings.NewReader("count( get( 100))")))
+	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=db0&slices=0,1", strings.NewReader("Count( Bitmap( 100))")))
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	} else if body := w.Body.String(); body != `{"result":100}`+"\n" {
@@ -55,7 +55,7 @@ func TestHandler_Query_Args_Protobuf(t *testing.T) {
 	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
 		if db != "db0" {
 			t.Fatalf("unexpected db: %s", db)
-		} else if query.String() != `count(get(id=100))` {
+		} else if query.String() != `Count(Bitmap(id=100))` {
 			t.Fatalf("unexpected query: %s", query.String())
 		} else if !reflect.DeepEqual(slices, []uint64{0, 1}) {
 			t.Fatalf("unexpected slices: %+v", slices)
@@ -66,7 +66,7 @@ func TestHandler_Query_Args_Protobuf(t *testing.T) {
 	// Generate request body.
 	reqBody, err := proto.Marshal(&internal.QueryRequest{
 		DB:     proto.String("db0"),
-		Query:  proto.String("count(get(100))"),
+		Query:  proto.String("Count(Bitmap(100))"),
 		Slices: []uint64{0, 1},
 	})
 	if err != nil {
@@ -87,7 +87,7 @@ func TestHandler_Query_Args_Protobuf(t *testing.T) {
 // Ensure the handler returns an error when parsing bad arguments.
 func TestHandler_Query_Args_Err(t *testing.T) {
 	w := httptest.NewRecorder()
-	NewHandler().ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=db0&slices=a,b", strings.NewReader("get(100)")))
+	NewHandler().ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=db0&slices=a,b", strings.NewReader("Bitmap(100)")))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	} else if body := w.Body.String(); body != `{"error":"invalid slice argument"}`+"\n" {
@@ -103,7 +103,7 @@ func TestHandler_Query_Uint64_JSON(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=db0&slices=0,1", strings.NewReader("count( get( 100))")))
+	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=db0&slices=0,1", strings.NewReader("Count( Bitmap( 100))")))
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	} else if body := w.Body.String(); body != `{"result":100}`+"\n" {
@@ -119,7 +119,7 @@ func TestHandler_Query_Uint64_Protobuf(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	r := MustNewHTTPRequest("POST", "/query", strings.NewReader("count(get(100))"))
+	r := MustNewHTTPRequest("POST", "/query", strings.NewReader("Count(Bitmap(100))"))
 	r.Header.Set("Accept", "application/x-protobuf")
 	h.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
@@ -138,15 +138,49 @@ func TestHandler_Query_Uint64_Protobuf(t *testing.T) {
 func TestHandler_Query_Bitmap_JSON(t *testing.T) {
 	h := NewHandler()
 	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
-		return pilosa.NewBitmap(1, 3, 66, pilosa.SliceWidth+1), nil
+		bm := pilosa.NewBitmap(1, 3, 66, pilosa.SliceWidth+1)
+		bm.Attrs = map[string]interface{}{"a": "b", "c": 1, "d": true}
+		return bm, nil
 	}
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query", strings.NewReader("get(100)")))
+	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=d", strings.NewReader("Bitmap(100)")))
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", w.Code)
-	} else if body := w.Body.String(); body != `{"result":[1,3,66,65537]}`+"\n" {
-		t.Fatalf("unexpected body: %q", body)
+	} else if body := w.Body.String(); body != `{"result":{"attrs":{"a":"b","c":1,"d":true},"bits":[1,3,66,65537]}}`+"\n" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+// Ensure the handler can execute a query that returns a bitmap with profiles as JSON.
+func TestHandler_Query_Bitmap_Profiles_JSON(t *testing.T) {
+	idx := NewIndex()
+	defer idx.Close()
+
+	// Create database and set profile attributes.
+	db, err := idx.CreateDBIfNotExists("d")
+	if err != nil {
+		t.Fatal(err)
+	} else if err := db.SetProfileAttrs(3, map[string]interface{}{"x": "y"}); err != nil {
+		t.Fatal(err)
+	} else if err := db.SetProfileAttrs(66, map[string]interface{}{"y": 123, "z": false}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHandler()
+	h.Index = idx.Index
+	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
+		bm := pilosa.NewBitmap(1, 3, 66, pilosa.SliceWidth+1)
+		bm.Attrs = map[string]interface{}{"a": "b", "c": 1, "d": true}
+		return bm, nil
+	}
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query?db=d&profiles=true", strings.NewReader("Bitmap(100)")))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	} else if body := w.Body.String(); body != `{"result":{"attrs":{"a":"b","c":1,"d":true},"bits":[1,3,66,65537]},"profiles":[{"id":3,"attrs":{"x":"y"}},{"id":66,"attrs":{"y":123,"z":false}}]}`+"\n" {
+		t.Fatalf("unexpected body: %s", body)
 	}
 }
 
@@ -154,11 +188,13 @@ func TestHandler_Query_Bitmap_JSON(t *testing.T) {
 func TestHandler_Query_Bitmap_Protobuf(t *testing.T) {
 	h := NewHandler()
 	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
-		return pilosa.NewBitmap(1, pilosa.SliceWidth+1), nil
+		bm := pilosa.NewBitmap(1, pilosa.SliceWidth+1)
+		bm.Attrs = map[string]interface{}{"a": "b", "c": int64(1), "d": true}
+		return bm, nil
 	}
 
 	w := httptest.NewRecorder()
-	r := MustNewHTTPRequest("POST", "/query", strings.NewReader("get(100)"))
+	r := MustNewHTTPRequest("POST", "/query", strings.NewReader("Bitmap(100)"))
 	r.Header.Set("Accept", "application/x-protobuf")
 	h.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
@@ -170,6 +206,81 @@ func TestHandler_Query_Bitmap_Protobuf(t *testing.T) {
 		t.Fatal(err)
 	} else if a := resp.GetBitmap().GetChunks(); len(a) != 2 {
 		t.Fatalf("unexpected bitmap chunk length: %d", len(a))
+	} else if attrs := resp.GetBitmap().GetAttrs(); len(attrs) != 3 {
+		t.Fatalf("unexpected attr length: %d", len(attrs))
+	} else if k, v := attrs[0].GetKey(), attrs[0].GetStringValue(); k != "a" || v != "b" {
+		t.Fatalf("unexpected attr[0]: %s=%v", k, v)
+	} else if k, v := attrs[1].GetKey(), attrs[1].GetIntValue(); k != "c" || v != int64(1) {
+		t.Fatalf("unexpected attr[1]: %s=%v", k, v)
+	} else if k, v := attrs[2].GetKey(), attrs[2].GetBoolValue(); k != "d" || v != true {
+		t.Fatalf("unexpected attr[2]: %s=%v", k, v)
+	}
+}
+
+// Ensure the handler can execute a query that returns a bitmap with profiles as protobuf.
+func TestHandler_Query_Bitmap_Profiles_Protobuf(t *testing.T) {
+	idx := NewIndex()
+	defer idx.Close()
+
+	// Create database and set profile attributes.
+	db, err := idx.CreateDBIfNotExists("d")
+	if err != nil {
+		t.Fatal(err)
+	} else if err := db.SetProfileAttrs(1, map[string]interface{}{"x": "y"}); err != nil {
+		t.Fatal(err)
+	}
+
+	h := NewHandler()
+	h.Index = idx.Index
+	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
+		bm := pilosa.NewBitmap(1, pilosa.SliceWidth+1)
+		bm.Attrs = map[string]interface{}{"a": "b", "c": int64(1), "d": true}
+		return bm, nil
+	}
+
+	// Encode request body.
+	buf, err := proto.Marshal(&internal.QueryRequest{
+		DB:       proto.String("d"),
+		Query:    proto.String("Bitmap(100)"),
+		Profiles: proto.Bool(true),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := httptest.NewRecorder()
+	r := MustNewHTTPRequest("POST", "/query", bytes.NewReader(buf))
+	r.Header.Set("Content-Type", "application/x-protobuf")
+	r.Header.Set("Accept", "application/x-protobuf")
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	}
+
+	var resp internal.QueryResponse
+	if err := proto.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if a := resp.GetBitmap().GetChunks(); len(a) != 2 {
+		t.Fatalf("unexpected bitmap chunk length: %d", len(a))
+	} else if attrs := resp.GetBitmap().GetAttrs(); len(attrs) != 3 {
+		t.Fatalf("unexpected attr length: %d", len(attrs))
+	} else if k, v := attrs[0].GetKey(), attrs[0].GetStringValue(); k != "a" || v != "b" {
+		t.Fatalf("unexpected attr[0]: %s=%v", k, v)
+	} else if k, v := attrs[1].GetKey(), attrs[1].GetIntValue(); k != "c" || v != int64(1) {
+		t.Fatalf("unexpected attr[1]: %s=%v", k, v)
+	} else if k, v := attrs[2].GetKey(), attrs[2].GetBoolValue(); k != "d" || v != true {
+		t.Fatalf("unexpected attr[2]: %s=%v", k, v)
+	}
+
+	if a := resp.GetProfiles(); len(a) != 1 {
+		t.Fatalf("unexpected profiles length: %d", len(a))
+	} else if a[0].GetID() != 1 {
+		t.Fatalf("unexpected id: %d", a[0].GetID())
+	} else if len(a[0].GetAttrs()) != 1 {
+		t.Fatalf("unexpected profile attr length: %d", len(a))
+	} else if k, v := a[0].GetAttrs()[0].GetKey(), a[0].GetAttrs()[0].GetStringValue(); k != "x" || v != "y" {
+		t.Fatalf("unexpected attr[0]: %s=%v", k, v)
 	}
 }
 
@@ -184,7 +295,7 @@ func TestHandler_Query_Pairs_JSON(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query", strings.NewReader(`top-n(frame=x, n=2)`)))
+	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query", strings.NewReader(`TopN(frame=x, n=2)`)))
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	} else if body := w.Body.String(); body != `{"result":[{"key":1,"count":2},{"key":3,"count":4}]}`+"\n" {
@@ -203,7 +314,7 @@ func TestHandler_Query_Pairs_Protobuf(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	r := MustNewHTTPRequest("POST", "/query", strings.NewReader(`top-n(frame=x, n=2)`))
+	r := MustNewHTTPRequest("POST", "/query", strings.NewReader(`TopN(frame=x, n=2)`))
 	r.Header.Set("Accept", "application/x-protobuf")
 	h.ServeHTTP(w, r)
 	if w.Code != http.StatusOK {
@@ -226,7 +337,7 @@ func TestHandler_Query_Err_JSON(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query", strings.NewReader(`get(100)`)))
+	h.ServeHTTP(w, MustNewHTTPRequest("POST", "/query", strings.NewReader(`Bitmap(100)`)))
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	} else if body := w.Body.String(); body != `{"error":"marker"}`+"\n" {
@@ -242,7 +353,7 @@ func TestHandler_Query_Err_Protobuf(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	r := MustNewHTTPRequest("POST", "/query", strings.NewReader(`top-n(frame=x, n=2)`))
+	r := MustNewHTTPRequest("POST", "/query", strings.NewReader(`TopN(frame=x, n=2)`))
 	r.Header.Set("Accept", "application/x-protobuf")
 	h.ServeHTTP(w, r)
 	if w.Code != http.StatusInternalServerError {

--- a/internal/internal.pb.go
+++ b/internal/internal.pb.go
@@ -13,6 +13,8 @@ It has these top-level messages:
 	Chunk
 	Pair
 	Bit
+	Profile
+	Attr
 	QueryRequest
 	QueryResponse
 	ImportRequest
@@ -29,6 +31,7 @@ var _ = math.Inf
 
 type Bitmap struct {
 	Chunks           []*Chunk `protobuf:"bytes,1,rep" json:"Chunks,omitempty"`
+	Attrs            []*Attr  `protobuf:"bytes,2,rep" json:"Attrs,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -39,6 +42,13 @@ func (*Bitmap) ProtoMessage()    {}
 func (m *Bitmap) GetChunks() []*Chunk {
 	if m != nil {
 		return m.Chunks
+	}
+	return nil
+}
+
+func (m *Bitmap) GetAttrs() []*Attr {
+	if m != nil {
+		return m.Attrs
 	}
 	return nil
 }
@@ -115,10 +125,75 @@ func (m *Bit) GetProfileID() uint64 {
 	return 0
 }
 
+type Profile struct {
+	ID               *uint64 `protobuf:"varint,1,req" json:"ID,omitempty"`
+	Attrs            []*Attr `protobuf:"bytes,2,rep" json:"Attrs,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *Profile) Reset()         { *m = Profile{} }
+func (m *Profile) String() string { return proto.CompactTextString(m) }
+func (*Profile) ProtoMessage()    {}
+
+func (m *Profile) GetID() uint64 {
+	if m != nil && m.ID != nil {
+		return *m.ID
+	}
+	return 0
+}
+
+func (m *Profile) GetAttrs() []*Attr {
+	if m != nil {
+		return m.Attrs
+	}
+	return nil
+}
+
+type Attr struct {
+	Key              *string `protobuf:"bytes,1,req" json:"Key,omitempty"`
+	StringValue      *string `protobuf:"bytes,2,opt" json:"StringValue,omitempty"`
+	IntValue         *int64  `protobuf:"varint,3,opt" json:"IntValue,omitempty"`
+	BoolValue        *bool   `protobuf:"varint,4,opt" json:"BoolValue,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *Attr) Reset()         { *m = Attr{} }
+func (m *Attr) String() string { return proto.CompactTextString(m) }
+func (*Attr) ProtoMessage()    {}
+
+func (m *Attr) GetKey() string {
+	if m != nil && m.Key != nil {
+		return *m.Key
+	}
+	return ""
+}
+
+func (m *Attr) GetStringValue() string {
+	if m != nil && m.StringValue != nil {
+		return *m.StringValue
+	}
+	return ""
+}
+
+func (m *Attr) GetIntValue() int64 {
+	if m != nil && m.IntValue != nil {
+		return *m.IntValue
+	}
+	return 0
+}
+
+func (m *Attr) GetBoolValue() bool {
+	if m != nil && m.BoolValue != nil {
+		return *m.BoolValue
+	}
+	return false
+}
+
 type QueryRequest struct {
 	DB               *string  `protobuf:"bytes,1,req" json:"DB,omitempty"`
 	Query            *string  `protobuf:"bytes,2,req" json:"Query,omitempty"`
 	Slices           []uint64 `protobuf:"varint,3,rep" json:"Slices,omitempty"`
+	Profiles         *bool    `protobuf:"varint,4,opt" json:"Profiles,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -147,12 +222,20 @@ func (m *QueryRequest) GetSlices() []uint64 {
 	return nil
 }
 
+func (m *QueryRequest) GetProfiles() bool {
+	if m != nil && m.Profiles != nil {
+		return *m.Profiles
+	}
+	return false
+}
+
 type QueryResponse struct {
-	Err              *string `protobuf:"bytes,1,opt" json:"Err,omitempty"`
-	Bitmap           *Bitmap `protobuf:"bytes,2,opt" json:"Bitmap,omitempty"`
-	N                *uint64 `protobuf:"varint,3,opt" json:"N,omitempty"`
-	Pairs            []*Pair `protobuf:"bytes,4,rep" json:"Pairs,omitempty"`
-	XXX_unrecognized []byte  `json:"-"`
+	Err              *string    `protobuf:"bytes,1,opt" json:"Err,omitempty"`
+	Bitmap           *Bitmap    `protobuf:"bytes,2,opt" json:"Bitmap,omitempty"`
+	N                *uint64    `protobuf:"varint,3,opt" json:"N,omitempty"`
+	Pairs            []*Pair    `protobuf:"bytes,4,rep" json:"Pairs,omitempty"`
+	Profiles         []*Profile `protobuf:"bytes,5,rep" json:"Profiles,omitempty"`
+	XXX_unrecognized []byte     `json:"-"`
 }
 
 func (m *QueryResponse) Reset()         { *m = QueryResponse{} }
@@ -183,6 +266,13 @@ func (m *QueryResponse) GetN() uint64 {
 func (m *QueryResponse) GetPairs() []*Pair {
 	if m != nil {
 		return m.Pairs
+	}
+	return nil
+}
+
+func (m *QueryResponse) GetProfiles() []*Profile {
+	if m != nil {
+		return m.Profiles
 	}
 	return nil
 }

--- a/internal/internal.proto
+++ b/internal/internal.proto
@@ -2,6 +2,7 @@ package internal;
 
 message Bitmap {
 	repeated Chunk Chunks = 1;
+	repeated Attr Attrs   = 2;
 }
 
 message Chunk {
@@ -19,17 +20,31 @@ message Bit {
 	required uint64 ProfileID = 2;
 }
 
+message Profile {
+	required uint64 ID  = 1;
+	repeated Attr Attrs = 2;
+}
+
+message Attr {
+	required string Key         = 1;
+	optional string StringValue = 2;
+	optional int64 IntValue     = 3;
+	optional bool BoolValue     = 4;
+}
+
 message QueryRequest {
-	required string DB = 1;
-	required string Query = 2;
-	repeated uint64 Slices = 3;
+	required string DB       = 1;
+	required string Query    = 2;
+	repeated uint64 Slices   = 3;
+	optional bool   Profiles = 4;
 }
 
 message QueryResponse {
-	optional string Err    = 1;
-	optional Bitmap Bitmap = 2;
-	optional uint64 N      = 3;
-	repeated Pair   Pairs  = 4;
+	optional string  Err      = 1;
+	optional Bitmap  Bitmap   = 2;
+	optional uint64  N        = 3;
+	repeated Pair    Pairs    = 4;
+	repeated Profile Profiles = 5;
 }
 
 message ImportRequest {

--- a/pilosa.go
+++ b/pilosa.go
@@ -2,6 +2,10 @@ package pilosa
 
 import (
 	"errors"
+	"sort"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/umbel/pilosa/internal"
 )
 
 //go:generate protoc --gogo_out=. internal/internal.proto
@@ -19,3 +23,102 @@ var (
 
 // Version represents the current running version of Pilosa.
 var Version string
+
+// Profile represents vertical column in a database.
+// A profile can have a set of attributes attached to it.
+type Profile struct {
+	ID    uint64                 `json:"id"`
+	Attrs map[string]interface{} `json:"attrs,omitempty"`
+}
+
+// encodeProfiles converts a into its internal representation.
+func encodeProfiles(a []*Profile) []*internal.Profile {
+	other := make([]*internal.Profile, len(a))
+	for i := range a {
+		other[i] = encodeProfile(a[i])
+	}
+	return other
+}
+
+// decodeProfiles converts a from its internal representation.
+func decodeProfiles(a []*internal.Profile) []*Profile {
+	other := make([]*Profile, len(a))
+	for i := range a {
+		other[i] = decodeProfile(a[i])
+	}
+	return other
+}
+
+// encodeProfile converts p into its internal representation.
+func encodeProfile(p *Profile) *internal.Profile {
+	return &internal.Profile{
+		ID:    proto.Uint64(p.ID),
+		Attrs: encodeAttrs(p.Attrs),
+	}
+}
+
+// decodeProfile converts b from its internal representation.
+func decodeProfile(pb *internal.Profile) *Profile {
+	p := &Profile{
+		ID: pb.GetID(),
+	}
+
+	if len(pb.GetAttrs()) > 0 {
+		p.Attrs = make(map[string]interface{}, len(pb.GetAttrs()))
+		for _, attr := range pb.GetAttrs() {
+			k, v := decodeAttr(attr)
+			p.Attrs[k] = v
+		}
+	}
+
+	return p
+}
+
+func encodeAttrs(m map[string]interface{}) []*internal.Attr {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	a := make([]*internal.Attr, len(keys))
+	for i := range keys {
+		a[i] = encodeAttr(keys[i], m[keys[i]])
+	}
+	return a
+}
+
+func decodeAttrs(pb []*internal.Attr) map[string]interface{} {
+	m := make(map[string]interface{}, len(pb))
+	for i := range pb {
+		key, value := decodeAttr(pb[i])
+		m[key] = value
+	}
+	return m
+}
+
+// encodeAttr converts a key/value pair into an Attr internal representation.
+func encodeAttr(key string, value interface{}) *internal.Attr {
+	pb := &internal.Attr{Key: proto.String(key)}
+	switch value := value.(type) {
+	case string:
+		pb.StringValue = proto.String(value)
+	case int64:
+		pb.IntValue = proto.Int64(value)
+	case bool:
+		pb.BoolValue = proto.Bool(value)
+	}
+	return pb
+}
+
+// decodeAttr converts from an Attr internal representation to a key/value pair.
+func decodeAttr(attr *internal.Attr) (key string, value interface{}) {
+	if attr.StringValue != nil {
+		return attr.GetKey(), attr.GetStringValue()
+	} else if attr.IntValue != nil {
+		return attr.GetKey(), attr.GetIntValue()
+	} else if attr.BoolValue != nil {
+		return attr.GetKey(), attr.GetBoolValue()
+	}
+	return attr.GetKey(), nil
+}

--- a/pql/ast_test.go
+++ b/pql/ast_test.go
@@ -7,18 +7,26 @@ import (
 	"github.com/umbel/pilosa/pql"
 )
 
-// Ensure the Clear call can be converted into a string.
-func TestClear_String(t *testing.T) {
-	s := (&pql.Clear{ID: 1, Frame: "x.n", Filter: 2, ProfileID: 3}).String()
-	if s != `clear(id=1, frame=x.n, filter=2, profile_id=3)` {
+// Ensure the Bitmap call can be converted into a string.
+func TestBitmap_String(t *testing.T) {
+	s := (&pql.Bitmap{ID: 1, Frame: "x.n"}).String()
+	if s != `Bitmap(id=1, frame=x.n)` {
+		t.Fatalf("unexpected string: %s", s)
+	}
+}
+
+// Ensure the ClearBit call can be converted into a string.
+func TestClearBit_String(t *testing.T) {
+	s := (&pql.ClearBit{ID: 1, Frame: "x.n", Filter: 2, ProfileID: 3}).String()
+	if s != `ClearBit(id=1, frame=x.n, filter=2, profileID=3)` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
 
 // Ensure the Count call can be converted into a string.
 func TestCount_String(t *testing.T) {
-	s := (&pql.Count{Input: &pql.Get{ID: 1, Frame: "x.n"}}).String()
-	if s != `count(get(id=1, frame=x.n))` {
+	s := (&pql.Count{Input: &pql.Bitmap{ID: 1, Frame: "x.n"}}).String()
+	if s != `Count(Bitmap(id=1, frame=x.n))` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
@@ -26,19 +34,11 @@ func TestCount_String(t *testing.T) {
 // Ensure the Difference call can be converted into a string.
 func TestDifference_String(t *testing.T) {
 	s := (&pql.Difference{Inputs: pql.BitmapCalls{
-		&pql.Get{ID: 1, Frame: "x.n"},
-		&pql.Get{ID: 2},
+		&pql.Bitmap{ID: 1, Frame: "x.n"},
+		&pql.Bitmap{ID: 2},
 	},
 	}).String()
-	if s != `difference(get(id=1, frame=x.n), get(id=2))` {
-		t.Fatalf("unexpected string: %s", s)
-	}
-}
-
-// Ensure the Get call can be converted into a string.
-func TestGet_String(t *testing.T) {
-	s := (&pql.Get{ID: 1, Frame: "x.n"}).String()
-	if s != `get(id=1, frame=x.n)` {
+	if s != `Difference(Bitmap(id=1, frame=x.n), Bitmap(id=2))` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
@@ -46,11 +46,18 @@ func TestGet_String(t *testing.T) {
 // Ensure the Intersect call can be converted into a string.
 func TestIntersect_String(t *testing.T) {
 	s := (&pql.Intersect{Inputs: pql.BitmapCalls{
-		&pql.Get{ID: 1, Frame: "x.n"},
-		&pql.Get{ID: 2},
+		&pql.Bitmap{ID: 1, Frame: "x.n"},
+		&pql.Bitmap{ID: 2},
 	},
 	}).String()
-	if s != `intersect(get(id=1, frame=x.n), get(id=2))` {
+	if s != `Intersect(Bitmap(id=1, frame=x.n), Bitmap(id=2))` {
+		t.Fatalf("unexpected string: %s", s)
+	}
+}
+
+// Ensure the Profile call can be converted into a string.
+func TestProfile_String(t *testing.T) {
+	if s := (&pql.Profile{ID: 1}).String(); s != `Profile(id=1)` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
@@ -63,15 +70,23 @@ func TestRange_String(t *testing.T) {
 		StartTime: time.Unix(0, 0).UTC(),
 		EndTime:   time.Date(2000, 1, 2, 3, 4, 0, 0, time.UTC),
 	}).String()
-	if s != `range(id=1, frame=x.n, start=1970-01-01T00:00, end=2000-01-02T03:04)` {
+	if s != `Range(id=1, frame=x.n, start=1970-01-01T00:00, end=2000-01-02T03:04)` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
 
-// Ensure the Set call can be converted into a string.
-func TestSet_String(t *testing.T) {
-	s := (&pql.Set{ID: 1, Frame: "x.n", Filter: 2, ProfileID: 3}).String()
-	if s != `set(id=1, frame=x.n, filter=2, profile_id=3)` {
+// Ensure the SetBit call can be converted into a string.
+func TestSetBit_String(t *testing.T) {
+	s := (&pql.SetBit{ID: 1, Frame: "x.n", Filter: 2, ProfileID: 3}).String()
+	if s != `SetBit(id=1, frame=x.n, filter=2, profileID=3)` {
+		t.Fatalf("unexpected string: %s", s)
+	}
+}
+
+// Ensure the SetBitmapAttrs call can be converted into a string.
+func TestSetBitmapAttrs_String(t *testing.T) {
+	s := (&pql.SetBitmapAttrs{ID: 1, Frame: "x.n", Attrs: map[string]interface{}{"foo": "bar", "baz": 123, "bat": true, "x": nil}}).String()
+	if s != `SetBitmapAttrs(id=1, frame=x.n, bat=true, baz=123, foo="bar", x=null)` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
@@ -79,11 +94,11 @@ func TestSet_String(t *testing.T) {
 // Ensure the Union call can be converted into a string.
 func TestUnion_String(t *testing.T) {
 	s := (&pql.Union{Inputs: pql.BitmapCalls{
-		&pql.Get{ID: 1, Frame: "x.n"},
-		&pql.Get{ID: 2},
+		&pql.Bitmap{ID: 1, Frame: "x.n"},
+		&pql.Bitmap{ID: 2},
 	},
 	}).String()
-	if s != `union(get(id=1, frame=x.n), get(id=2))` {
+	if s != `Union(Bitmap(id=1, frame=x.n), Bitmap(id=2))` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }


### PR DESCRIPTION
## Overview

This commit adds the ability to set string, integer, and boolean values on bitmaps and profiles within Pilosa. Bitmap attributes are automatically returned when making a `Bitmap()` call. Profile attributes must be requested by setting `profile=true` in the URL.

The function names have also been renamed to initial caps so that the PQL query language can support math operations in the future.
