### PR TITLE
if a version is not found, set it as unknown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 GLIDE := $(shell command -v glide 2>/dev/null)
 PROTOC := $(shell command -v protoc 2>/dev/null)
-VERSION := $(shell git describe --tags)
+VERSION := $(shell git describe --tags 2> /dev/null || echo unknown)
 IDENTIFIER := $(VERSION)-$(GOOS)-$(GOARCH)
 CLONE_URL=github.com/pilosa/pilosa
 BUILD_TIME=`date -u +%FT%T%z`


### PR DESCRIPTION
If `git describe --tags` can't find the version, it displays `fatal: No names found, cannot describe anything.`. This PR prevents that and uses `unknown` as the version.