### PR TITLE
Refetch full counts for TopN()

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -255,6 +255,15 @@ func (p Pairs) Add(other []Pair) []Pair {
 	return a
 }
 
+// Keys returns a slice of all keys in p.
+func (p Pairs) Keys() []uint64 {
+	a := make([]uint64, len(p))
+	for i := range p {
+		a[i] = p[i].Key
+	}
+	return a
+}
+
 func encodePairs(a Pairs) []*internal.Pair {
 	other := make([]*internal.Pair, len(a))
 	for i := range a {

--- a/handler.go
+++ b/handler.go
@@ -115,6 +115,7 @@ func (h *Handler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 	opt := &ExecOptions{
 		Timestamp: req.Timestamp,
 		Quantum:   req.Quantum,
+		Remote:    req.Remote,
 	}
 
 	// Parse query string.
@@ -475,6 +476,10 @@ type QueryRequest struct {
 
 	// Time granularity to use with the timestamp.
 	Quantum TimeQuantum
+
+	// If true, indicates that query is part of a larger distributed query.
+	// If false, this request is on the originating node.
+	Remote bool
 }
 
 func decodeQueryRequest(pb *internal.QueryRequest) *QueryRequest {
@@ -484,6 +489,7 @@ func decodeQueryRequest(pb *internal.QueryRequest) *QueryRequest {
 		Slices:   pb.GetSlices(),
 		Profiles: pb.GetProfiles(),
 		Quantum:  TimeQuantum(pb.GetQuantum()),
+		Remote:   pb.GetRemote(),
 	}
 
 	if pb.Timestamp != nil {

--- a/internal/internal.pb.go
+++ b/internal/internal.pb.go
@@ -26,17 +26,15 @@ It has these top-level messages:
 package internal
 
 import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
 import math "math"
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
-var _ = fmt.Errorf
 var _ = math.Inf
 
 type Bitmap struct {
-	Chunks           []*Chunk `protobuf:"bytes,1,rep,name=Chunks" json:"Chunks,omitempty"`
-	Attrs            []*Attr  `protobuf:"bytes,2,rep,name=Attrs" json:"Attrs,omitempty"`
+	Chunks           []*Chunk `protobuf:"bytes,1,rep" json:"Chunks,omitempty"`
+	Attrs            []*Attr  `protobuf:"bytes,2,rep" json:"Attrs,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -59,8 +57,8 @@ func (m *Bitmap) GetAttrs() []*Attr {
 }
 
 type Chunk struct {
-	Key              *uint64  `protobuf:"varint,1,req,name=Key" json:"Key,omitempty"`
-	Value            []uint64 `protobuf:"varint,2,rep,name=Value" json:"Value,omitempty"`
+	Key              *uint64  `protobuf:"varint,1,req" json:"Key,omitempty"`
+	Value            []uint64 `protobuf:"varint,2,rep" json:"Value,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -83,8 +81,8 @@ func (m *Chunk) GetValue() []uint64 {
 }
 
 type Pair struct {
-	Key              *uint64 `protobuf:"varint,1,req,name=Key" json:"Key,omitempty"`
-	Count            *uint64 `protobuf:"varint,2,req,name=Count" json:"Count,omitempty"`
+	Key              *uint64 `protobuf:"varint,1,req" json:"Key,omitempty"`
+	Count            *uint64 `protobuf:"varint,2,req" json:"Count,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -107,8 +105,8 @@ func (m *Pair) GetCount() uint64 {
 }
 
 type Bit struct {
-	BitmapID         *uint64 `protobuf:"varint,1,req,name=BitmapID" json:"BitmapID,omitempty"`
-	ProfileID        *uint64 `protobuf:"varint,2,req,name=ProfileID" json:"ProfileID,omitempty"`
+	BitmapID         *uint64 `protobuf:"varint,1,req" json:"BitmapID,omitempty"`
+	ProfileID        *uint64 `protobuf:"varint,2,req" json:"ProfileID,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -131,8 +129,8 @@ func (m *Bit) GetProfileID() uint64 {
 }
 
 type Profile struct {
-	ID               *uint64 `protobuf:"varint,1,req,name=ID" json:"ID,omitempty"`
-	Attrs            []*Attr `protobuf:"bytes,2,rep,name=Attrs" json:"Attrs,omitempty"`
+	ID               *uint64 `protobuf:"varint,1,req" json:"ID,omitempty"`
+	Attrs            []*Attr `protobuf:"bytes,2,rep" json:"Attrs,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -155,10 +153,10 @@ func (m *Profile) GetAttrs() []*Attr {
 }
 
 type Attr struct {
-	Key              *string `protobuf:"bytes,1,req,name=Key" json:"Key,omitempty"`
-	StringValue      *string `protobuf:"bytes,2,opt,name=StringValue" json:"StringValue,omitempty"`
-	UintValue        *uint64 `protobuf:"varint,3,opt,name=UintValue" json:"UintValue,omitempty"`
-	BoolValue        *bool   `protobuf:"varint,4,opt,name=BoolValue" json:"BoolValue,omitempty"`
+	Key              *string `protobuf:"bytes,1,req" json:"Key,omitempty"`
+	StringValue      *string `protobuf:"bytes,2,opt" json:"StringValue,omitempty"`
+	UintValue        *uint64 `protobuf:"varint,3,opt" json:"UintValue,omitempty"`
+	BoolValue        *bool   `protobuf:"varint,4,opt" json:"BoolValue,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -195,7 +193,7 @@ func (m *Attr) GetBoolValue() bool {
 }
 
 type AttrMap struct {
-	Attrs            []*Attr `protobuf:"bytes,1,rep,name=Attrs" json:"Attrs,omitempty"`
+	Attrs            []*Attr `protobuf:"bytes,1,rep" json:"Attrs,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -211,12 +209,13 @@ func (m *AttrMap) GetAttrs() []*Attr {
 }
 
 type QueryRequest struct {
-	DB               *string  `protobuf:"bytes,1,req,name=DB" json:"DB,omitempty"`
-	Query            *string  `protobuf:"bytes,2,req,name=Query" json:"Query,omitempty"`
-	Slices           []uint64 `protobuf:"varint,3,rep,name=Slices" json:"Slices,omitempty"`
-	Profiles         *bool    `protobuf:"varint,4,opt,name=Profiles" json:"Profiles,omitempty"`
-	Timestamp        *int64   `protobuf:"varint,5,opt,name=Timestamp" json:"Timestamp,omitempty"`
-	Quantum          *uint32  `protobuf:"varint,6,opt,name=Quantum" json:"Quantum,omitempty"`
+	DB               *string  `protobuf:"bytes,1,req" json:"DB,omitempty"`
+	Query            *string  `protobuf:"bytes,2,req" json:"Query,omitempty"`
+	Slices           []uint64 `protobuf:"varint,3,rep" json:"Slices,omitempty"`
+	Profiles         *bool    `protobuf:"varint,4,opt" json:"Profiles,omitempty"`
+	Timestamp        *int64   `protobuf:"varint,5,opt" json:"Timestamp,omitempty"`
+	Quantum          *uint32  `protobuf:"varint,6,opt" json:"Quantum,omitempty"`
+	Remote           *bool    `protobuf:"varint,7,opt" json:"Remote,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -266,13 +265,20 @@ func (m *QueryRequest) GetQuantum() uint32 {
 	return 0
 }
 
+func (m *QueryRequest) GetRemote() bool {
+	if m != nil && m.Remote != nil {
+		return *m.Remote
+	}
+	return false
+}
+
 type QueryResponse struct {
-	Err              *string    `protobuf:"bytes,1,opt,name=Err" json:"Err,omitempty"`
-	Bitmap           *Bitmap    `protobuf:"bytes,2,opt,name=Bitmap" json:"Bitmap,omitempty"`
-	N                *uint64    `protobuf:"varint,3,opt,name=N" json:"N,omitempty"`
-	Pairs            []*Pair    `protobuf:"bytes,4,rep,name=Pairs" json:"Pairs,omitempty"`
-	Profiles         []*Profile `protobuf:"bytes,5,rep,name=Profiles" json:"Profiles,omitempty"`
-	Changed          *bool      `protobuf:"varint,6,opt,name=Changed" json:"Changed,omitempty"`
+	Err              *string    `protobuf:"bytes,1,opt" json:"Err,omitempty"`
+	Bitmap           *Bitmap    `protobuf:"bytes,2,opt" json:"Bitmap,omitempty"`
+	N                *uint64    `protobuf:"varint,3,opt" json:"N,omitempty"`
+	Pairs            []*Pair    `protobuf:"bytes,4,rep" json:"Pairs,omitempty"`
+	Profiles         []*Profile `protobuf:"bytes,5,rep" json:"Profiles,omitempty"`
+	Changed          *bool      `protobuf:"varint,6,opt" json:"Changed,omitempty"`
 	XXX_unrecognized []byte     `json:"-"`
 }
 
@@ -323,11 +329,11 @@ func (m *QueryResponse) GetChanged() bool {
 }
 
 type ImportRequest struct {
-	DB               *string  `protobuf:"bytes,1,req,name=DB" json:"DB,omitempty"`
-	Frame            *string  `protobuf:"bytes,2,req,name=Frame" json:"Frame,omitempty"`
-	Slice            *uint64  `protobuf:"varint,3,req,name=Slice" json:"Slice,omitempty"`
-	BitmapIDs        []uint64 `protobuf:"varint,4,rep,name=BitmapIDs" json:"BitmapIDs,omitempty"`
-	ProfileIDs       []uint64 `protobuf:"varint,5,rep,name=ProfileIDs" json:"ProfileIDs,omitempty"`
+	DB               *string  `protobuf:"bytes,1,req" json:"DB,omitempty"`
+	Frame            *string  `protobuf:"bytes,2,req" json:"Frame,omitempty"`
+	Slice            *uint64  `protobuf:"varint,3,req" json:"Slice,omitempty"`
+	BitmapIDs        []uint64 `protobuf:"varint,4,rep" json:"BitmapIDs,omitempty"`
+	ProfileIDs       []uint64 `protobuf:"varint,5,rep" json:"ProfileIDs,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -371,7 +377,7 @@ func (m *ImportRequest) GetProfileIDs() []uint64 {
 }
 
 type ImportResponse struct {
-	Err              *string `protobuf:"bytes,1,opt,name=Err" json:"Err,omitempty"`
+	Err              *string `protobuf:"bytes,1,opt" json:"Err,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -387,7 +393,7 @@ func (m *ImportResponse) GetErr() string {
 }
 
 type Cache struct {
-	BitmapIDs        []uint64 `protobuf:"varint,1,rep,name=BitmapIDs" json:"BitmapIDs,omitempty"`
+	BitmapIDs        []uint64 `protobuf:"varint,1,rep" json:"BitmapIDs,omitempty"`
 	XXX_unrecognized []byte   `json:"-"`
 }
 
@@ -403,7 +409,7 @@ func (m *Cache) GetBitmapIDs() []uint64 {
 }
 
 type SliceMaxResponse struct {
-	SliceMax         *uint64 `protobuf:"varint,1,req,name=SliceMax" json:"SliceMax,omitempty"`
+	SliceMax         *uint64 `protobuf:"varint,1,req" json:"SliceMax,omitempty"`
 	XXX_unrecognized []byte  `json:"-"`
 }
 
@@ -419,17 +425,4 @@ func (m *SliceMaxResponse) GetSliceMax() uint64 {
 }
 
 func init() {
-	proto.RegisterType((*Bitmap)(nil), "internal.Bitmap")
-	proto.RegisterType((*Chunk)(nil), "internal.Chunk")
-	proto.RegisterType((*Pair)(nil), "internal.Pair")
-	proto.RegisterType((*Bit)(nil), "internal.Bit")
-	proto.RegisterType((*Profile)(nil), "internal.Profile")
-	proto.RegisterType((*Attr)(nil), "internal.Attr")
-	proto.RegisterType((*AttrMap)(nil), "internal.AttrMap")
-	proto.RegisterType((*QueryRequest)(nil), "internal.QueryRequest")
-	proto.RegisterType((*QueryResponse)(nil), "internal.QueryResponse")
-	proto.RegisterType((*ImportRequest)(nil), "internal.ImportRequest")
-	proto.RegisterType((*ImportResponse)(nil), "internal.ImportResponse")
-	proto.RegisterType((*Cache)(nil), "internal.Cache")
-	proto.RegisterType((*SliceMaxResponse)(nil), "internal.SliceMaxResponse")
 }

--- a/internal/internal.proto
+++ b/internal/internal.proto
@@ -43,6 +43,7 @@ message QueryRequest {
 	optional bool   Profiles  = 4;
 	optional int64  Timestamp = 5;
 	optional uint32 Quantum   = 6;
+	optional bool   Remote    = 7;
 }
 
 message QueryResponse {

--- a/pql/ast.go
+++ b/pql/ast.go
@@ -3,6 +3,7 @@ package pql
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -295,12 +296,15 @@ func (c *SetProfileAttrs) String() string {
 type TopN struct {
 	Frame string
 
+	// Maximum number of results to return.
+	N int
+
 	// Bitmap to use for intersection while computing top results.
 	// Original bitmap counts are used if no Src is provided.
 	Src BitmapCall
 
-	// Maximum number of results to return.
-	N int
+	// Specific bitmaps to retrieve.
+	BitmapIDs []uint64
 
 	// Field name and values to filter on.
 	Field   string
@@ -318,6 +322,13 @@ func (c *TopN) String() string {
 	}
 	if c.N > 0 {
 		args = append(args, fmt.Sprintf("n=%d", c.N))
+	}
+	if len(c.BitmapIDs) > 0 {
+		strs := make([]string, len(c.BitmapIDs))
+		for i := range c.BitmapIDs {
+			strs[i] = strconv.FormatUint(c.BitmapIDs[i], 10)
+		}
+		args = append(args, fmt.Sprintf("ids=[%s]", strings.Join(strs, ",")))
 	}
 	if c.Field != "" {
 		args = append(args, fmt.Sprintf("field=%q", c.Field))

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -254,22 +254,23 @@ func TestParser_Parse_SetBitmapAttrs_Array(t *testing.T) {
 
 // Ensure the parser can parse a "TopN()" function with keyed args.
 func TestParser_Parse_TopN_Key(t *testing.T) {
-	q, err := pql.ParseString(`TopN(Bitmap(100), frame="b.n", n=2, field="XXX", [5,10,15])`)
+	q, err := pql.ParseString(`TopN(Bitmap(100), frame="b.n", n=2, ids=[1,2,3], field="XXX", [5,10,15])`)
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
 		Root: &pql.TopN{
-			Src:     &pql.Bitmap{ID: 100},
-			Frame:   "b.n",
-			N:       2,
-			Field:   "XXX",
-			Filters: []interface{}{uint64(5), uint64(10), uint64(15)},
+			Src:       &pql.Bitmap{ID: 100},
+			Frame:     "b.n",
+			N:         2,
+			BitmapIDs: []uint64{1, 2, 3},
+			Field:     "XXX",
+			Filters:   []interface{}{uint64(5), uint64(10), uint64(15)},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
 	}
 
-	if s := q.String(); s != `TopN(Bitmap(id=100), frame=b.n, n=2, field="XXX", [5,10,15])` {
+	if s := q.String(); s != `TopN(Bitmap(id=100), frame=b.n, n=2, ids=[1,2,3], field="XXX", [5,10,15])` {
 		t.Fatalf("unexpected string encoding: %s", s)
 	}
 }


### PR DESCRIPTION
## Overview

This pull request adds refetching to get the actual TopN() count after the top bitmaps are determined.

I originally tried tracking which bitmaps were not being reported by slices but we batch multiple slices together when doing remote calls so it was complicated & messy to track across the batches. I changed it to do a refetch of the resulting top bitmaps which should be a quick call. Most of the overhead is in HTTP anyway.

---

Fixes #57
