### PR TITLE
handle `unionArrayBitmap` width of bitmaps correctly

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1364,6 +1364,7 @@ func unionArrayBitmap(a, b *container) *container {
 			break
 		} else if i >= len(a.array) {
 			output.add(vb)
+			continue
 		} else if eof {
 			output.add(a.array[i])
 			i++


### PR DESCRIPTION
this fixes a bug in the Union logic.
we already pushed this out as a hotfix to a new build for umbel.
this PR is getting the fix into master.