### PR TITLE
set Index.LogOutput to be Server's as well as handler

### DIFF
--- a/server.go
+++ b/server.go
@@ -108,6 +108,7 @@ func (s *Server) Open() error {
 	s.Handler.Cluster = s.Cluster
 	s.Handler.Executor = e
 	s.Handler.LogOutput = s.LogOutput
+	s.Index.LogOutput = s.LogOutput
 
 	// Serve HTTP.
 	go func() { http.Serve(ln, s.Handler) }()


### PR DESCRIPTION
Does this make sense? When creating a local cluster in-process, I'm trying to have control over where each server's logs go.