### PR TITLE
Optimize Import

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,6 +12,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"time"
 
@@ -567,6 +568,16 @@ type Bit struct {
 // Bits represents a slice of bits.
 type Bits []Bit
 
+func (p Bits) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p Bits) Len() int      { return len(p) }
+
+func (p Bits) Less(i, j int) bool {
+	if p[i].BitmapID == p[j].BitmapID {
+		return p[i].ProfileID < p[j].ProfileID
+	}
+	return p[i].BitmapID < p[j].BitmapID
+}
+
 // BitmapIDs returns a slice of all the bitmap IDs.
 func (a Bits) BitmapIDs() []uint64 {
 	other := make([]uint64, len(a))
@@ -592,5 +603,11 @@ func (a Bits) GroupBySlice() map[uint64][]Bit {
 		slice := bit.ProfileID / SliceWidth
 		m[slice] = append(m[slice], bit)
 	}
+
+	for slice, bits := range m {
+		sort.Sort(Bits(bits))
+		m[slice] = bits
+	}
+
 	return m
 }

--- a/fragment.go
+++ b/fragment.go
@@ -848,13 +848,14 @@ func (f *Fragment) Import(bitmapIDs, profileIDs []uint64) error {
 				bmCounter = bitmap.Count()
 				lastID = bitmapID
 			}
-
-			// Invalidate block checksum.
-			delete(f.checksums, int(bitmapID/HashBlockSize))
 			if bitmap.SetBit(profileID) {
 				bmCounter += 1
 			}
+
+			// Invalidate block checksum.
+			delete(f.checksums, int(bitmapID/HashBlockSize))
 		}
+
 		f.cache.Invalidate()
 		return nil
 	}(); err != nil {


### PR DESCRIPTION
## Overview

This pull request optimizes the import by sorting the bits before performing the import and then using a buffered writer when persisting the roaring bitmap. I profiled against an 85M bit dataset which originally took longer than an hour to import (and even then I just `SIGKILL`'d it). After the changes the sorting the import took `2m1s`.
### Performance Breakdown

Currently the import time breaks down as follows:

```
51s Parsing CSV
23s Grouping bits by slice
----------------------------------------------------
 5s Protobuf Unmarshaling
37s Setting bits
 5s Writing data & mmapping to fragment
```

Everything above the line is client side and everything below is server side. Once on the server side it takes `47s` to import and persist to disk (1.8M bits/sec).

If we want to further increase performance we can split the CSV on the client side. On the server side the import is currently single threaded so we can import each slice in parallel to improve performance.
