### PR TITLE
Add schema endpoint

### DIFF
--- a/db.go
+++ b/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 )
 
@@ -130,6 +131,20 @@ func (db *DB) Frame(name string) *Frame {
 
 func (db *DB) frame(name string) *Frame { return db.frames[name] }
 
+// Frames returns a list of all frames in the database.
+func (db *DB) Frames() []*Frame {
+	db.mu.Lock()
+	defer db.mu.Unlock()
+
+	a := make([]*Frame, 0, len(db.frames))
+	for _, f := range db.frames {
+		a = append(a, f)
+	}
+	sort.Sort(frameSlice(a))
+
+	return a
+}
+
 // CreateFrameIfNotExists returns a frame in the database by name.
 func (db *DB) CreateFrameIfNotExists(name string) (*Frame, error) {
 	db.mu.Lock()
@@ -152,3 +167,9 @@ func (db *DB) createFrameIfNotExists(name string) (*Frame, error) {
 
 	return f, nil
 }
+
+type dbSlice []*DB
+
+func (p dbSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p dbSlice) Len() int           { return len(p) }
+func (p dbSlice) Less(i, j int) bool { return p[i].Name() < p[j].Name() }

--- a/frame.go
+++ b/frame.go
@@ -186,3 +186,9 @@ func (f *Frame) createFragmentIfNotExists(slice uint64) (*Fragment, error) {
 
 	return frag, nil
 }
+
+type frameSlice []*Frame
+
+func (p frameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p frameSlice) Len() int           { return len(p) }
+func (p frameSlice) Less(i, j int) bool { return p[i].Name() < p[j].Name() }

--- a/index.go
+++ b/index.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 )
 
@@ -94,6 +95,20 @@ func (i *Index) DB(name string) *DB {
 }
 
 func (i *Index) db(name string) *DB { return i.dbs[name] }
+
+// DBs returns a list of all databases in the index.
+func (i *Index) DBs() []*DB {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
+	a := make([]*DB, 0, len(i.dbs))
+	for _, db := range i.dbs {
+		a = append(a, db)
+	}
+	sort.Sort(dbSlice(a))
+
+	return a
+}
 
 // CreateDBIfNotExists returns a database by name.
 // The database is created if it does not already exist.


### PR DESCRIPTION
This commit adds a new HTTP handler to return a list of all databases
and frames in the index:

```
GET /schema
```

This returns JSON in the following format:

```
{
  "dbs":[
    {
      "name":"d0",
      "frames":[
        {"name":"f0"},
        {"name":"f1"}
      ]
    }
  ]
}
```

Fixes #61
