### PR TITLE
fixes a minor logic bug in the cluster tests

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -41,7 +41,7 @@ func TestCluster_Partition(t *testing.T) {
 		c.PartitionN = partitionN
 
 		partitionID := c.Partition(db, slice)
-		if partitionID < 0 || partitionID > partitionN {
+		if partitionID < 0 || partitionID >= partitionN {
 			t.Errorf("partition out of range: slice=%d, p=%d, n=%d", slice, partitionID, partitionN)
 		}
 


### PR DESCRIPTION
This test condition never occurred because the actual partition logic is correct, but I'm pretty sure that the `partitionID` should never be equal to `partitionN`