### PR TITLE
Remove post-mmap resizing

### DIFF
--- a/cmd/pilosactl/main.go
+++ b/cmd/pilosactl/main.go
@@ -711,8 +711,7 @@ func (cmd *InspectCommand) Run() error {
 	t := time.Now()
 	fmt.Fprintf(cmd.Stderr, "unmarshaling bitmap...")
 	bm := roaring.NewBitmap()
-	buf := (*[0x7FFFFFFF]byte)(unsafe.Pointer(&data[0]))[:fi.Size()]
-	if err := bm.UnmarshalBinary(buf); err != nil {
+	if err := bm.UnmarshalBinary(data); err != nil {
 		return err
 	}
 	fmt.Fprintf(cmd.Stderr, " (%s)\n", time.Since(t))

--- a/fragment.go
+++ b/fragment.go
@@ -191,7 +191,7 @@ func (f *Fragment) openStorage() error {
 	}
 
 	// Attach the mmap file to the bitmap.
-	data := (*[0x7FFFFFFF]byte)(unsafe.Pointer(&f.storageData[0]))[:fi.Size()]
+	data := f.storageData
 	if err := f.storage.UnmarshalBinary(data); err != nil {
 		return fmt.Errorf("unmarshal storage: file=%s, err=%s", f.file.Name(), err)
 	}


### PR DESCRIPTION
@tgruben Can you give this a try? I'm not sure why I was resizing the `[]byte` when it was returned from `mmap()`. :-/

Fixes #106
