### PR TITLE
Handle return data from remote ClearBit()

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -695,6 +695,8 @@ func (e *Executor) exec(node *Node, db string, q *pql.Query, slices []uint64, op
 			v, err = pb.Results[i].GetN(), nil
 		case *pql.SetBit:
 			v, err = pb.Results[i].GetChanged(), nil
+		case *pql.ClearBit:
+			v, err = pb.Results[i].GetChanged(), nil
 		case *pql.SetBitmapAttrs:
 		case *pql.SetProfileAttrs:
 		default:


### PR DESCRIPTION
## Overview

Previously `ClearBit()` did not handle returned data correctly and panicked. This change adds it to the list of available return types.
