### PR TITLE
Add 'pilosactl bench' command

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -56,7 +56,12 @@ func (s *AttrStore) Open() error {
 }
 
 // Close closes the store.
-func (s *AttrStore) Close() error { return s.db.Close() }
+func (s *AttrStore) Close() error {
+	if s.db != nil {
+		s.db.Close()
+	}
+	return nil
+}
 
 // Attrs returns a set of attributes by ID.
 func (s *AttrStore) Attrs(id uint64) (m map[string]interface{}, err error) {

--- a/db.go
+++ b/db.go
@@ -1,6 +1,7 @@
 package pilosa
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -153,6 +154,10 @@ func (db *DB) CreateFrameIfNotExists(name string) (*Frame, error) {
 }
 
 func (db *DB) createFrameIfNotExists(name string) (*Frame, error) {
+	if name == "" {
+		return nil, errors.New("frame name required")
+	}
+
 	// Find frame in cache first.
 	if f := db.frames[name]; f != nil {
 		return f, nil

--- a/fragment.go
+++ b/fragment.go
@@ -41,7 +41,7 @@ const (
 	DefaultCacheFlushInterval = 1 * time.Minute
 
 	// DefaultFragmentMaxOpN is the default value for Fragment.MaxOpN.
-	DefaultFragmentMaxOpN = 10000
+	DefaultFragmentMaxOpN = 1000
 )
 
 // Fragment represents the intersection of a frame and slice in a database.
@@ -256,12 +256,12 @@ func (f *Fragment) close() error {
 
 	// Flush cache if closing gracefully.
 	if err := f.flushCache(); err != nil {
-		f.logger().Printf("error flushing cache on close: err=%s, path=%s", err, f.path)
+		f.logger().Printf("fragment: error flushing cache on close: err=%s, path=%s", err, f.path)
 	}
 
 	// Close underlying storage.
 	if err := f.closeStorage(); err != nil {
-		f.logger().Printf("error closing storage: err=%s, path=%s", err, f.path)
+		f.logger().Printf("fragment: error closing storage: err=%s, path=%s", err, f.path)
 	}
 
 	return nil
@@ -634,6 +634,9 @@ func (f *Fragment) Snapshot() error {
 }
 
 func (f *Fragment) snapshot() error {
+	logger := f.logger()
+	logger.Printf("fragment: snapshotting %s/%s/%d", f.db, f.frame, f.slice)
+
 	// Create a temporary file to snapshot to.
 	snapshotPath := f.path + SnapshotExt
 	file, err := os.Create(snapshotPath)

--- a/handler.go
+++ b/handler.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"strconv"
 	"strings"
@@ -49,8 +50,23 @@ func NewHandler() *Handler {
 
 // ServeHTTP handles an HTTP request.
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	t := time.Now()
+	// Handle pprof requests separately.
+	if strings.HasPrefix(r.URL.Path, "/debug/pprof") {
+		switch r.URL.Path {
+		case "/debug/pprof/cmdline":
+			pprof.Cmdline(w, r)
+		case "/debug/pprof/profile":
+			pprof.Profile(w, r)
+		case "/debug/pprof/symbol":
+			pprof.Symbol(w, r)
+		default:
+			pprof.Index(w, r)
+		}
+		return
+	}
 
+	// Route API calls to appropriate handler functions.
+	t := time.Now()
 	switch r.URL.Path {
 	case "/schema":
 		switch r.Method {

--- a/index.go
+++ b/index.go
@@ -1,6 +1,7 @@
 package pilosa
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -119,6 +120,10 @@ func (i *Index) CreateDBIfNotExists(name string) (*DB, error) {
 }
 
 func (i *Index) createDBIfNotExists(name string) (*DB, error) {
+	if name == "" {
+		return nil, errors.New("database name required")
+	}
+
 	// Return database if it exists.
 	if db := i.db(name); db != nil {
 		return db, nil

--- a/pilosa.go
+++ b/pilosa.go
@@ -21,6 +21,9 @@ var (
 
 	// ErrFragmentNotFound is returned when a fragment does not exist.
 	ErrFragmentNotFound = errors.New("fragment not found")
+
+	// ErrQueryRequired is returned when no query is specified.
+	ErrQueryRequired = errors.New("query required")
 )
 
 // Version represents the current running version of Pilosa.


### PR DESCRIPTION
## Overview

This commit adds a simple benchmarking utility to the `pilosactl` binary. It currently only supports individual `SetBit()` commands but it's a good start towards making a generic benchmarking framework at the integration level.

The subcommands and usage/help messages were also cleaned up to output correctly.
