### PR TITLE
Add query fault tolerance to Executor.

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -21,6 +21,16 @@ type Node struct {
 // Nodes represents a list of nodes.
 type Nodes []*Node
 
+// Contains returns true if a node exists in the list.
+func (a Nodes) Contains(n *Node) bool {
+	for i := range a {
+		if a[i] == n {
+			return true
+		}
+	}
+	return false
+}
+
 // ContainsHost returns true if host matches on of the node's host.
 func (a Nodes) ContainsHost(host string) bool {
 	for _, n := range a {
@@ -29,6 +39,17 @@ func (a Nodes) ContainsHost(host string) bool {
 		}
 	}
 	return false
+}
+
+// Filter returns a new list of nodes with node removed.
+func (a Nodes) Filter(n *Node) []*Node {
+	other := make([]*Node, 0, len(a))
+	for i := range a {
+		if a[i] != n {
+			other = append(other, a[i])
+		}
+	}
+	return other
 }
 
 // FilterHost returns a new list of nodes with host removed.
@@ -49,6 +70,13 @@ func (a Nodes) Hosts() []string {
 		hosts[i] = n.Host
 	}
 	return hosts
+}
+
+// Clone returns a shallow copy of nodes.
+func (a Nodes) Clone() []*Node {
+	other := make([]*Node, len(a))
+	copy(other, a)
+	return other
 }
 
 // Cluster represents a collection of nodes.
@@ -72,6 +100,16 @@ func NewCluster() *Cluster {
 		PartitionN: DefaultPartitionN,
 		ReplicaN:   DefaultReplicaN,
 	}
+}
+
+// NodeByHost returns a node reference by host.
+func (c *Cluster) NodeByHost(host string) *Node {
+	for _, n := range c.Nodes {
+		if n.Host == host {
+			return n
+		}
+	}
+	return nil
 }
 
 // Partition returns the partition that a slice belongs to.


### PR DESCRIPTION
## Overview

This pull request adds the ability for failing nodes to be detected at query time and to have queries redirected to secondary nodes. It has been abstracted into a `mapReduce()` function on the `Executor` which handles the batching of slices (as well as rebatching in the event of a failure).

A cancelable `Context` is also passed along to each mapper so that if there is a critical failure in the query (e.g. a slice has no nodes available) then the context cancelation will propagate to all other running mappers.

This pull request also parallelizes bitmap and count queries across slices. Previously these were being executed serially. `TopN()` queries were already parallelized across slices.