### PR TITLE
Anti-entropy monitor

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -420,6 +420,11 @@ func (e *Executor) executeSetBit(db string, c *pql.SetBit, opt *ExecOptions) (bo
 			continue
 		}
 
+		// Do not forward call if this is already being forwarded.
+		if opt.Remote {
+			continue
+		}
+
 		// Forward call to remote node otherwise.
 		if res, err := e.exec(node, db, &pql.Query{Calls: pql.Calls{c}}, nil, opt); err != nil {
 			return false, err


### PR DESCRIPTION
## Overview

This pull request adds monitors to periodically start an index sync with another remote node. The monitor runs on each node for every other node in the cluster. So in a 3 node cluster with nodes `A`, `B`, `C`, there are the following monitors:

`A -> B`, `A -> C`
`B -> A`, `A -> C`
`C -> B`, `A -> C`

The connections are duplicated but that shouldn't matter since we are caching block checksums. We may want to introduce some jitter just so the double syncs don't line up exactly. Maybe an interval like `10m +/-50%` and it'll pick a random interval between `5m` & `15m`.
### Misc

I also fixed a bug in `SetBit()` where calls were getting caught in a redirect loop. I'll note it in the line notes.
