### PR TITLE
Serialize cache flush

### DIFF
--- a/cmd/pilosactl/main.go
+++ b/cmd/pilosactl/main.go
@@ -12,9 +12,13 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"syscall"
+	"text/tabwriter"
 	"time"
+	"unsafe"
 
 	"github.com/umbel/pilosa"
+	"github.com/umbel/pilosa/roaring"
 )
 
 var (
@@ -78,6 +82,7 @@ The commands are:
 	import     imports data from a CSV file
 	backup     backs up a frame to an archive file
 	restore    restores a frame from an archive file
+	inspect    inspects fragment data files
 	bench      benchmarks operations
 
 Use the "-h" flag with any command for more information.
@@ -108,6 +113,8 @@ func (m *Main) ParseFlags(args []string) error {
 		m.Cmd = NewBackupCommand(m.Stdin, m.Stdout, m.Stderr)
 	case "restore":
 		m.Cmd = NewRestoreCommand(m.Stdin, m.Stdout, m.Stderr)
+	case "inspect":
+		m.Cmd = NewInspectCommand(m.Stdin, m.Stdout, m.Stderr)
 	case "bench":
 		m.Cmd = NewBenchCommand(m.Stdin, m.Stdout, m.Stderr)
 	default:
@@ -511,6 +518,116 @@ func (cmd *RestoreCommand) Run() error {
 	if err := client.RestoreFrom(f, cmd.Database, cmd.Frame); err != nil {
 		return err
 	}
+
+	return nil
+}
+
+// InspectCommand represents a command for inspecting fragment data files.
+type InspectCommand struct {
+	// Path to data file
+	Path string
+
+	// Standard input/output
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewInspectCommand returns a new instance of InspectCommand.
+func NewInspectCommand(stdin io.Reader, stdout, stderr io.Writer) *InspectCommand {
+	return &InspectCommand{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+}
+
+// ParseFlags parses command line flags from args.
+func (cmd *InspectCommand) ParseFlags(args []string) error {
+	fs := flag.NewFlagSet("pilosactl", flag.ContinueOnError)
+	fs.SetOutput(ioutil.Discard)
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	// Parse path.
+	if fs.NArg() == 0 {
+		return errors.New("path required")
+	} else if fs.NArg() > 1 {
+		return errors.New("only one path allowed")
+	}
+	cmd.Path = fs.Arg(0)
+
+	return nil
+}
+
+// Usage returns the usage message to be printed.
+func (cmd *InspectCommand) Usage() string {
+	return strings.TrimSpace(`
+usage: pilosactl inspect PATH 
+
+Inspects a data file and provides stats.
+
+`)
+}
+
+// Run executes the main program execution.
+func (cmd *InspectCommand) Run() error {
+	// Open file handle.
+	f, err := os.Open(cmd.Path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return err
+	}
+
+	// Memory map the file.
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(fi.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return err
+	}
+	defer syscall.Munmap(data)
+
+	// Attach the mmap file to the bitmap.
+	t := time.Now()
+	fmt.Fprintf(cmd.Stderr, "unmarshaling bitmap...")
+	bm := roaring.NewBitmap()
+	buf := (*[0x7FFFFFFF]byte)(unsafe.Pointer(&data[0]))[:fi.Size()]
+	if err := bm.UnmarshalBinary(buf); err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.Stderr, " (%s)\n", time.Since(t))
+
+	// Retrieve stats.
+	t = time.Now()
+	fmt.Fprintf(cmd.Stderr, "calculating stats...")
+	info := bm.Info()
+	fmt.Fprintf(cmd.Stderr, " (%s)\n", time.Since(t))
+
+	// Print top-level info.
+	fmt.Fprintf(cmd.Stdout, "== Bitmap Info ==\n")
+	fmt.Fprintf(cmd.Stdout, "Containers: %d\n", len(info.Containers))
+	fmt.Fprintf(cmd.Stdout, "Operations: %d\n", info.OpN)
+	fmt.Fprintln(cmd.Stdout, "")
+
+	// Print info for each container.
+	fmt.Fprintln(cmd.Stdout, "== Containers ==")
+	tw := tabwriter.NewWriter(cmd.Stdout, 0, 8, 0, '\t', 0)
+	fmt.Fprintf(tw, "%s\t%s\t% 8s \t% 8s\t%s\n", "KEY", "TYPE", "N", "ALLOC", "OFFSET")
+	for _, ci := range info.Containers {
+		fmt.Fprintf(tw, "%d\t%s\t% 8d \t% 8d \t0x%08x\n",
+			ci.Key,
+			ci.Type,
+			ci.N,
+			ci.Alloc,
+			uintptr(ci.Pointer)-uintptr(unsafe.Pointer(&data[0])),
+		)
+	}
+	tw.Flush()
 
 	return nil
 }

--- a/frame.go
+++ b/frame.go
@@ -161,6 +161,18 @@ func (f *Frame) Fragment(slice uint64) *Fragment {
 
 func (f *Frame) fragment(slice uint64) *Fragment { return f.fragments[slice] }
 
+// Fragments returns a list of all fragments in the frame.
+func (f *Frame) Fragments() []*Fragment {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	other := make([]*Fragment, 0, len(f.fragments))
+	for _, fragment := range f.fragments {
+		other = append(other, fragment)
+	}
+	return other
+}
+
 // CreateFragmentIfNotExists returns a fragment in the frame by slice.
 func (f *Frame) CreateFragmentIfNotExists(slice uint64) (*Fragment, error) {
 	f.mu.Lock()

--- a/index_test.go
+++ b/index_test.go
@@ -1,6 +1,7 @@
 package pilosa_test
 
 import (
+	"bytes"
 	"io/ioutil"
 	"os"
 	"reflect"
@@ -118,6 +119,7 @@ func TestIndexSyncer_SyncIndex(t *testing.T) {
 // Index is a test wrapper for pilosa.Index.
 type Index struct {
 	*pilosa.Index
+	LogOutput bytes.Buffer
 }
 
 // NewIndex returns a new instance of Index with a temporary path.
@@ -129,6 +131,8 @@ func NewIndex() *Index {
 
 	i := &Index{Index: pilosa.NewIndex()}
 	i.Path = path
+	i.Index.LogOutput = &i.LogOutput
+
 	return i
 }
 


### PR DESCRIPTION
## Overview

This pull request moves the cache flush to the `Index` and only serializes a single fragment at a time. This removes large IO spikes and cleans up stack traces since the number of goroutines drops dramatically.
## Notes

Also included in this commit is the `inspect` command for the `pilsoactl` binary. This provides insight into pilosa data files.
