### PR TITLE
have roaring clone() return the clone (as opposed to the original)

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1057,7 +1057,7 @@ func (c *container) clone() *container {
 		copy(other.bitmap, c.bitmap)
 	}
 
-	return c
+	return other
 }
 
 // WriteTo writes c to w.


### PR DESCRIPTION
Hey @benbjohnson and @tgruben,
I ran across what I think is a bug while doing some work on bitmap caching and realized that cloned containers were still pointing to the original container. I'm pretty sure this fix is correct, but I'm curious if either of you can think of any ramifications to making this change? Existing tests pass both with/without the change.