### PR TITLE
thread logoutput index -> db -> frame -> fragment

### DIFF
--- a/db.go
+++ b/db.go
@@ -40,7 +40,7 @@ type DB struct {
 }
 
 // NewDB returns a new instance of DB.
-func NewDB(path, name string, logOutput io.Writer) *DB {
+func NewDB(path, name string) *DB {
 	return &DB{
 		path:           path,
 		name:           name,
@@ -49,9 +49,8 @@ func NewDB(path, name string, logOutput io.Writer) *DB {
 
 		profileAttrStore: NewAttrStore(filepath.Join(path, "data")),
 
-		stats: NopStatsClient,
-
-		LogOutput: logOutput,
+		stats:     NopStatsClient,
+		LogOutput: ioutil.Discard,
 	}
 }
 
@@ -275,7 +274,8 @@ func (db *DB) createFrameIfNotExists(name string) (*Frame, error) {
 }
 
 func (db *DB) newFrame(path, name string) *Frame {
-	f := NewFrame(path, db.name, name, db.LogOutput)
+	f := NewFrame(path, db.name, name)
+	f.LogOutput = db.LogOutput
 	f.stats = db.stats.WithTags(fmt.Sprintf("frame:%s", name))
 	return f
 }

--- a/db_test.go
+++ b/db_test.go
@@ -89,8 +89,7 @@ func NewDB() *DB {
 	if err != nil {
 		panic(err)
 	}
-
-	return &DB{DB: pilosa.NewDB(path, "d", ioutil.Discard)}
+	return &DB{DB: pilosa.NewDB(path, "d")}
 }
 
 // MustOpenDB returns a new, opened database at a temporary path. Panic on error.
@@ -115,7 +114,7 @@ func (db *DB) Reopen() error {
 	}
 
 	path, name := db.Path(), db.Name()
-	db.DB = pilosa.NewDB(path, name, ioutil.Discard)
+	db.DB = pilosa.NewDB(path, name)
 
 	if err := db.Open(); err != nil {
 		return err

--- a/fragment.go
+++ b/fragment.go
@@ -90,14 +90,14 @@ type Fragment struct {
 }
 
 // NewFragment returns a new instance of Fragment.
-func NewFragment(path, db, frame string, slice uint64, logOutput io.Writer) *Fragment {
+func NewFragment(path, db, frame string, slice uint64) *Fragment {
 	return &Fragment{
 		path:  path,
 		db:    db,
 		frame: frame,
 		slice: slice,
 
-		LogOutput: logOutput,
+		LogOutput: ioutil.Discard,
 		MaxOpN:    DefaultFragmentMaxOpN,
 
 		stats: NopStatsClient,

--- a/fragment_test.go
+++ b/fragment_test.go
@@ -505,7 +505,7 @@ func BenchmarkFragment_Blocks(b *testing.B) {
 	}
 
 	// Open the fragment specified by the path.
-	f := pilosa.NewFragment(*FragmentPath, "d", "f", 0, ioutil.Discard)
+	f := pilosa.NewFragment(*FragmentPath, "d", "f", 0)
 	if err := f.Open(); err != nil {
 		b.Fatal(err)
 	}
@@ -566,7 +566,7 @@ func NewFragment(db, frame string, slice uint64) *Fragment {
 	file.Close()
 
 	f := &Fragment{
-		Fragment:        pilosa.NewFragment(file.Name(), db, frame, slice, ioutil.Discard),
+		Fragment:        pilosa.NewFragment(file.Name(), db, frame, slice),
 		BitmapAttrStore: MustOpenAttrStore(),
 	}
 	f.Fragment.BitmapAttrStore = f.BitmapAttrStore.AttrStore
@@ -597,7 +597,7 @@ func (f *Fragment) Reopen() error {
 		return err
 	}
 
-	f.Fragment = pilosa.NewFragment(path, f.DB(), f.Frame(), f.Slice(), ioutil.Discard)
+	f.Fragment = pilosa.NewFragment(path, f.DB(), f.Frame(), f.Slice())
 	f.Fragment.BitmapAttrStore = f.BitmapAttrStore.AttrStore
 	if err := f.Open(); err != nil {
 		return err

--- a/frame.go
+++ b/frame.go
@@ -38,7 +38,7 @@ type Frame struct {
 }
 
 // NewFrame returns a new instance of frame.
-func NewFrame(path, db, name string, logOutput io.Writer) *Frame {
+func NewFrame(path, db, name string) *Frame {
 	return &Frame{
 		path: path,
 		db:   db,
@@ -49,7 +49,7 @@ func NewFrame(path, db, name string, logOutput io.Writer) *Frame {
 
 		stats: NopStatsClient,
 
-		LogOutput: logOutput,
+		LogOutput: ioutil.Discard,
 	}
 }
 
@@ -286,7 +286,8 @@ func (f *Frame) createFragmentIfNotExists(slice uint64) (*Fragment, error) {
 }
 
 func (f *Frame) newFragment(path string, slice uint64) *Fragment {
-	frag := NewFragment(path, f.db, f.name, slice, f.LogOutput)
+	frag := NewFragment(path, f.db, f.name, slice)
+	frag.LogOutput = f.LogOutput
 	frag.stats = f.stats.WithTags(fmt.Sprintf("slice:%d", slice))
 	return frag
 }

--- a/frame_test.go
+++ b/frame_test.go
@@ -66,7 +66,7 @@ func NewFrame() *Frame {
 		panic(err)
 	}
 
-	return &Frame{Frame: pilosa.NewFrame(path, "d", "f", ioutil.Discard)}
+	return &Frame{Frame: pilosa.NewFrame(path, "d", "f")}
 }
 
 // MustOpenFrame returns a new, opened frame at a temporary path. Panic on error.
@@ -91,7 +91,7 @@ func (f *Frame) Reopen() error {
 	}
 
 	path, db, name := f.Path(), f.DB(), f.Name()
-	f.Frame = pilosa.NewFrame(path, db, name, ioutil.Discard)
+	f.Frame = pilosa.NewFrame(path, db, name)
 
 	if err := f.Open(); err != nil {
 		return err

--- a/index.go
+++ b/index.go
@@ -187,7 +187,8 @@ func (i *Index) createDBIfNotExists(name string) (*DB, error) {
 }
 
 func (i *Index) newDB(path, name string) *DB {
-	db := NewDB(path, name, i.LogOutput)
+	db := NewDB(path, name)
+	db.LogOutput = i.LogOutput
 	db.stats = i.Stats.WithTags(fmt.Sprintf("db:%s", db.Name()))
 	return db
 }


### PR DESCRIPTION
also stop extra output to stderr from tests

@travis I think this completes what I started with the last thing you reviewed for me. Log output is now controllable with nothing internal defaulting to stderr with no way to override.