### PR TITLE
Add ClearBit support to Zipf benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ The configuration file is a json object with the top level key `benchmarks`. Thi
         {
             "num": 2,
             "name": "rand-plus-zipf",
-            "args": ["random-set-bits", "-iterations", "20000", "zipf-set-bits", "-iterations", "100"]
+            "args": ["random-set-bits", "-iterations", "20000", "zipf", "-iterations", "100"]
         }
     ]
 }

--- a/cmd/pilosactl/main.go
+++ b/cmd/pilosactl/main.go
@@ -1238,8 +1238,8 @@ func (cmd *BagentCommand) ParseFlags(args []string) error {
 			bm = &bench.DiagonalSetBits{}
 		case "random-set-bits":
 			bm = &bench.RandomSetBits{}
-		case "zipf-set-bits":
-			bm = &bench.ZipfSetBits{}
+		case "zipf":
+			bm = &bench.Zipf{}
 		case "multi-db-set-bits":
 			bm = &bench.MultiDBSetBits{}
 		case "random-query":
@@ -1287,7 +1287,7 @@ The following flags are allowed:
 	subcommands:
 		diagonal-set-bits
 		random-set-bits
-		zipf-set-bits
+		zipf
 		multi-db-set-bits
 		random-query
 		import

--- a/cmd/pilosactl/spawn.json
+++ b/cmd/pilosactl/spawn.json
@@ -8,7 +8,7 @@
         {
             "num": 2,
             "name": "rand-plus-zipf",
-            "args": ["random-set-bits", "-iterations", "20000", "zipf-set-bits", "-iterations", "100"]
+            "args": ["random-set-bits", "-iterations", "20000", "zipf", "-iterations", "100"]
         }
     ]
 }

--- a/cmd/pilosactl/zipfspawn.json
+++ b/cmd/pilosactl/zipfspawn.json
@@ -2,7 +2,11 @@
     "benchmarks": [
         {
             "num": 1,
-            "args": ["zipf-set-bits", "-iterations", "10000", "-profile-id-range", "100", "-bitmap-id-range", "100", "-seed", "2345", "-client-type", "round_robin", "-bitmap-exponent", "1.001", "-bitmap-ratio", ".9", "-profile-exponent", "1.001", "-profile-ratio", ".3"]
+            "args": ["zipf", "-iterations", "10000", "-profile-id-range", "100", "-bitmap-id-range", "100", "-seed", "2345", "-client-type", "round_robin", "-bitmap-exponent", "1.001", "-bitmap-ratio", ".9", "-profile-exponent", "1.001", "-profile-ratio", ".3"]
+        },
+        {
+            "num": 1,
+            "args": ["zipf", "-iterations", "10000", "-profile-id-range", "100", "-bitmap-id-range", "100", "-seed", "2345", "-client-type", "round_robin", "-bitmap-exponent", "1.001", "-bitmap-ratio", ".9", "-profile-exponent", "1.001", "-profile-ratio", ".3", "-operation", "clear"]
         }
     ]
 }


### PR DESCRIPTION
This adds an argument "-operation" to the zipf benchmark which you can use to switch the operation from "SetBit" to "ClearBit." This also modifies the name of the benchmark from "zipf-set-bits" to simply "zipf."