### PR TITLE
add option to save all stats

### DIFF
--- a/bench/stats.go
+++ b/bench/stats.go
@@ -5,19 +5,25 @@ import (
 )
 
 type Stats struct {
-	Min   time.Duration
-	Max   time.Duration
-	Total time.Duration
-	Num   int64
+	Min     time.Duration
+	Max     time.Duration
+	Total   time.Duration
+	Num     int64
+	All     []time.Duration
+	SaveAll bool
 }
 
 func NewStats() *Stats {
 	return &Stats{
 		Min: 1<<63 - 1,
+		All: make([]time.Duration, 0),
 	}
 }
 
 func (s *Stats) Add(td time.Duration) {
+	if s.SaveAll {
+		s.All = append(s.All, td)
+	}
 	s.Num += 1
 	s.Total += td
 	if td < s.Min {
@@ -36,4 +42,7 @@ func AddToResults(s *Stats, results map[string]interface{}) {
 	results["min"] = s.Min
 	results["max"] = s.Max
 	results["avg"] = s.Avg()
+	if s.SaveAll {
+		results["all"] = s.All
+	}
 }


### PR DESCRIPTION
this doesn't do anything as is, but makes it easy to see all times for a benchmark if you need a more fine-grained look at the distribution