### PR TITLE
Fix ClearBit() file handle issue.

### DIFF
--- a/bitmap.go
+++ b/bitmap.go
@@ -126,7 +126,22 @@ func (b *Bitmap) SetBit(i uint64) (changed bool) {
 
 // ClearBit clears the i-th bit of the bitmap.
 func (b *Bitmap) ClearBit(i uint64) (changed bool) {
-	return b.createSegmentIfNotExists(i / SliceWidth).ClearBit(i)
+	s := b.segment(i / SliceWidth)
+	if s == nil {
+		return false
+	}
+	return s.ClearBit(i)
+}
+
+// segment returns a segment for a given slice.
+// Returns nil if segment does not exist.
+func (b *Bitmap) segment(slice uint64) *BitmapSegment {
+	if i := sort.Search(len(b.segments), func(i int) bool {
+		return b.segments[i].slice >= slice
+	}); i < len(b.segments) && b.segments[i].slice == slice {
+		return &b.segments[i]
+	}
+	return nil
 }
 
 func (b *Bitmap) createSegmentIfNotExists(slice uint64) *BitmapSegment {

--- a/executor.go
+++ b/executor.go
@@ -417,15 +417,15 @@ func (e *Executor) executeClearBit(db string, c *pql.ClearBit, opt *ExecOptions)
 	for _, node := range e.Cluster.FragmentNodes(db, slice) {
 		// Update locally if host matches.
 		if node.Host == e.Host {
-			f, err := e.Index.CreateFragmentIfNotExists(db, c.Frame, slice)
-			if err != nil {
-				return false, fmt.Errorf("fragment: %s", err)
+			f := e.Index.Fragment(db, c.Frame, slice)
+			if f == nil {
+				return false, nil
 			}
+
 			val, err := f.ClearBit(c.ID, c.ProfileID)
 			if err != nil {
 				return false, err
-			}
-			if val {
+			} else if val {
 				ret = true
 			}
 			continue


### PR DESCRIPTION
## Overview

Previously the index would create a fragment if it didn't exist when clearing a bit. This causes additional file handles to be created when it's already known that the bit is not set.

Fixes #123.
