### PR TITLE
Add bulk call support to the query endpoint

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -286,3 +286,32 @@ type uint64Slice []uint64
 func (p uint64Slice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 func (p uint64Slice) Len() int           { return len(p) }
 func (p uint64Slice) Less(i, j int) bool { return p[i] < p[j] }
+
+// merge combines p and other to a unique sorted set of values.
+// p and other must both have unique sets and be sorted.
+func (p uint64Slice) merge(other []uint64) []uint64 {
+	ret := make([]uint64, 0, len(p))
+
+	i, j := 0, 0
+	for i < len(p) && j < len(other) {
+		a, b := p[i], other[j]
+		if a == b {
+			ret = append(ret, a)
+			i, j = i+1, j+1
+		} else if a < b {
+			ret = append(ret, a)
+			i++
+		} else {
+			ret = append(ret, b)
+			j++
+		}
+	}
+
+	if i < len(p) {
+		ret = append(ret, p[i:]...)
+	} else if j < len(other) {
+		ret = append(ret, other[j:]...)
+	}
+
+	return ret
+}

--- a/cmd/pilosa/main_test.go
+++ b/cmd/pilosa/main_test.go
@@ -40,9 +40,11 @@ func TestMain_Set_Quick(t *testing.T) {
 		for frame, frameSet := range SetCommands(cmds).Frames() {
 			for id, profileIDs := range frameSet {
 				exp := MustMarshalJSON(map[string]interface{}{
-					"result": map[string]interface{}{
-						"bits":  profileIDs,
-						"attrs": map[string]interface{}{},
+					"results": []interface{}{
+						map[string]interface{}{
+							"bits":  profileIDs,
+							"attrs": map[string]interface{}{},
+						},
 					},
 				}) + "\n"
 				if res, err := m.Query("db=d", fmt.Sprintf(`Bitmap(id=%d, frame=%q)`, id, frame)); err != nil {
@@ -61,9 +63,11 @@ func TestMain_Set_Quick(t *testing.T) {
 		for frame, frameSet := range SetCommands(cmds).Frames() {
 			for id, profileIDs := range frameSet {
 				exp := MustMarshalJSON(map[string]interface{}{
-					"result": map[string]interface{}{
-						"bits":  profileIDs,
-						"attrs": map[string]interface{}{},
+					"results": []interface{}{
+						map[string]interface{}{
+							"bits":  profileIDs,
+							"attrs": map[string]interface{}{},
+						},
 					},
 				}) + "\n"
 				if res, err := m.Query("db=d", fmt.Sprintf(`Bitmap(id=%d, frame=%q)`, id, frame)); err != nil {
@@ -110,14 +114,14 @@ func TestMain_SetBitmapAttrs(t *testing.T) {
 	// Query bitmap x.n/1.
 	if res, err := m.Query("db=d", `Bitmap(id=1, frame="x.n")`); err != nil {
 		t.Fatal(err)
-	} else if res != `{"result":{"attrs":{"x":100},"bits":[100]}}`+"\n" {
+	} else if res != `{"results":[{"attrs":{"x":100},"bits":[100]}]}`+"\n" {
 		t.Fatalf("unexpected result: %s", res)
 	}
 
 	// Query bitmap x.n/2.
 	if res, err := m.Query("db=d", `Bitmap(id=2, frame="x.n")`); err != nil {
 		t.Fatal(err)
-	} else if res != `{"result":{"attrs":{"x":200},"bits":[100]}}`+"\n" {
+	} else if res != `{"results":[{"attrs":{"x":200},"bits":[100]}]}`+"\n" {
 		t.Fatalf("unexpected result: %s", res)
 	}
 
@@ -128,7 +132,7 @@ func TestMain_SetBitmapAttrs(t *testing.T) {
 	// Query bitmap after reopening.
 	if res, err := m.Query("db=d&profiles=true", `Bitmap(id=1, frame="x.n")`); err != nil {
 		t.Fatal(err)
-	} else if res != `{"result":{"attrs":{"x":100},"bits":[100]}}`+"\n" {
+	} else if res != `{"results":[{"attrs":{"x":100},"bits":[100]}]}`+"\n" {
 		t.Fatalf("unexpected result(reopen): %s", res)
 	}
 }
@@ -153,7 +157,7 @@ func TestMain_SetProfileAttrs(t *testing.T) {
 	// Query bitmap.
 	if res, err := m.Query("db=d&profiles=true", `Bitmap(id=1, frame="x.n")`); err != nil {
 		t.Fatal(err)
-	} else if res != `{"result":{"attrs":{},"bits":[100,101]},"profiles":[{"id":100,"attrs":{"foo":"bar"}}]}`+"\n" {
+	} else if res != `{"results":[{"attrs":{},"bits":[100,101]}],"profiles":[{"id":100,"attrs":{"foo":"bar"}}]}`+"\n" {
 		t.Fatalf("unexpected result: %s", res)
 	}
 
@@ -164,7 +168,7 @@ func TestMain_SetProfileAttrs(t *testing.T) {
 	// Query bitmap after reopening.
 	if res, err := m.Query("db=d&profiles=true", `Bitmap(id=1, frame="x.n")`); err != nil {
 		t.Fatal(err)
-	} else if res != `{"result":{"attrs":{},"bits":[100,101]},"profiles":[{"id":100,"attrs":{"foo":"bar"}}]}`+"\n" {
+	} else if res != `{"results":[{"attrs":{},"bits":[100,101]}],"profiles":[{"id":100,"attrs":{"foo":"bar"}}]}`+"\n" {
 		t.Fatalf("unexpected result(reopen): %s", res)
 	}
 }

--- a/internal/internal.pb.go
+++ b/internal/internal.pb.go
@@ -18,6 +18,7 @@ It has these top-level messages:
 	AttrMap
 	QueryRequest
 	QueryResponse
+	QueryResult
 	ImportRequest
 	ImportResponse
 	Cache
@@ -273,13 +274,10 @@ func (m *QueryRequest) GetRemote() bool {
 }
 
 type QueryResponse struct {
-	Err              *string    `protobuf:"bytes,1,opt" json:"Err,omitempty"`
-	Bitmap           *Bitmap    `protobuf:"bytes,2,opt" json:"Bitmap,omitempty"`
-	N                *uint64    `protobuf:"varint,3,opt" json:"N,omitempty"`
-	Pairs            []*Pair    `protobuf:"bytes,4,rep" json:"Pairs,omitempty"`
-	Profiles         []*Profile `protobuf:"bytes,5,rep" json:"Profiles,omitempty"`
-	Changed          *bool      `protobuf:"varint,6,opt" json:"Changed,omitempty"`
-	XXX_unrecognized []byte     `json:"-"`
+	Err              *string        `protobuf:"bytes,1,opt" json:"Err,omitempty"`
+	Results          []*QueryResult `protobuf:"bytes,2,rep" json:"Results,omitempty"`
+	Profiles         []*Profile     `protobuf:"bytes,3,rep" json:"Profiles,omitempty"`
+	XXX_unrecognized []byte         `json:"-"`
 }
 
 func (m *QueryResponse) Reset()         { *m = QueryResponse{} }
@@ -293,23 +291,9 @@ func (m *QueryResponse) GetErr() string {
 	return ""
 }
 
-func (m *QueryResponse) GetBitmap() *Bitmap {
+func (m *QueryResponse) GetResults() []*QueryResult {
 	if m != nil {
-		return m.Bitmap
-	}
-	return nil
-}
-
-func (m *QueryResponse) GetN() uint64 {
-	if m != nil && m.N != nil {
-		return *m.N
-	}
-	return 0
-}
-
-func (m *QueryResponse) GetPairs() []*Pair {
-	if m != nil {
-		return m.Pairs
+		return m.Results
 	}
 	return nil
 }
@@ -321,7 +305,40 @@ func (m *QueryResponse) GetProfiles() []*Profile {
 	return nil
 }
 
-func (m *QueryResponse) GetChanged() bool {
+type QueryResult struct {
+	Bitmap           *Bitmap `protobuf:"bytes,1,opt" json:"Bitmap,omitempty"`
+	N                *uint64 `protobuf:"varint,2,opt" json:"N,omitempty"`
+	Pairs            []*Pair `protobuf:"bytes,3,rep" json:"Pairs,omitempty"`
+	Changed          *bool   `protobuf:"varint,4,opt" json:"Changed,omitempty"`
+	XXX_unrecognized []byte  `json:"-"`
+}
+
+func (m *QueryResult) Reset()         { *m = QueryResult{} }
+func (m *QueryResult) String() string { return proto.CompactTextString(m) }
+func (*QueryResult) ProtoMessage()    {}
+
+func (m *QueryResult) GetBitmap() *Bitmap {
+	if m != nil {
+		return m.Bitmap
+	}
+	return nil
+}
+
+func (m *QueryResult) GetN() uint64 {
+	if m != nil && m.N != nil {
+		return *m.N
+	}
+	return 0
+}
+
+func (m *QueryResult) GetPairs() []*Pair {
+	if m != nil {
+		return m.Pairs
+	}
+	return nil
+}
+
+func (m *QueryResult) GetChanged() bool {
 	if m != nil && m.Changed != nil {
 		return *m.Changed
 	}

--- a/internal/internal.proto
+++ b/internal/internal.proto
@@ -47,12 +47,16 @@ message QueryRequest {
 }
 
 message QueryResponse {
-	optional string  Err      = 1;
-	optional Bitmap  Bitmap   = 2;
-	optional uint64  N        = 3;
-	repeated Pair    Pairs    = 4;
-	repeated Profile Profiles = 5;
-	optional bool    Changed  = 6;
+	optional string      Err      = 1;
+	repeated QueryResult Results  = 2;
+	repeated Profile     Profiles = 3;
+}
+
+message QueryResult {
+	optional Bitmap  Bitmap   = 1;
+	optional uint64  N        = 2;
+	repeated Pair    Pairs    = 3;
+	optional bool    Changed  = 4;
 }
 
 message ImportRequest {

--- a/pql/ast.go
+++ b/pql/ast.go
@@ -10,11 +10,17 @@ import (
 
 // Query represents a PQL query.
 type Query struct {
-	Root Call
+	Calls Calls
 }
 
 // String returns a string representation of the query.
-func (q *Query) String() string { return q.Root.String() }
+func (q *Query) String() string {
+	a := make([]string, len(q.Calls))
+	for i, call := range q.Calls {
+		a[i] = call.String()
+	}
+	return strings.Join(a, "\n")
+}
 
 // Node represents any node in the AST.
 type Node interface {

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -15,9 +15,11 @@ func TestParser_Parse_Bitmap_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Bitmap{
-			ID:    1,
-			Frame: "b.n",
+		Calls: pql.Calls{
+			&pql.Bitmap{
+				ID:    1,
+				Frame: "b.n",
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -30,9 +32,11 @@ func TestParser_Parse_Bitmap_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Bitmap{
-			ID:    1,
-			Frame: "b.n",
+		Calls: pql.Calls{
+			&pql.Bitmap{
+				ID:    1,
+				Frame: "b.n",
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -45,10 +49,12 @@ func TestParser_Parse_ClearBit_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.ClearBit{
-			ID:        1,
-			Frame:     "b.n",
-			ProfileID: 3,
+		Calls: pql.Calls{
+			&pql.ClearBit{
+				ID:        1,
+				Frame:     "b.n",
+				ProfileID: 3,
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -61,10 +67,12 @@ func TestParser_Parse_ClearBit_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.ClearBit{
-			ID:        1,
-			Frame:     "b.n",
-			ProfileID: 3,
+		Calls: pql.Calls{
+			&pql.ClearBit{
+				ID:        1,
+				Frame:     "b.n",
+				ProfileID: 3,
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -77,9 +85,11 @@ func TestParser_Parse_Count(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Count{
-			Input: &pql.Bitmap{
-				ID: 1,
+		Calls: pql.Calls{
+			&pql.Count{
+				Input: &pql.Bitmap{
+					ID: 1,
+				},
 			},
 		},
 	}) {
@@ -93,10 +103,12 @@ func TestParser_Parse_Difference(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Difference{
-			Inputs: pql.BitmapCalls{
-				&pql.Bitmap{ID: 1},
-				&pql.Bitmap{ID: 2},
+		Calls: pql.Calls{
+			&pql.Difference{
+				Inputs: pql.BitmapCalls{
+					&pql.Bitmap{ID: 1},
+					&pql.Bitmap{ID: 2},
+				},
 			},
 		},
 	}) {
@@ -110,10 +122,12 @@ func TestParser_Parse_Intersect(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Intersect{
-			Inputs: pql.BitmapCalls{
-				&pql.Bitmap{ID: 1},
-				&pql.Bitmap{ID: 2},
+		Calls: pql.Calls{
+			&pql.Intersect{
+				Inputs: pql.BitmapCalls{
+					&pql.Bitmap{ID: 1},
+					&pql.Bitmap{ID: 2},
+				},
 			},
 		},
 	}) {
@@ -127,7 +141,9 @@ func TestParser_Parse_Profile_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Profile{ID: 1},
+		Calls: pql.Calls{
+			&pql.Profile{ID: 1},
+		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
 	}
@@ -139,7 +155,9 @@ func TestParser_Parse_Profile_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Profile{ID: 1},
+		Calls: pql.Calls{
+			&pql.Profile{ID: 1},
+		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
 	}
@@ -151,11 +169,13 @@ func TestParser_Parse_Range_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Range{
-			ID:        20,
-			Frame:     "b.n",
-			StartTime: time.Date(2000, 1, 2, 3, 4, 0, 0, time.UTC),
-			EndTime:   time.Date(2001, 1, 2, 3, 4, 0, 0, time.UTC),
+		Calls: pql.Calls{
+			&pql.Range{
+				ID:        20,
+				Frame:     "b.n",
+				StartTime: time.Date(2000, 1, 2, 3, 4, 0, 0, time.UTC),
+				EndTime:   time.Date(2001, 1, 2, 3, 4, 0, 0, time.UTC),
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -168,11 +188,13 @@ func TestParser_Parse_Range_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Range{
-			ID:        20,
-			Frame:     "b.n",
-			StartTime: time.Date(2000, 1, 2, 3, 4, 0, 0, time.UTC),
-			EndTime:   time.Date(2001, 1, 2, 3, 4, 0, 0, time.UTC),
+		Calls: pql.Calls{
+			&pql.Range{
+				ID:        20,
+				Frame:     "b.n",
+				StartTime: time.Date(2000, 1, 2, 3, 4, 0, 0, time.UTC),
+				EndTime:   time.Date(2001, 1, 2, 3, 4, 0, 0, time.UTC),
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -185,10 +207,12 @@ func TestParser_Parse_SetBit_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.SetBit{
-			ID:        1,
-			Frame:     "b.n",
-			ProfileID: 3,
+		Calls: pql.Calls{
+			&pql.SetBit{
+				ID:        1,
+				Frame:     "b.n",
+				ProfileID: 3,
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -201,10 +225,12 @@ func TestParser_Parse_SetBit_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.SetBit{
-			ID:        1,
-			Frame:     "b.n",
-			ProfileID: 3,
+		Calls: pql.Calls{
+			&pql.SetBit{
+				ID:        1,
+				Frame:     "b.n",
+				ProfileID: 3,
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -217,15 +243,17 @@ func TestParser_Parse_SetBitmapAttrs_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.SetBitmapAttrs{
-			ID:    1,
-			Frame: "b.n",
-			Attrs: map[string]interface{}{
-				"foo": "bar",
-				"bar": uint64(123),
-				"baz": true,
-				"bat": false,
-				"x":   nil,
+		Calls: pql.Calls{
+			&pql.SetBitmapAttrs{
+				ID:    1,
+				Frame: "b.n",
+				Attrs: map[string]interface{}{
+					"foo": "bar",
+					"bar": uint64(123),
+					"baz": true,
+					"bat": false,
+					"x":   nil,
+				},
 			},
 		},
 	}) {
@@ -239,12 +267,14 @@ func TestParser_Parse_SetBitmapAttrs_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.SetBitmapAttrs{
-			ID:    1,
-			Frame: "b.n",
-			Attrs: map[string]interface{}{
-				"foo": "bar",
-				"bar": uint64(123),
+		Calls: pql.Calls{
+			&pql.SetBitmapAttrs{
+				ID:    1,
+				Frame: "b.n",
+				Attrs: map[string]interface{}{
+					"foo": "bar",
+					"bar": uint64(123),
+				},
 			},
 		},
 	}) {
@@ -258,13 +288,15 @@ func TestParser_Parse_TopN_Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.TopN{
-			Src:       &pql.Bitmap{ID: 100},
-			Frame:     "b.n",
-			N:         2,
-			BitmapIDs: []uint64{1, 2, 3},
-			Field:     "XXX",
-			Filters:   []interface{}{uint64(5), uint64(10), uint64(15)},
+		Calls: pql.Calls{
+			&pql.TopN{
+				Src:       &pql.Bitmap{ID: 100},
+				Frame:     "b.n",
+				N:         2,
+				BitmapIDs: []uint64{1, 2, 3},
+				Field:     "XXX",
+				Filters:   []interface{}{uint64(5), uint64(10), uint64(15)},
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -281,12 +313,14 @@ func TestParser_Parse_TopN_Array(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.TopN{
-			Src:     &pql.Bitmap{ID: 100},
-			Frame:   "b.n",
-			N:       2,
-			Field:   "XXX",
-			Filters: []interface{}{"foo", true, false},
+		Calls: pql.Calls{
+			&pql.TopN{
+				Src:     &pql.Bitmap{ID: 100},
+				Frame:   "b.n",
+				N:       2,
+				Field:   "XXX",
+				Filters: []interface{}{"foo", true, false},
+			},
 		},
 	}) {
 		t.Fatalf("unexpected query: %s", spew.Sdump(q))
@@ -303,10 +337,12 @@ func TestParser_Parse_Union(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(q, &pql.Query{
-		Root: &pql.Union{
-			Inputs: pql.BitmapCalls{
-				&pql.Bitmap{ID: 1},
-				&pql.Bitmap{ID: 2},
+		Calls: pql.Calls{
+			&pql.Union{
+				Inputs: pql.BitmapCalls{
+					&pql.Bitmap{ID: 1},
+					&pql.Bitmap{ID: 2},
+				},
 			},
 		},
 	}) {

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -165,7 +165,7 @@ func testBitmapMarshalQuick(t *testing.T, n int, min, max uint64, sorted bool) {
 		// Add more values to bitmap.
 		for _, v := range a1 {
 			set[v] = struct{}{}
-			if err := bm.Add(v); err != nil {
+			if _, err := bm.Add(v); err != nil {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
## Overview

This pull request changes the `pql.Query` so that it can accept one or more top-level calls instead of only one.

The query request format change because a query with a single call is still valid. However, the result format now returns a `results` field that has one result for each top-level call. The `profiles` field is
still the same, however, it combines all profiles from all bitmap responses into one return so that there's not duplicate attributes.

If an error occurs on any call then it is returned in the top-level response object. There is not an error per call. That's just confusing. :)

Fixes #59
## Example

You can query against the server using `curl`:

``` sh
$ curl -XPOST "http://localhost:15000/query?db=d&profiles=true" -d '
SetBit(id=1,frame="b.n",profileID=1000)
SetBit(id=2,frame="b.n",profileID=1000)
SetProfileAttrs(id=1000,foo="bar")
Bitmap(id=1,frame="b.n")
SetBit(id=2,frame="b.n",profileID=1001)
ClearBit(id=2,frame="b.n",profileID=1000)
SetBit(id=2,frame="b.n",profileID=1001)
SetBit(id=2,frame="b.n",profileID=1001)
Bitmap(id=2,frame="b.n")
Bitmap(id=1,frame="b.n")
'
```

And receive a response:

``` sh
{
  "results": [
    false,
    true,
    null,
    {"attrs": {}, "bits": [1000]},
    false,
    true,
    false,
    false,
    {"attrs": {}, "bits": [1001]},
    {"attrs": {}, "bits": [1000]}
  ],
  "profiles": [
    {"id": 1000, "attrs": {"foo": "bar"}}
  ]
}
```
