### PR TITLE
change README install command to only install cmd/...

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ go get github.com/pilosa/pilosa
 Now you can install the `pilosa` binary:
 
 ```sh
-$ go install github.com/pilosa/pilosa/...
+$ go install github.com/pilosa/pilosa/cmd/...
 ```
 
 Now run `pilosa` with the default configuration:


### PR DESCRIPTION
installing everything under the top level causes issues due to things under
vendor/ getting installed