### PR TITLE
Add slice to BitmapSegment operations.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -1,6 +1,8 @@
 package pilosa
 
 import (
+	"bytes"
+	"fmt"
 	"io"
 	"sort"
 	"time"
@@ -260,6 +262,19 @@ func (p Pairs) Keys() []uint64 {
 		a[i] = p[i].Key
 	}
 	return a
+}
+
+func (p Pairs) String() string {
+	var buf bytes.Buffer
+	buf.WriteString("Pairs(")
+	for i := range p {
+		fmt.Fprintf(&buf, "%d/%d", p[i].Key, p[i].Count)
+		if i < len(p)-1 {
+			buf.WriteString(", ")
+		}
+	}
+	buf.WriteString(")")
+	return buf.String()
 }
 
 func encodePairs(a Pairs) []*internal.Pair {


### PR DESCRIPTION
## Overview

Previously the `slice` was not copied to each new segment when `Intersect()`, `Union()`, and `Difference()` operations were performed. This causes issues when those bitmaps were then operated on later such as performing a `TopN()` on a source bitmap.

Fixes #120.
