### PR TITLE
Fix unlocked Frame.fragments accessor.

### DIFF
--- a/index.go
+++ b/index.go
@@ -252,7 +252,7 @@ func (i *Index) Fragment(db, frame string, slice uint64) *Fragment {
 	if f == nil {
 		return nil
 	}
-	return f.fragment(slice)
+	return f.Fragment(slice)
 }
 
 // CreateFragmentIfNotExists returns the fragment for a database, frame & slice.


### PR DESCRIPTION
Fixes:

```
2016/11/04 11:19:13 fragment: snapshotting 406/b.n/0
fatal error: concurrent map read and map write

goroutine 1150994 [running]:
runtime.throw(0x84e0f8, 0x21)
        /usr/local/Cellar/go/1.7.1/libexec/src/runtime/panic.go:566 +0x95 fp=0xc6e2885b18 sp=0xc6e2885af8
runtime.mapaccess1_fast64(0x7cd780, 0xc61bd1d3b0, 0x15, 0xc56e499522)
        /usr/local/Cellar/go/1.7.1/libexec/src/runtime/hashmap_fast.go:111 +0x1a7 fp=0xc6e2885b40 sp=0xc6e2885b18
github.com/umbel/pilosa.(*Index).Fragment(0xc42015a070, 0xc56e499518, 0x3, 0xc56e499522, 0x8, 0x15, 0x0)
        /Users/tgruben/review/src/github.com/umbel/pilosa/index.go:255 +0x84 fp=0xc6e2885b80 sp=0xc6e2885b40
github.com/umbel/pilosa.(*Handler).handleGetFragmentBlocks(0xc420160000, 0xa10000, 0xc5adb9a8f0, 0xc4dc716d20)
        /Users/tgruben/review/src/github.com/umbel/pilosa/handler.go:771 +0xf3 fp=0xc6e2885ca0 sp=0xc6e2885b80
github.com/umbel/pilosa.(*Handler).ServeHTTP(0xc420160000, 0xa10000, 0xc5adb9a8f0, 0xc4dc716d20)
        /Users/tgruben/review/src/github.com/umbel/pilosa/handler.go:149 +0xf50 fp=0xc6e2885cf0 sp=0xc6e2885ca0
net/http.serverHandler.ServeHTTP(0xc4200b2300, 0xa10000, 0xc5adb9a8f0, 0xc4dc716d20)
        /usr/local/Cellar/go/1.7.1/libexec/src/net/http/server.go:2202 +0x7d fp=0xc6e2885d38 sp=0xc6e2885cf0
net/http.(*conn).serve(0xc592e1c880, 0xa10b00, 0xc56e4994c0)
```

/cc @tgruben 