### PR TITLE
modify pilosactl import to allow it to read from stdin

### DIFF
--- a/pilosactl/import.go
+++ b/pilosactl/import.go
@@ -128,15 +128,22 @@ func (cmd *ImportCommand) Run(ctx context.Context) error {
 func (cmd *ImportCommand) importPath(ctx context.Context, path string) error {
 	a := make([]pilosa.Bit, 0, cmd.BufferSize)
 
-	// Open file for reading.
-	f, err := os.Open(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
+	var r *csv.Reader
 
-	// Read rows as bits.
-	r := csv.NewReader(f)
+	if path != "-" {
+		// Open file for reading.
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		// Read rows as bits.
+		r = csv.NewReader(f)
+	} else {
+		r = csv.NewReader(cmd.Stdin)
+	}
+
 	r.FieldsPerRecord = -1
 	rnum := 0
 	for {


### PR DESCRIPTION
pass a "-" argument for stdin

With this, the ImportCommand can be used by external programs (like the pdk) to get super fast pilosa importing in a streaming fashion (rather than going through a file)

See network data PR in pilosa/pdk for example usage.