### PR TITLE
use temp location for pilosactl and pilosa binaries

### DIFF
--- a/creator/remote.go
+++ b/creator/remote.go
@@ -3,11 +3,10 @@ package creator
 import (
 	"fmt"
 	"io"
+	"math/rand"
 	"net"
-	"path"
 	"strconv"
 	"sync"
-
 	"time"
 
 	"github.com/BurntSushi/toml"
@@ -48,8 +47,10 @@ func (c *RemoteCluster) Start() error {
 	if err != nil {
 		return fmt.Errorf("connecting to cluster hosts: %v", err)
 	}
+	cmdName := "pilosa"
 	if c.CopyBinary {
-		fmt.Fprintf(c.Stderr, "create: building pilosa binary with GOOS=%v and GOARCH=%v to copy to hosts", c.GOOS, c.GOARCH)
+		cmdName = "/tmp/pilosa" + strconv.Itoa(rand.Int())
+		fmt.Fprintf(c.Stderr, "create: building pilosa binary with GOOS=%v and GOARCH=%v to copy to hosts at %v", c.GOOS, c.GOARCH, cmdName)
 
 		pkg := "github.com/pilosa/pilosa/cmd/pilosa"
 		bin, err := build.Binary(pkg, c.GOOS, c.GOARCH)
@@ -57,7 +58,7 @@ func (c *RemoteCluster) Start() error {
 			return fmt.Errorf("building binary: %v", err)
 		}
 
-		err = fleet.WriteFile(path.Base(pkg), "+x", bin)
+		err = fleet.WriteFile(cmdName, "+x", bin)
 		if err != nil {
 			return fmt.Errorf("writing binary to fleet: %v", err)
 		}
@@ -133,7 +134,7 @@ func (c *RemoteCluster) Start() error {
 			gomaxprocsString = "GOMAXPROCS=" + strconv.Itoa(c.GoMaxProcs) + " "
 		}
 
-		err = sess.Start("PATH=.:$PATH " + gomaxprocsString + "pilosa -config " + configname)
+		err = sess.Start(gomaxprocsString + cmdName + " -config " + configname)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
I did it this way instead of using mktemp because
a) mktemp would have created a different filename on every host, which would
make the client side logic much more confusing
b) mktemp isn't guaranteed to be available everywhere, so we're not losing much
by assuming /tmp exists.