### PR TITLE
Add import sorting command

### DIFF
--- a/client.go
+++ b/client.go
@@ -682,3 +682,12 @@ func (a Bits) GroupBySlice() map[uint64][]Bit {
 
 	return m
 }
+
+// BitsByPos represents a slice of bits sorted by internal position.
+type BitsByPos []Bit
+
+func (p BitsByPos) Swap(i, j int) { p[i], p[j] = p[j], p[i] }
+func (p BitsByPos) Len() int      { return len(p) }
+func (p BitsByPos) Less(i, j int) bool {
+	return Pos(p[i].BitmapID, p[i].ProfileID) < Pos(p[j].BitmapID, p[j].ProfileID)
+}

--- a/fragment.go
+++ b/fragment.go
@@ -427,8 +427,7 @@ func (f *Fragment) pos(bitmapID, profileID uint64) (uint64, error) {
 	if profileID < minProfileID || profileID >= minProfileID+SliceWidth {
 		return 0, errors.New("profile out of bounds")
 	}
-
-	return (bitmapID * SliceWidth) + (profileID % SliceWidth), nil
+	return Pos(bitmapID, profileID), nil
 }
 
 // ForEachBit executes fn for every bit set in the fragment.
@@ -1421,4 +1420,9 @@ func byteSlicesEqual(a [][]byte) bool {
 		}
 	}
 	return true
+}
+
+// Pos returns the bitmap position of a bitmap/profile pair.
+func Pos(bitmapID, profileID uint64) uint64 {
+	return (bitmapID * SliceWidth) + (profileID % SliceWidth)
 }

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -247,20 +247,22 @@ func (b *Bitmap) OffsetRange(offset, start, end uint64) *Bitmap {
 	off := highbits(offset)
 	hi0, hi1 := highbits(start), highbits(end)
 
+	// Find starting container.
+	n := len(b.containers)
+	i := sort.Search(n, func(i int) bool { return b.keys[i] >= hi0 })
+
 	var other Bitmap
-	for i, c := range b.containers {
+	for ; i < n; i++ {
 		key := b.keys[i]
 
 		// If we've exceeded the upper bound then exit.
 		if key >= hi1 {
 			break
-		} else if key < hi0 {
-			continue
 		}
 
 		// Otherwise append container with offset key.
 		other.keys = append(other.keys, off+(key-hi0))
-		other.containers = append(other.containers, c)
+		other.containers = append(other.containers, b.containers[i])
 	}
 	return &other
 }


### PR DESCRIPTION
## Overview

Introduces new `pilosactl sort` to sort import files by bit position so they can be inserted faster. Also optimizes container scanning and adds a `-buffer-size` flag to `import`.
## Usage

Sorting files is simple:

``` sh
$ pilosactl sort PATH > OUTPUT
```

All output goes to `STDOUT` so make sure to redirect it to a file.
## Benchmark

Previously importing the `14/b.n` file of 60M bits took a really, really long time. After sorting the import properly and optimizing the container search the import takes `3m53s` using the default buffer size of `1M`.

However, the fragment snapshotting after each chunk was taking up 50% of the import time. Increasing the buffer size to `10m` reduced the import time to `1m23s`. Increasing it further didn't seem to impact the import time significantly. Raising it to `100m` (which would import the entire file at once) reduced the import time to 1m17s`
