### PR TITLE
roaring: change bit split to 40/24

### DIFF
--- a/roaring/internal_test.go
+++ b/roaring/internal_test.go
@@ -9,29 +9,29 @@ import (
 func TestBitmapIterator(t *testing.T) {
 	for i, tt := range []struct {
 		bitmap []uint64
-		values []uint16
+		values []uint32
 	}{
 		// Empty
 		{
 			bitmap: []uint64{6}, // 0110
-			values: []uint16{1, 2},
+			values: []uint32{1, 2},
 		},
 
 		// Single uint64 bitmap
 		{
 			bitmap: []uint64{6}, // 0110
-			values: []uint16{1, 2},
+			values: []uint32{1, 2},
 		},
 
 		// Multi uint64 bitmap
 		{
 			bitmap: []uint64{1 << 63, 1, 0, 1, 3 << 62},
-			values: []uint16{63, 64, 192, 318, 319},
+			values: []uint32{63, 64, 192, 318, 319},
 		},
 	} {
 		itr := newBitmapIterator(tt.bitmap)
 
-		var a []uint16
+		var a []uint32
 		for v, eof := itr.next(); !eof; v, eof = itr.next() {
 			a = append(a, v)
 		}


### PR DESCRIPTION
## Overview

This commit changes the `roaring.Bitmap` to use a 40/24 split in the high and low bits. This change also requires the low bits to use `uint32` instead of `uint16`.

/cc @tgruben 
## Stats

I loaded a data file with 85M bits into `pilosa`, restarted the server, then performed a heap pprof to see how much space was required for roaring Bitmap containers.

This was tried with the original 48/16 split on `master`, then an `46/18` split, and then finally a `40/24` split.

```
master  1029MB
18-bit   712MB
24-bit   245MB
```

The final split also increased the `maxArraySize` from 4096 to 1M because the containers were filling more easily with a larger bit range so they were all allocating full roaring bitmap containers.
