### PR TITLE
TopN()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,7 +1,6 @@
 package pilosa
 
 import (
-	"encoding/json"
 	"io"
 	"sort"
 	"time"
@@ -13,40 +12,37 @@ import (
 
 // Cache represents a cache for bitmaps.
 type Cache interface {
-	io.WriterTo
-	io.ReaderFrom
-
-	Add(bitmapID, category uint64, bm *Bitmap)
+	Add(bitmapID uint64, bm *Bitmap)
 	Get(bitmapID uint64) *Bitmap
 	Len() int
 
 	// Updates the cache, if necessary.
 	Invalidate()
 
-	// Returns a list of all key/count pairs.
-	Pairs() []Pair
+	// Returns an ordered list of the top ranked bitmaps.
+	Top() []BitmapPair
 }
 
 // LRUCache represents a least recently used Cache implemenation.
 type LRUCache struct {
-	cache *lru.Cache
-	keys  map[uint64]struct{}
+	cache   *lru.Cache
+	bitmaps map[uint64]*Bitmap
 }
 
 // NewLRUCache returns a new instance of LRUCache.
 func NewLRUCache(maxEntries int) *LRUCache {
 	c := &LRUCache{
-		cache: lru.New(maxEntries),
-		keys:  make(map[uint64]struct{}),
+		cache:   lru.New(maxEntries),
+		bitmaps: make(map[uint64]*Bitmap),
 	}
 	c.cache.OnEvicted = c.onEvicted
 	return c
 }
 
 // Get returns a bitmap with a given id.
-func (c *LRUCache) Add(bitmapID, category uint64, bm *Bitmap) {
+func (c *LRUCache) Add(bitmapID uint64, bm *Bitmap) {
 	c.cache.Add(bitmapID, bm)
-	c.keys[bitmapID] = struct{}{}
+	c.bitmaps[bitmapID] = bm
 }
 
 // Get returns a bitmap with a given id.
@@ -64,53 +60,28 @@ func (c *LRUCache) Len() int { return c.cache.Len() }
 // Invalidate is a no-op.
 func (c *LRUCache) Invalidate() {}
 
-// Pairs returns all key/count pairs in the cache.
-func (c *LRUCache) Pairs() []Pair {
-	a := make([]Pair, 0, len(c.keys))
-	for k := range c.keys {
-		a = append(a, Pair{
-			Key:   k,
-			Count: c.Get(k).Count(),
+// Top returns all bitmaps in the cache.
+func (c *LRUCache) Top() []BitmapPair {
+	a := make([]BitmapPair, 0, len(c.bitmaps))
+	for id, bm := range c.bitmaps {
+		a = append(a, BitmapPair{
+			ID:     id,
+			Bitmap: bm,
 		})
 	}
+	sort.Sort(BitmapPairs(a))
 	return a
 }
 
-// WriteTo writes the cache to w.
-func (c *LRUCache) WriteTo(w io.Writer) (n int64, err error) {
-	// Write keys to slice.
-	a := make([]uint64, 0, len(c.keys))
-	for k := range c.keys {
-		a = append(a, k)
-	}
-
-	// Encode to file as array of keys.
-	if err := json.NewEncoder(w).Encode(a); err != nil {
-		return 0, err
-	}
-	return 0, nil
-}
-
-// ReadFrom read from r into the cache.
-func (c *LRUCache) ReadFrom(r io.Reader) (n int64, err error) {
-	var keys []uint64
-	if err := json.NewDecoder(r).Decode(&keys); err != nil {
-		return 0, err
-	}
-	panic("FIXME: TODO")
-}
-
-func (c *LRUCache) onEvicted(key lru.Key, _ interface{}) {
-	delete(c.keys, key.(uint64))
-}
+func (c *LRUCache) onEvicted(key lru.Key, _ interface{}) { delete(c.bitmaps, key.(uint64)) }
 
 // Ensure LRUCache implements Cache.
 var _ Cache = &LRUCache{}
 
 // RankCache represents a cache with sorted entries.
 type RankCache struct {
-	entries  map[uint64]*Pair
-	rankings []Pair // cached, ordered list
+	entries  map[uint64]*Bitmap
+	rankings []BitmapPair // cached, ordered list
 
 	updateN    int
 	updateTime time.Time
@@ -123,44 +94,33 @@ type RankCache struct {
 // NewRankCache returns a new instance of RankCache.
 func NewRankCache() *RankCache {
 	return &RankCache{
-		entries: make(map[uint64]*Pair),
+		entries: make(map[uint64]*Bitmap),
 	}
 }
 
 // Get returns a bitmap with a given id.
-func (c *RankCache) Add(bitmapID, category uint64, bm *Bitmap) {
+func (c *RankCache) Add(bitmapID uint64, bm *Bitmap) {
 	// Ignore if the bit count on the bitmap is below the threshold.
 	if bm.Count() < c.ThresholdValue {
 		return
 	}
 
 	// Add to cache.
-	c.entries[bitmapID] = &Pair{
-		Key:      bitmapID,
-		Count:    bm.Count(),
-		bitmap:   bm,
-		category: category,
-	}
+	c.entries[bitmapID] = bm
 
 	// If size is larger than the threshold then trim it.
 	if len(c.entries) > c.ThresholdLength {
 		c.update()
-		for k, entry := range c.entries {
-			if entry.bitmap.Count() <= c.ThresholdValue {
-				delete(c.entries, k)
+		for id, bm := range c.entries {
+			if bm.Count() <= c.ThresholdValue {
+				delete(c.entries, id)
 			}
 		}
 	}
 }
 
 // Get returns a bitmap with a given id.
-func (c *RankCache) Get(bitmapID uint64) *Bitmap {
-	entry, ok := c.entries[bitmapID]
-	if !ok {
-		return nil
-	}
-	return entry.bitmap
-}
+func (c *RankCache) Get(bitmapID uint64) *Bitmap { return c.entries[bitmapID] }
 
 // Len returns the number of items in the cache.
 func (c *RankCache) Len() int { return len(c.entries) }
@@ -176,21 +136,19 @@ func (c *RankCache) Invalidate() {
 // update reorders the entries by rank.
 func (c *RankCache) update() {
 	// Convert cache to a sorted list.
-	list := make([]Pair, 0, len(c.entries))
-	for k, item := range c.entries {
-		list = append(list, Pair{
-			Key:      k,
-			Count:    item.bitmap.Count(),
-			bitmap:   item.bitmap,
-			category: item.category,
+	rankings := make([]BitmapPair, 0, len(c.entries))
+	for id, bm := range c.entries {
+		rankings = append(rankings, BitmapPair{
+			ID:     id,
+			Bitmap: bm,
 		})
 	}
-	sort.Sort(Pairs(list))
+	sort.Sort(BitmapPairs(rankings))
 
 	// Store the count of the item at the threshold index.
-	c.rankings = list
+	c.rankings = rankings
 	if len(c.rankings) > c.ThresholdIndex {
-		c.ThresholdValue = list[c.ThresholdIndex].bitmap.Count()
+		c.ThresholdValue = rankings[c.ThresholdIndex].Bitmap.Count()
 	} else {
 		c.ThresholdValue = 1
 	}
@@ -199,8 +157,8 @@ func (c *RankCache) update() {
 	c.updateTime, c.updateN = time.Now(), 0
 }
 
-// Pairs returns an ordered list of key/count pairs.
-func (c *RankCache) Pairs() []Pair { return c.rankings }
+// Top returns an ordered list of bitmaps.
+func (c *RankCache) Top() []BitmapPair { return c.rankings }
 
 // WriteTo writes the cache to w.
 func (c *RankCache) WriteTo(w io.Writer) (n int64, err error) {
@@ -215,12 +173,22 @@ func (c *RankCache) ReadFrom(r io.Reader) (n int64, err error) {
 // Ensure RankCache implements Cache.
 var _ Cache = &RankCache{}
 
+// BitmapPair represents a bitmap with an associated identifier.
+type BitmapPair struct {
+	ID     uint64
+	Bitmap *Bitmap
+}
+
+// BitmapPairs is a sortable list of BitmapPair objects.
+type BitmapPairs []BitmapPair
+
+func (p BitmapPairs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p BitmapPairs) Len() int           { return len(p) }
+func (p BitmapPairs) Less(i, j int) bool { return p[i].Bitmap.Count() > p[j].Bitmap.Count() }
+
 type Pair struct {
 	Key   uint64 `json:"key"`
 	Count uint64 `json:"count"`
-
-	bitmap   *Bitmap
-	category uint64
 }
 
 func encodePair(p Pair) *internal.Pair {
@@ -242,6 +210,27 @@ type Pairs []Pair
 func (p Pairs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func (p Pairs) Len() int           { return len(p) }
 func (p Pairs) Less(i, j int) bool { return p[i].Count > p[j].Count }
+
+// Add merges other into p and returns a new slice.
+func (p Pairs) Add(other []Pair) []Pair {
+	// Create lookup of key/counts.
+	m := make(map[uint64]uint64, len(p))
+	for _, pair := range p {
+		m[pair.Key] = pair.Count
+	}
+
+	// Add/merge from other.
+	for _, pair := range other {
+		m[pair.Key] += pair.Count
+	}
+
+	// Convert back to slice.
+	a := make([]Pair, 0, len(m))
+	for k, v := range m {
+		a = append(a, Pair{Key: k, Count: v})
+	}
+	return a
+}
 
 func encodePairs(a Pairs) []*internal.Pair {
 	other := make([]*internal.Pair, len(a))

--- a/executor_test.go
+++ b/executor_test.go
@@ -14,8 +14,8 @@ import (
 func TestExecutor_Execute_Bitmap(t *testing.T) {
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "f", 0).MustSetBit(10, 3)
-	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBit(10, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).MustSetBits(10, 3)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, SliceWidth+1)
 
 	if err := idx.Frame("d", "f").SetBitmapAttrs(10, map[string]interface{}{"foo": "bar", "baz": 123}); err != nil {
 		t.Fatal(err)
@@ -39,10 +39,10 @@ func TestExecutor_Execute_Bitmap(t *testing.T) {
 func TestExecutor_Execute_Difference(t *testing.T) {
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(10, 1)
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(10, 2)
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(10, 3)
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(11, 2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(10, 1)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(10, 2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(10, 3)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(11, 2)
 
 	e := NewExecutor(idx.Index, NewCluster(1))
 	if res, err := e.Execute("d", MustParse(`Difference(Bitmap(id=10), Bitmap(id=11))`), nil); err != nil {
@@ -58,13 +58,13 @@ func TestExecutor_Execute_Difference(t *testing.T) {
 func TestExecutor_Execute_Intersect(t *testing.T) {
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(10, 1)
-	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBit(10, SliceWidth+1)
-	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBit(10, SliceWidth+2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(10, 1)
+	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBits(10, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBits(10, SliceWidth+2)
 
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(11, 1)
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(11, 2)
-	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBit(11, SliceWidth+2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(11, 1)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(11, 2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBits(11, SliceWidth+2)
 
 	e := NewExecutor(idx.Index, NewCluster(1))
 	if res, err := e.Execute("d", MustParse(`Intersect(Bitmap(id=10), Bitmap(id=11))`), nil); err != nil {
@@ -82,12 +82,12 @@ func TestExecutor_Execute_Intersect(t *testing.T) {
 func TestExecutor_Execute_Union(t *testing.T) {
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(10, 0)
-	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBit(10, SliceWidth+1)
-	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBit(10, SliceWidth+2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(10, 0)
+	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBits(10, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBits(10, SliceWidth+2)
 
-	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBit(11, 2)
-	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBit(11, SliceWidth+2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 0).MustSetBits(11, 2)
+	idx.MustCreateFragmentIfNotExists("d", "general", 1).MustSetBits(11, SliceWidth+2)
 
 	e := NewExecutor(idx.Index, NewCluster(1))
 	if res, err := e.Execute("d", MustParse(`Union(Bitmap(id=10), Bitmap(id=11))`), nil); err != nil {
@@ -105,9 +105,9 @@ func TestExecutor_Execute_Union(t *testing.T) {
 func TestExecutor_Execute_Count(t *testing.T) {
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "f", 0).MustSetBit(10, 3)
-	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBit(10, SliceWidth+1)
-	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBit(10, SliceWidth+2)
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).MustSetBits(10, 3)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, SliceWidth+2)
 
 	e := NewExecutor(idx.Index, NewCluster(1))
 	if n, err := e.Execute("d", MustParse(`Count(Bitmap(id=10, frame=f))`), nil); err != nil {
@@ -162,6 +162,67 @@ func TestExecutor_Execute_SetBitmapAttrs(t *testing.T) {
 	}
 }
 
+// Ensure a TopN() query can be executed.
+func TestExecutor_Execute_TopN(t *testing.T) {
+	idx := MustOpenIndex()
+	defer idx.Close()
+
+	// Set bits for bitmaps 0, 10, & 20 across two slices.
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).SetBit(0, 0)
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).SetBit(0, 1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(0, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(0, SliceWidth+2)
+	idx.MustCreateFragmentIfNotExists("d", "f", 5).SetBit(0, (5*SliceWidth)+100)
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).SetBit(10, 0)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(10, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).SetBit(20, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "other", 0).SetBit(0, 0)
+
+	// Execute query.
+	e := NewExecutor(idx.Index, NewCluster(1))
+	if result, err := e.Execute("d", MustParse(`TopN(frame=f, n=2)`), nil); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, []pilosa.Pair{
+		{Key: 0, Count: 5},
+		{Key: 10, Count: 2},
+	}) {
+		t.Fatalf("unexpected result: %s", spew.Sdump(result))
+	}
+}
+
+// Ensure a TopN() query with a source bitmap can be executed.
+func TestExecutor_Execute_TopN_Src(t *testing.T) {
+	idx := MustOpenIndex()
+	defer idx.Close()
+
+	// Set bits for bitmaps 0, 10, & 20 across two slices.
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).SetBit(0, 0)
+	idx.MustCreateFragmentIfNotExists("d", "f", 0).SetBit(0, 1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(0, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(10, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(10, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(20, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(20, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).SetBit(20, SliceWidth+2)
+
+	// Create an intersecting bitmap.
+	idx.MustCreateFragmentIfNotExists("d", "other", 1).SetBit(100, SliceWidth)
+	idx.MustCreateFragmentIfNotExists("d", "other", 1).SetBit(100, SliceWidth+1)
+	idx.MustCreateFragmentIfNotExists("d", "other", 1).SetBit(100, SliceWidth+2)
+
+	// Execute query.
+	e := NewExecutor(idx.Index, NewCluster(1))
+	if result, err := e.Execute("d", MustParse(`TopN(Bitmap(id=100, frame=other), frame=f, n=3)`), nil); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(result, []pilosa.Pair{
+		{Key: 20, Count: 3},
+		{Key: 10, Count: 2},
+		{Key: 0, Count: 1},
+	}) {
+		t.Fatalf("unexpected result: %s", spew.Sdump(result))
+	}
+}
+
 // Ensure a remote query can return a bitmap.
 func TestExecutor_Execute_Remote_Bitmap(t *testing.T) {
 	c := NewCluster(2)
@@ -194,7 +255,7 @@ func TestExecutor_Execute_Remote_Bitmap(t *testing.T) {
 	// The local node owns slice 1.
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBit(10, (1*SliceWidth)+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, (1*SliceWidth)+1)
 
 	e := NewExecutor(idx.Index, c)
 	if res, err := e.Execute("d", MustParse(`Bitmap(id=10, frame=f)`), nil); err != nil {
@@ -225,8 +286,8 @@ func TestExecutor_Execute_Remote_Count(t *testing.T) {
 	// Create local executor data. The local node owns slice 1.
 	idx := MustOpenIndex()
 	defer idx.Close()
-	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBit(10, (1*SliceWidth)+1)
-	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBit(10, (1*SliceWidth)+2)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, (1*SliceWidth)+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, (1*SliceWidth)+2)
 
 	e := NewExecutor(idx.Index, c)
 	if n, err := e.Execute("d", MustParse(`Count(Bitmap(id=10, frame=f))`), nil); err != nil {
@@ -273,6 +334,51 @@ func TestExecutor_Execute_Remote_SetBit(t *testing.T) {
 	}
 	if !remoteCalled {
 		t.Fatalf("expected remote execution")
+	}
+}
+
+// Ensure a remote query can return a top-n query.
+func TestExecutor_Execute_Remote_TopN(t *testing.T) {
+	c := NewCluster(2)
+
+	// Create secondary server and update second cluster node.
+	s := NewServer()
+	defer s.Close()
+	c.Nodes[1].Host = s.Host()
+
+	// Mock secondary server's executor to verify arguments and return a bitmap.
+	s.Handler.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
+		if db != `d` {
+			t.Fatalf("unexpected db: %s", db)
+		} else if query.String() != `TopN(frame=f, n=3)` {
+			t.Fatalf("unexpected query: %s", query.String())
+		} else if !reflect.DeepEqual(slices, []uint64{0, 2, 4, 6}) {
+			t.Fatalf("unexpected slices: %+v", slices)
+		}
+
+		// Return pair counts.
+		return []pilosa.Pair{
+			{Key: 0, Count: 5},
+			{Key: 10, Count: 2},
+			{Key: 30, Count: 2},
+		}, nil
+	}
+
+	// Create local executor data on slice 1 & 3.
+	idx := MustOpenIndex()
+	defer idx.Close()
+	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(30, (1*SliceWidth)+1)
+	idx.MustCreateFragmentIfNotExists("d", "f", 3).MustSetBits(30, (3*SliceWidth)+2)
+
+	e := NewExecutor(idx.Index, c)
+	if res, err := e.Execute("d", MustParse(`TopN(frame=f, n=3)`), nil); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(res, []pilosa.Pair{
+		{Key: 0, Count: 5},
+		{Key: 30, Count: 4},
+		{Key: 10, Count: 2},
+	}) {
+		t.Fatalf("unexpected results: %s", spew.Sdump(res))
 	}
 }
 

--- a/frame.go
+++ b/frame.go
@@ -109,6 +109,7 @@ func (f *Frame) openFragments() error {
 		if err := frag.Open(); err != nil {
 			return fmt.Errorf("open fragment: slice=%s, err=%s", frag.Slice(), err)
 		}
+		frag.BitmapAttrStore = f
 		f.fragments[frag.Slice()] = frag
 	}
 
@@ -189,6 +190,7 @@ func (f *Frame) createFragmentIfNotExists(slice uint64) (*Fragment, error) {
 	if err := frag.Open(); err != nil {
 		return nil, err
 	}
+	frag.BitmapAttrStore = f
 	f.fragments[slice] = frag
 
 	return frag, nil

--- a/handler.go
+++ b/handler.go
@@ -400,7 +400,7 @@ func encodeQueryResponse(resp *QueryResponse) *internal.QueryResponse {
 		switch result := resp.Result.(type) {
 		case *Bitmap:
 			pb.Bitmap = encodeBitmap(result)
-		case Pairs:
+		case []Pair:
 			pb.Pairs = encodePairs(result)
 		case uint64:
 			pb.N = proto.Uint64(result)

--- a/handler_test.go
+++ b/handler_test.go
@@ -288,7 +288,7 @@ func TestHandler_Query_Bitmap_Profiles_Protobuf(t *testing.T) {
 func TestHandler_Query_Pairs_JSON(t *testing.T) {
 	h := NewHandler()
 	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
-		return pilosa.Pairs{
+		return []pilosa.Pair{
 			{Key: 1, Count: 2},
 			{Key: 3, Count: 4},
 		}, nil
@@ -307,7 +307,7 @@ func TestHandler_Query_Pairs_JSON(t *testing.T) {
 func TestHandler_Query_Pairs_Protobuf(t *testing.T) {
 	h := NewHandler()
 	h.Executor.ExecuteFn = func(db string, query *pql.Query, slices []uint64) (interface{}, error) {
-		return pilosa.Pairs{
+		return []pilosa.Pair{
 			{Key: 1, Count: 2},
 			{Key: 3, Count: 4},
 		}, nil

--- a/pql/ast_test.go
+++ b/pql/ast_test.go
@@ -17,8 +17,8 @@ func TestBitmap_String(t *testing.T) {
 
 // Ensure the ClearBit call can be converted into a string.
 func TestClearBit_String(t *testing.T) {
-	s := (&pql.ClearBit{ID: 1, Frame: "x.n", Filter: 2, ProfileID: 3}).String()
-	if s != `ClearBit(id=1, frame=x.n, filter=2, profileID=3)` {
+	s := (&pql.ClearBit{ID: 1, Frame: "x.n", ProfileID: 3}).String()
+	if s != `ClearBit(id=1, frame=x.n, profileID=3)` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }
@@ -77,8 +77,8 @@ func TestRange_String(t *testing.T) {
 
 // Ensure the SetBit call can be converted into a string.
 func TestSetBit_String(t *testing.T) {
-	s := (&pql.SetBit{ID: 1, Frame: "x.n", Filter: 2, ProfileID: 3}).String()
-	if s != `SetBit(id=1, frame=x.n, filter=2, profileID=3)` {
+	s := (&pql.SetBit{ID: 1, Frame: "x.n", ProfileID: 3}).String()
+	if s != `SetBit(id=1, frame=x.n, profileID=3)` {
 		t.Fatalf("unexpected string: %s", s)
 	}
 }

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -41,14 +41,13 @@ func TestParser_Parse_Bitmap_Array(t *testing.T) {
 
 // Ensure the parser can parse a "ClearBit()" function with keyed args.
 func TestParser_Parse_ClearBit_Key(t *testing.T) {
-	q, err := pql.ParseString(`ClearBit(id=1, frame="b.n", filter=2, profileID = 3)`)
+	q, err := pql.ParseString(`ClearBit(id=1, frame="b.n", profileID = 3)`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.ClearBit{
 			ID:        1,
 			Frame:     "b.n",
-			Filter:    2,
 			ProfileID: 3,
 		},
 	}) {
@@ -58,14 +57,13 @@ func TestParser_Parse_ClearBit_Key(t *testing.T) {
 
 // Ensure the parser can parse a "ClearBit()" function with array args.
 func TestParser_Parse_ClearBit_Array(t *testing.T) {
-	q, err := pql.ParseString(`ClearBit(1, "b.n", 2, 3)`)
+	q, err := pql.ParseString(`ClearBit(1, "b.n", 3)`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.ClearBit{
 			ID:        1,
 			Frame:     "b.n",
-			Filter:    2,
 			ProfileID: 3,
 		},
 	}) {
@@ -183,14 +181,13 @@ func TestParser_Parse_Range_Array(t *testing.T) {
 
 // Ensure the parser can parse a "SetBit()" function with keyed args.
 func TestParser_Parse_SetBit_Key(t *testing.T) {
-	q, err := pql.ParseString(`SetBit(id=1, frame="b.n", filter=2, profileID = 3)`)
+	q, err := pql.ParseString(`SetBit(id=1, frame="b.n", profileID = 3)`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.SetBit{
 			ID:        1,
 			Frame:     "b.n",
-			Filter:    2,
 			ProfileID: 3,
 		},
 	}) {
@@ -200,14 +197,13 @@ func TestParser_Parse_SetBit_Key(t *testing.T) {
 
 // Ensure the parser can parse a "SetBit()" function with array args.
 func TestParser_Parse_SetBit_Array(t *testing.T) {
-	q, err := pql.ParseString(`SetBit(1, "b.n", 2, 3)`)
+	q, err := pql.ParseString(`SetBit(1, "b.n", 3)`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.SetBit{
 			ID:        1,
 			Frame:     "b.n",
-			Filter:    2,
 			ProfileID: 3,
 		},
 	}) {
@@ -258,31 +254,45 @@ func TestParser_Parse_SetBitmapAttrs_Array(t *testing.T) {
 
 // Ensure the parser can parse a "TopN()" function with keyed args.
 func TestParser_Parse_TopN_Key(t *testing.T) {
-	q, err := pql.ParseString(`TopN(frame="b.n", n=2)`)
+	q, err := pql.ParseString(`TopN(Bitmap(100), frame="b.n", n=2, field="XXX", [5,10,15])`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.TopN{
-			Frame: "b.n",
-			N:     2,
+			Src:     &pql.Bitmap{ID: 100},
+			Frame:   "b.n",
+			N:       2,
+			Field:   "XXX",
+			Filters: []interface{}{uint64(5), uint64(10), uint64(15)},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
+	}
+
+	if s := q.String(); s != `TopN(Bitmap(id=100), frame=b.n, n=2, field="XXX", [5,10,15])` {
+		t.Fatalf("unexpected string encoding: %s", s)
 	}
 }
 
 // Ensure the parser can parse a "TopN()" function with array args.
 func TestParser_Parse_TopN_Array(t *testing.T) {
-	q, err := pql.ParseString(`TopN("b.n", 2)`)
+	q, err := pql.ParseString(`TopN(Bitmap(100), "b.n", 2, "XXX", ["foo",true,false])`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.TopN{
-			Frame: "b.n",
-			N:     2,
+			Src:     &pql.Bitmap{ID: 100},
+			Frame:   "b.n",
+			N:       2,
+			Field:   "XXX",
+			Filters: []interface{}{"foo", true, false},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
+	}
+
+	if s := q.String(); s != `TopN(Bitmap(id=100), frame=b.n, n=2, field="XXX", ["foo",true,false])` {
+		t.Fatalf("unexpected string encoding: %s", s)
 	}
 }
 


### PR DESCRIPTION
## Overview

This commit adds TopN() functionality to the fragment, executor and handler. It also fixes parsing of the `TopN()` function in PQL. I also merged the previous `TopN()` and `TopNAll()` into a single function so we wouldn't have two separate code paths.

There's a new `field` attribute to specify the field to filter on instead of hardcoding to `"category"`. You can also specify string and boolean values for the filters. 

/cc @tgruben @travisturner 
