### PR TITLE
Check for early close during AAE

### DIFF
--- a/server.go
+++ b/server.go
@@ -167,6 +167,7 @@ func (s *Server) monitorAntiEntropy() {
 		syncer.Index = s.Index
 		syncer.Host = s.Host
 		syncer.Cluster = s.Cluster
+		syncer.Closing = s.closing
 
 		// Sync indexes.
 		if err := syncer.SyncIndex(); err != nil {


### PR DESCRIPTION
## Overview

This pull request adds a `Closing` channel to the `IndexSyncer` and the `FragmentSyncer` that is periodically checked during execution. If the channel is closed then an in-progress sync is immediately stopped.
