### PR TITLE
Add export command to pilosactl

### DIFF
--- a/cmd/pilosactl/main.go
+++ b/cmd/pilosactl/main.go
@@ -80,6 +80,7 @@ The commands are:
 
 	config     prints the default configuration
 	import     imports data from a CSV file
+	export     exports data to a CSV file
 	backup     backs up a frame to an archive file
 	restore    restores a frame from an archive file
 	inspect    inspects fragment data files
@@ -109,6 +110,8 @@ func (m *Main) ParseFlags(args []string) error {
 		m.Cmd = NewConfigCommand(m.Stdin, m.Stdout, m.Stderr)
 	case "import":
 		m.Cmd = NewImportCommand(m.Stdin, m.Stdout, m.Stderr)
+	case "export":
+		m.Cmd = NewExportCommand(m.Stdin, m.Stdout, m.Stderr)
 	case "backup":
 		m.Cmd = NewBackupCommand(m.Stdin, m.Stdout, m.Stderr)
 	case "restore":
@@ -348,6 +351,118 @@ func (cmd *ImportCommand) parsePath(path string) ([]pilosa.Bit, error) {
 	}
 
 	return a, nil
+}
+
+// ExportCommand represents a command for bulk exporting data from a server.
+type ExportCommand struct {
+	// Remote host and port.
+	Host string
+
+	// Name of the database & frame to export from.
+	Database string
+	Frame    string
+
+	// Filename to export to.
+	Path string
+
+	// Standard input/output
+	Stdin  io.Reader
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// NewExportCommand returns a new instance of ExportCommand.
+func NewExportCommand(stdin io.Reader, stdout, stderr io.Writer) *ExportCommand {
+	return &ExportCommand{
+		Stdin:  stdin,
+		Stdout: stdout,
+		Stderr: stderr,
+	}
+}
+
+// ParseFlags parses command line flags from args.
+func (cmd *ExportCommand) ParseFlags(args []string) error {
+	fs := flag.NewFlagSet("pilosactl", flag.ContinueOnError)
+	fs.SetOutput(ioutil.Discard)
+	fs.StringVar(&cmd.Host, "host", "localhost:15000", "host:port")
+	fs.StringVar(&cmd.Database, "d", "", "database")
+	fs.StringVar(&cmd.Frame, "f", "", "frame")
+	fs.StringVar(&cmd.Path, "o", "", "output file")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Usage returns the usage message to be printed.
+func (cmd *ExportCommand) Usage() string {
+	return strings.TrimSpace(`
+usage: pilosactl export -host HOST -d database -f frame -o OUTFILE
+
+Bulk exports a fragment to a CSV file. If the OUTFILE is not specified then
+the output is written to STDOUT.
+
+The format of the CSV file is:
+
+	BITMAPID,PROFILEID
+
+The file does not contain any headers.
+`)
+}
+
+// Run executes the main program execution.
+func (cmd *ExportCommand) Run() error {
+	logger := log.New(cmd.Stderr, "", log.LstdFlags)
+
+	// Validate arguments.
+	if cmd.Database == "" {
+		return pilosa.ErrDatabaseRequired
+	} else if cmd.Frame == "" {
+		return pilosa.ErrFrameRequired
+	}
+
+	// Use output file, if specified.
+	// Otherwise use STDOUT.
+	var w io.Writer = cmd.Stdout
+	if cmd.Path != "" {
+		f, err := os.Create(cmd.Path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		w = f
+	}
+
+	// Create a client to the server.
+	client, err := pilosa.NewClient(cmd.Host)
+	if err != nil {
+		return err
+	}
+
+	// Determine slice count.
+	sliceN, err := client.SliceN()
+	if err != nil {
+		return err
+	}
+
+	// Export each slice.
+	for slice := uint64(0); slice <= sliceN; slice++ {
+		logger.Printf("exporting slice: %d", slice)
+		if err := client.ExportCSV(cmd.Database, cmd.Frame, slice, w); err != nil {
+			return err
+		}
+	}
+
+	// Close writer, if applicable.
+	if w, ok := w.(io.Closer); ok {
+		if err := w.Close(); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // BackupCommand represents a command for backing up a frame.

--- a/fragment_test.go
+++ b/fragment_test.go
@@ -108,6 +108,35 @@ func TestFragment_Snapshot(t *testing.T) {
 	}
 }
 
+// Ensure a fragment can iterate over all bits in order.
+func TestFragment_ForEachBit(t *testing.T) {
+	f := MustOpenFragment("d", "f", 0)
+	defer f.Close()
+
+	// Set bits on the fragment.
+	if _, err := f.SetBit(100, 20, nil, 0); err != nil {
+		t.Fatal(err)
+	} else if _, err := f.SetBit(2, 38, nil, 0); err != nil {
+		t.Fatal(err)
+	} else if _, err := f.SetBit(2, 37, nil, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Iterate over bits.
+	var result [][2]uint64
+	if err := f.ForEachBit(func(bitmapID, profileID uint64) error {
+		result = append(result, [2]uint64{bitmapID, profileID})
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify bits are correct.
+	if !reflect.DeepEqual(result, [][2]uint64{{2, 37}, {2, 38}, {100, 20}}) {
+		t.Fatalf("unexpected result: %#v", result)
+	}
+}
+
 // Ensure a fragment can return the top n results.
 func TestFragment_Top(t *testing.T) {
 	f := MustOpenFragment("d", "f", 0)


### PR DESCRIPTION
## Overview

CSV exports can now be done with the pilosactl application:

``` sh
$ pilosactl -d mydb -f myframe -o MYFILE.csv
```

If `-o` is not specified then the CSV is written to STDOUT. The exporter combines all slices for the db/frame to into a single concatenated CSV file.

/cc @tgruben 
