### PR TITLE
Refactor attribute stores

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -1,0 +1,210 @@
+package pilosa
+
+import (
+	"encoding/binary"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/gogo/protobuf/proto"
+	"github.com/umbel/pilosa/internal"
+)
+
+// AttrStore represents a storage layer for attributes.
+type AttrStore struct {
+	mu   sync.Mutex
+	path string
+	db   *bolt.DB
+
+	// in-memory cache
+	attrs map[uint64]map[string]interface{}
+}
+
+// NewAttrStore returns a new instance of AttrStore.
+func NewAttrStore(path string) *AttrStore {
+	return &AttrStore{
+		path:  path,
+		attrs: make(map[uint64]map[string]interface{}),
+	}
+}
+
+// Path returns path to the store's data file.
+func (s *AttrStore) Path() string { return s.path }
+
+// Open opens and initializes the store.
+func (s *AttrStore) Open() error {
+	// Open storage.
+	db, err := bolt.Open(s.path, 0666, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return err
+	}
+	s.db = db
+
+	// Initialize database.
+	if err := s.db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists([]byte("attrs")); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Close closes the store.
+func (s *AttrStore) Close() error { return s.db.Close() }
+
+// Attrs returns a set of attributes by ID.
+func (s *AttrStore) Attrs(id uint64) (m map[string]interface{}, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check cache for map.
+	if m = s.attrs[id]; m != nil {
+		return m, nil
+	}
+
+	// Find attributes from storage.
+	if err = s.db.View(func(tx *bolt.Tx) error {
+		m, err = txAttrs(tx, id)
+		if err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Add to cache.
+	s.attrs[id] = m
+
+	return
+}
+
+// SetAttrs sets attribute values for a given ID.
+func (s *AttrStore) SetAttrs(id uint64, m map[string]interface{}) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var attr map[string]interface{}
+	if err := s.db.Update(func(tx *bolt.Tx) error {
+		tmp, err := txAttrs(tx, id)
+		if err != nil {
+			return err
+		}
+		attr = tmp
+
+		// Create a new map if it is empty so we don't update emptyMap.
+		if len(attr) == 0 {
+			attr = make(map[string]interface{}, len(m))
+		}
+
+		// Merge attributes with original values.
+		// Nil values should delete keys.
+		for k, v := range m {
+			if v == nil {
+				delete(attr, k)
+			} else {
+				attr[k] = v
+			}
+		}
+
+		// Marshal and save new values.
+		buf, err := proto.Marshal(&internal.AttrMap{Attrs: encodeAttrs(attr)})
+		if err != nil {
+			return err
+		}
+		if err := tx.Bucket([]byte("attrs")).Put(u64tob(id), buf); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	// Swap attributes map in cache.
+	s.attrs[id] = attr
+
+	return nil
+}
+
+// txAttrs returns a map of attributes for a bitmap.
+func txAttrs(tx *bolt.Tx, id uint64) (map[string]interface{}, error) {
+	v := tx.Bucket([]byte("attrs")).Get(u64tob(id))
+	if v == nil {
+		return emptyMap, nil
+	}
+
+	var pb internal.AttrMap
+	if err := proto.Unmarshal(v, &pb); err != nil {
+		return nil, err
+	}
+	return decodeAttrs(pb.GetAttrs()), nil
+}
+
+func encodeAttrs(m map[string]interface{}) []*internal.Attr {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	a := make([]*internal.Attr, len(keys))
+	for i := range keys {
+		a[i] = encodeAttr(keys[i], m[keys[i]])
+	}
+	return a
+}
+
+func decodeAttrs(pb []*internal.Attr) map[string]interface{} {
+	m := make(map[string]interface{}, len(pb))
+	for i := range pb {
+		key, value := decodeAttr(pb[i])
+		m[key] = value
+	}
+	return m
+}
+
+// encodeAttr converts a key/value pair into an Attr internal representation.
+func encodeAttr(key string, value interface{}) *internal.Attr {
+	pb := &internal.Attr{Key: proto.String(key)}
+	switch value := value.(type) {
+	case string:
+		pb.StringValue = proto.String(value)
+	case float64:
+		pb.IntValue = proto.Int64(int64(value))
+	case int64:
+		pb.IntValue = proto.Int64(value)
+	case bool:
+		pb.BoolValue = proto.Bool(value)
+	}
+	return pb
+}
+
+// decodeAttr converts from an Attr internal representation to a key/value pair.
+func decodeAttr(attr *internal.Attr) (key string, value interface{}) {
+	if attr.StringValue != nil {
+		return attr.GetKey(), attr.GetStringValue()
+	} else if attr.IntValue != nil {
+		return attr.GetKey(), attr.GetIntValue()
+	} else if attr.BoolValue != nil {
+		return attr.GetKey(), attr.GetBoolValue()
+	}
+	return attr.GetKey(), nil
+}
+
+// u64tob encodes v to big endian encoding.
+func u64tob(v uint64) []byte {
+	b := make([]byte, 8)
+	binary.BigEndian.PutUint64(b, v)
+	return b
+}
+
+// btou64 decodes b from big endian encoding.
+func btou64(b []byte) uint64 { return binary.BigEndian.Uint64(b) }
+
+// emptyMap is a reusable map that contains no keys.
+var emptyMap = make(map[string]interface{})

--- a/attr_test.go
+++ b/attr_test.go
@@ -1,0 +1,103 @@
+package pilosa_test
+
+import (
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/umbel/pilosa"
+)
+
+// Ensure database can set and retrieve profile attributes.
+func TestAttrStore_Attrs(t *testing.T) {
+	s := MustOpenAttrStore()
+	defer s.Close()
+
+	// Set attributes.
+	if err := s.SetAttrs(1, map[string]interface{}{"A": int64(100)}); err != nil {
+		t.Fatal(err)
+	} else if err := s.SetAttrs(2, map[string]interface{}{"A": int64(200)}); err != nil {
+		t.Fatal(err)
+	} else if err := s.SetAttrs(1, map[string]interface{}{"B": "VALUE"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve attributes for profile #1.
+	if m, err := s.Attrs(1); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": int64(100), "B": "VALUE"}) {
+		t.Fatalf("unexpected attrs(1): %#v", m)
+	}
+
+	// Retrieve attributes for profile #2.
+	if m, err := s.Attrs(2); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": int64(200)}) {
+		t.Fatalf("unexpected attrs(2): %#v", m)
+	}
+}
+
+// Ensure database returns a non-nil empty map if unset.
+func TestAttrStore_Attrs_Empty(t *testing.T) {
+	s := MustOpenAttrStore()
+	defer s.Close()
+
+	if m, err := s.Attrs(100); err != nil {
+		t.Fatal(err)
+	} else if m == nil || len(m) > 0 {
+		t.Fatalf("unexpected attrs: %#v", m)
+	}
+}
+
+// Ensure database can unset attributes if explicitly set to nil.
+func TestAttrStore_Attrs_Unset(t *testing.T) {
+	s := MustOpenAttrStore()
+	defer s.Close()
+
+	// Set attributes.
+	if err := s.SetAttrs(1, map[string]interface{}{"A": "X", "B": "Y"}); err != nil {
+		t.Fatal(err)
+	} else if err := s.SetAttrs(1, map[string]interface{}{"B": nil}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify attributes.
+	if m, err := s.Attrs(1); err != nil {
+		t.Fatal(err)
+	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": "X"}) {
+		t.Fatalf("unexpected attrs: %#v", m)
+	}
+}
+
+// AttrStore represents a test wrapper for pilosa.AttrStore.
+type AttrStore struct {
+	*pilosa.AttrStore
+}
+
+// NewAttrStore returns a new instance of AttrStore.
+func NewAttrStore() *AttrStore {
+	f, err := ioutil.TempFile("", "pilosa-attr-")
+	if err != nil {
+		panic(err)
+	}
+	f.Close()
+	os.Remove(f.Name())
+
+	return &AttrStore{AttrStore: pilosa.NewAttrStore(f.Name())}
+}
+
+// MustOpenAttrStore returns a new, opened attribute store at a temporary path. Panic on error.
+func MustOpenAttrStore() *AttrStore {
+	s := NewAttrStore()
+	if err := s.Open(); err != nil {
+		panic(err)
+	}
+	return s
+}
+
+// Close closes the database and removes the underlying data.
+func (s *AttrStore) Close() error {
+	defer os.RemoveAll(s.Path())
+	return s.AttrStore.Close()
+}

--- a/db_test.go
+++ b/db_test.go
@@ -3,7 +3,6 @@ package pilosa_test
 import (
 	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/umbel/pilosa"
@@ -32,67 +31,6 @@ func TestDB_CreateFrameIfNotExists(t *testing.T) {
 
 	if f != db.Frame("f") {
 		t.Fatal("frame mismatch")
-	}
-}
-
-// Ensure database can set and retrieve profile attributes.
-func TestDB_ProfileAttrs(t *testing.T) {
-	db := MustOpenDB()
-	defer db.Close()
-
-	// Set attributes.
-	if err := db.SetProfileAttrs(1, map[string]interface{}{"A": float64(100)}); err != nil {
-		t.Fatal(err)
-	} else if err := db.SetProfileAttrs(2, map[string]interface{}{"A": float64(200)}); err != nil {
-		t.Fatal(err)
-	} else if err := db.SetProfileAttrs(1, map[string]interface{}{"B": "VALUE"}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Retrieve attributes for profile #1.
-	if m, err := db.ProfileAttrs(1); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": float64(100), "B": "VALUE"}) {
-		t.Fatalf("unexpected attrs(1): %#v", m)
-	}
-
-	// Retrieve attributes for profile #2.
-	if m, err := db.ProfileAttrs(2); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": float64(200)}) {
-		t.Fatalf("unexpected attrs(2): %#v", m)
-	}
-}
-
-// Ensure database returns a non-nil empty map if unset.
-func TestDB_ProfileAttrs_Empty(t *testing.T) {
-	db := MustOpenDB()
-	defer db.Close()
-
-	if m, err := db.ProfileAttrs(100); err != nil {
-		t.Fatal(err)
-	} else if m == nil || len(m) > 0 {
-		t.Fatalf("unexpected attrs: %#v", m)
-	}
-}
-
-// Ensure database can unset attributes if explicitly set to nil.
-func TestDB_ProfileAttrs_Unset(t *testing.T) {
-	db := MustOpenDB()
-	defer db.Close()
-
-	// Set attributes.
-	if err := db.SetProfileAttrs(1, map[string]interface{}{"A": "X", "B": "Y"}); err != nil {
-		t.Fatal(err)
-	} else if err := db.SetProfileAttrs(1, map[string]interface{}{"B": nil}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify attributes.
-	if m, err := db.ProfileAttrs(1); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": "X"}) {
-		t.Fatalf("unexpected attrs: %#v", m)
 	}
 }
 

--- a/executor.go
+++ b/executor.go
@@ -117,7 +117,7 @@ func (e *Executor) executeBitmapCall(db string, c pql.BitmapCall, slices []uint6
 	if c, ok := c.(*pql.Bitmap); ok {
 		fr := e.Index().Frame(db, c.Frame)
 		if fr != nil {
-			attrs, err := fr.BitmapAttrs(c.ID)
+			attrs, err := fr.BitmapAttrStore().Attrs(c.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -347,7 +347,7 @@ func (e *Executor) executeSetBitmapAttrs(db string, c *pql.SetBitmapAttrs) error
 	}
 
 	// Set attributes.
-	if err := frame.SetBitmapAttrs(c.ID, c.Attrs); err != nil {
+	if err := frame.BitmapAttrStore().SetAttrs(c.ID, c.Attrs); err != nil {
 		return err
 	}
 
@@ -365,7 +365,7 @@ func (e *Executor) executeSetProfileAttrs(db string, c *pql.SetProfileAttrs) err
 	}
 
 	// Set attributes.
-	if err := d.SetProfileAttrs(c.ID, c.Attrs); err != nil {
+	if err := d.ProfileAttrStore().SetAttrs(c.ID, c.Attrs); err != nil {
 		return err
 	}
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -17,7 +17,7 @@ func TestExecutor_Execute_Bitmap(t *testing.T) {
 	idx.MustCreateFragmentIfNotExists("d", "f", 0).MustSetBits(10, 3)
 	idx.MustCreateFragmentIfNotExists("d", "f", 1).MustSetBits(10, SliceWidth+1)
 
-	if err := idx.Frame("d", "f").SetBitmapAttrs(10, map[string]interface{}{"foo": "bar", "baz": 123}); err != nil {
+	if err := idx.Frame("d", "f").BitmapAttrStore().SetAttrs(10, map[string]interface{}{"foo": "bar", "baz": 123}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -155,7 +155,7 @@ func TestExecutor_Execute_SetBitmapAttrs(t *testing.T) {
 	}
 
 	f := idx.Frame("d", "f")
-	if m, err := f.BitmapAttrs(10); err != nil {
+	if m, err := f.BitmapAttrStore().Attrs(10); err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(m, map[string]interface{}{"foo": "bar", "baz": int64(123), "bat": true}) {
 		t.Fatalf("unexpected bitmap attr: %#v", m)

--- a/fragment.go
+++ b/fragment.go
@@ -66,10 +66,8 @@ type Fragment struct {
 	LogOutput io.Writer
 
 	// Bitmap attribute storage.
-	// Typically this is the parent frame unless overridden for testing.
-	BitmapAttrStore interface {
-		BitmapAttrs(id uint64) (map[string]interface{}, error)
-	}
+	// This is set by the parent frame unless overridden for testing.
+	BitmapAttrStore *AttrStore
 }
 
 // NewFragment returns a new instance of Fragment.
@@ -403,7 +401,7 @@ func (f *Fragment) TopN(n int, src *Bitmap, field string, fieldValues []interfac
 
 		// Apply filter, if set.
 		if filters != nil {
-			attr, err := f.BitmapAttrStore.BitmapAttrs(bitmapID)
+			attr, err := f.BitmapAttrStore.Attrs(bitmapID)
 			if err != nil {
 				return nil, err
 			} else if attr == nil {

--- a/frame_test.go
+++ b/frame_test.go
@@ -3,7 +3,6 @@ package pilosa_test
 import (
 	"io/ioutil"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/umbel/pilosa"
@@ -32,67 +31,6 @@ func TestFrame_CreateFragmentIfNotExists(t *testing.T) {
 
 	if frag != f.Fragment(100) {
 		t.Fatal("fragment mismatch")
-	}
-}
-
-// Ensure frame can set and retrieve bitmap attributes.
-func TestFrame_BitmapAttrs(t *testing.T) {
-	f := MustOpenFrame()
-	defer f.Close()
-
-	// Set attributes.
-	if err := f.SetBitmapAttrs(1, map[string]interface{}{"A": float64(100)}); err != nil {
-		t.Fatal(err)
-	} else if err := f.SetBitmapAttrs(2, map[string]interface{}{"A": float64(200)}); err != nil {
-		t.Fatal(err)
-	} else if err := f.SetBitmapAttrs(1, map[string]interface{}{"B": "VALUE"}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Retrieve attributes for bitmap #1.
-	if m, err := f.BitmapAttrs(1); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": float64(100), "B": "VALUE"}) {
-		t.Fatalf("unexpected attrs(1): %#v", m)
-	}
-
-	// Retrieve attributes for bitmap #2.
-	if m, err := f.BitmapAttrs(2); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": float64(200)}) {
-		t.Fatalf("unexpected attrs(2): %#v", m)
-	}
-}
-
-// Ensure frame returns a non-nil empty map if unset.
-func TestFrame_BitmapAttrs_Empty(t *testing.T) {
-	f := MustOpenFrame()
-	defer f.Close()
-
-	if m, err := f.BitmapAttrs(100); err != nil {
-		t.Fatal(err)
-	} else if m == nil || len(m) > 0 {
-		t.Fatalf("unexpected attrs: %#v", m)
-	}
-}
-
-// Ensure frame can unset attributes if explicitly set to nil.
-func TestFrame_BitmapAttrs_Unset(t *testing.T) {
-	f := MustOpenFrame()
-	defer f.Close()
-
-	// Set attributes.
-	if err := f.SetBitmapAttrs(1, map[string]interface{}{"A": "X", "B": "Y"}); err != nil {
-		t.Fatal(err)
-	} else if err := f.SetBitmapAttrs(1, map[string]interface{}{"B": nil}); err != nil {
-		t.Fatal(err)
-	}
-
-	// Verify attributes.
-	if m, err := f.BitmapAttrs(1); err != nil {
-		t.Fatal(err)
-	} else if !reflect.DeepEqual(m, map[string]interface{}{"A": "X"}) {
-		t.Fatalf("unexpected attrs: %#v", m)
 	}
 }
 

--- a/handler.go
+++ b/handler.go
@@ -138,7 +138,7 @@ func (h *Handler) readProfiles(db *DB, ids []uint64) ([]*Profile, error) {
 	a := make([]*Profile, 0, len(ids))
 	for _, id := range ids {
 		// Read attributes for profile. Skip profile if empty.
-		attrs, err := db.ProfileAttrs(id)
+		attrs, err := db.ProfileAttrStore().Attrs(id)
 		if err != nil {
 			return nil, err
 		} else if len(attrs) == 0 {

--- a/handler_test.go
+++ b/handler_test.go
@@ -161,9 +161,9 @@ func TestHandler_Query_Bitmap_Profiles_JSON(t *testing.T) {
 	db, err := idx.CreateDBIfNotExists("d")
 	if err != nil {
 		t.Fatal(err)
-	} else if err := db.SetProfileAttrs(3, map[string]interface{}{"x": "y"}); err != nil {
+	} else if err := db.ProfileAttrStore().SetAttrs(3, map[string]interface{}{"x": "y"}); err != nil {
 		t.Fatal(err)
-	} else if err := db.SetProfileAttrs(66, map[string]interface{}{"y": 123, "z": false}); err != nil {
+	} else if err := db.ProfileAttrStore().SetAttrs(66, map[string]interface{}{"y": 123, "z": false}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -226,7 +226,7 @@ func TestHandler_Query_Bitmap_Profiles_Protobuf(t *testing.T) {
 	db, err := idx.CreateDBIfNotExists("d")
 	if err != nil {
 		t.Fatal(err)
-	} else if err := db.SetProfileAttrs(1, map[string]interface{}{"x": "y"}); err != nil {
+	} else if err := db.ProfileAttrStore().SetAttrs(1, map[string]interface{}{"x": "y"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/internal.pb.go
+++ b/internal/internal.pb.go
@@ -15,6 +15,7 @@ It has these top-level messages:
 	Bit
 	Profile
 	Attr
+	AttrMap
 	QueryRequest
 	QueryResponse
 	ImportRequest
@@ -192,6 +193,22 @@ func (m *Attr) GetBoolValue() bool {
 	return false
 }
 
+type AttrMap struct {
+	Attrs            []*Attr `protobuf:"bytes,1,rep,name=Attrs" json:"Attrs,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *AttrMap) Reset()         { *m = AttrMap{} }
+func (m *AttrMap) String() string { return proto.CompactTextString(m) }
+func (*AttrMap) ProtoMessage()    {}
+
+func (m *AttrMap) GetAttrs() []*Attr {
+	if m != nil {
+		return m.Attrs
+	}
+	return nil
+}
+
 type QueryRequest struct {
 	DB               *string  `protobuf:"bytes,1,req,name=DB" json:"DB,omitempty"`
 	Query            *string  `protobuf:"bytes,2,req,name=Query" json:"Query,omitempty"`
@@ -367,6 +384,7 @@ func init() {
 	proto.RegisterType((*Bit)(nil), "internal.Bit")
 	proto.RegisterType((*Profile)(nil), "internal.Profile")
 	proto.RegisterType((*Attr)(nil), "internal.Attr")
+	proto.RegisterType((*AttrMap)(nil), "internal.AttrMap")
 	proto.RegisterType((*QueryRequest)(nil), "internal.QueryRequest")
 	proto.RegisterType((*QueryResponse)(nil), "internal.QueryResponse")
 	proto.RegisterType((*ImportRequest)(nil), "internal.ImportRequest")

--- a/internal/internal.proto
+++ b/internal/internal.proto
@@ -32,6 +32,10 @@ message Attr {
 	optional bool BoolValue     = 4;
 }
 
+message AttrMap {
+	repeated Attr Attrs = 1;
+}
+
 message QueryRequest {
 	required string DB       = 1;
 	required string Query    = 2;

--- a/pilosa.go
+++ b/pilosa.go
@@ -2,7 +2,6 @@ package pilosa
 
 import (
 	"errors"
-	"sort"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/umbel/pilosa/internal"
@@ -72,53 +71,4 @@ func decodeProfile(pb *internal.Profile) *Profile {
 	}
 
 	return p
-}
-
-func encodeAttrs(m map[string]interface{}) []*internal.Attr {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	a := make([]*internal.Attr, len(keys))
-	for i := range keys {
-		a[i] = encodeAttr(keys[i], m[keys[i]])
-	}
-	return a
-}
-
-func decodeAttrs(pb []*internal.Attr) map[string]interface{} {
-	m := make(map[string]interface{}, len(pb))
-	for i := range pb {
-		key, value := decodeAttr(pb[i])
-		m[key] = value
-	}
-	return m
-}
-
-// encodeAttr converts a key/value pair into an Attr internal representation.
-func encodeAttr(key string, value interface{}) *internal.Attr {
-	pb := &internal.Attr{Key: proto.String(key)}
-	switch value := value.(type) {
-	case string:
-		pb.StringValue = proto.String(value)
-	case int64:
-		pb.IntValue = proto.Int64(value)
-	case bool:
-		pb.BoolValue = proto.Bool(value)
-	}
-	return pb
-}
-
-// decodeAttr converts from an Attr internal representation to a key/value pair.
-func decodeAttr(attr *internal.Attr) (key string, value interface{}) {
-	if attr.StringValue != nil {
-		return attr.GetKey(), attr.GetStringValue()
-	} else if attr.IntValue != nil {
-		return attr.GetKey(), attr.GetIntValue()
-	} else if attr.BoolValue != nil {
-		return attr.GetKey(), attr.GetBoolValue()
-	}
-	return attr.GetKey(), nil
 }


### PR DESCRIPTION
## Overview

This pull request refactors the profile and bitmap attribute stores so that they share the same code. There is a new `AttrStore` which associates key/value pairs with a `uint64` identifier.

Also, the previous JSON encoding has been fixed to use protobufs which resolves encoding issues for `int64`.

---

/cc @tgruben 
