### PR TITLE
Add frame restore for cluster transfer

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// DefaultPartitionN is the default number of partitions in a cluster.
-	DefaultPartitionN = 64
+	DefaultPartitionN = 16
 
 	// DefaultReplicaN is the default number of replicas per partition.
 	DefaultReplicaN = 1
@@ -112,6 +112,9 @@ type Hasher interface {
 	// Hashes the key into a number between [0,N).
 	Hash(key uint64, n int) int
 }
+
+// NewHasher returns a new instance of the default hasher.
+func NewHasher() Hasher { return &jmphasher{} }
 
 // jmphasher represents an implementation of jmphash. Implements Hasher.
 type jmphasher struct{}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -56,6 +56,26 @@ func TestCluster_Partition(t *testing.T) {
 	}
 }
 
+// Ensure the hasher can hash correctly.
+func TestHasher(t *testing.T) {
+	for _, tt := range []struct {
+		key    uint64
+		bucket []int
+	}{
+		// Generated from the reference C++ code
+		{0, []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},
+		{1, []int{0, 0, 0, 0, 0, 0, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 17, 17}},
+		{0xdeadbeef, []int{0, 1, 2, 3, 3, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 5, 16, 16, 16}},
+		{0x0ddc0ffeebadf00d, []int{0, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 15, 15, 15, 15}},
+	} {
+		for i, v := range tt.bucket {
+			if got := pilosa.NewHasher().Hash(tt.key, i+1); got != v {
+				t.Errorf("hash(%v,%v)=%v, want %v", tt.key, i+1, got, v)
+			}
+		}
+	}
+}
+
 // NewCluster returns a cluster with n nodes and uses a mod-based hasher.
 func NewCluster(n int) *pilosa.Cluster {
 	c := pilosa.NewCluster()

--- a/executor.go
+++ b/executor.go
@@ -402,6 +402,7 @@ func (e *Executor) executeClearBit(db string, c *pql.ClearBit, opt *ExecOptions)
 func (e *Executor) executeSetBit(db string, c *pql.SetBit, opt *ExecOptions) (bool, error) {
 	slice := c.ProfileID / SliceWidth
 	ret := false
+
 	for _, node := range e.Cluster.SliceNodes(slice) {
 		// Update locally if host matches.
 		if node.Host == e.Host {


### PR DESCRIPTION
## Overview

This pull request adds an endpoint to restore an entire frame from another cluster. Multiple hosts can use this endpoint to copy and rebalance a cluster to a new cluster.

The endpoint is:

```
POST /frame/restore?host=<remote-host>&db=<db>&frame=<frame>
```
## Other notes

I changed the partition count (`PartitionN`) from `64` to `16`. While I was doing testing I found that 64 partitions caused large continuous stretches of partitions to be assigned to one node before allocating to a second node in a 2-node cluster.

It's probably worth testing out different partition counts to see how they spread out across different cluster configurations that we're expecting to set up.
