### PR TITLE
Separate max slices for standard and inverse views.

### DIFF
--- a/client.go
+++ b/client.go
@@ -47,11 +47,24 @@ func (c *Client) Host() string { return c.host }
 
 // MaxSliceByDatabase returns the number of slices on a server by database.
 func (c *Client) MaxSliceByDatabase(ctx context.Context) (map[string]uint64, error) {
+	return c.maxSliceByDatabase(ctx, false)
+}
+
+// MaxInverseSliceByDatabase returns the number of inverse slices on a server by database.
+func (c *Client) MaxInverseSliceByDatabase(ctx context.Context) (map[string]uint64, error) {
+	return c.maxSliceByDatabase(ctx, true)
+}
+
+// maxSliceByDatabase returns the number of slices on a server by database.
+func (c *Client) maxSliceByDatabase(ctx context.Context, inverse bool) (map[string]uint64, error) {
 	// Execute request against the host.
 	u := url.URL{
 		Scheme: "http",
 		Host:   c.host,
 		Path:   "/slices/max",
+		RawQuery: (&url.Values{
+			"inverse": {strconv.FormatBool(inverse)},
+		}).Encode(),
 	}
 
 	// Build request.

--- a/frame.go
+++ b/frame.go
@@ -93,6 +93,18 @@ func (f *Frame) MaxSlice() uint64 {
 	return view.MaxSlice()
 }
 
+// MaxInverseSlice returns the max inverse slice in the frame.
+func (f *Frame) MaxInverseSlice() uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	view := f.views[ViewInverse]
+	if view == nil {
+		return 0
+	}
+	return view.MaxSlice()
+}
+
 // SetRowLabel sets the row labels. Persists to meta file on update.
 func (f *Frame) SetRowLabel(v string) error {
 	f.mu.Lock()

--- a/handler.go
+++ b/handler.go
@@ -292,7 +292,13 @@ func (h *Handler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) handleGetSliceMax(w http.ResponseWriter, r *http.Request) error {
-	ms := h.Index.MaxSlices()
+	var ms map[string]uint64
+	if inverse, _ := strconv.ParseBool(r.URL.Query().Get("inverse")); inverse {
+		ms = h.Index.MaxInverseSlices()
+	} else {
+		ms = h.Index.MaxSlices()
+	}
+
 	if strings.Contains(r.Header.Get("Accept"), "application/x-protobuf") {
 		pb := &internal.MaxSlicesResponse{
 			MaxSlices: ms,

--- a/index.go
+++ b/index.go
@@ -125,6 +125,15 @@ func (i *Index) MaxSlices() map[string]uint64 {
 	return a
 }
 
+// MaxInverseSlices returns MaxInverseSlice map for all databases.
+func (i *Index) MaxInverseSlices() map[string]uint64 {
+	a := make(map[string]uint64)
+	for _, db := range i.DBs() {
+		a[db.Name()] = db.MaxInverseSlice()
+	}
+	return a
+}
+
 // Schema returns schema data for all databases and frames.
 func (i *Index) Schema() []*DBInfo {
 	var a []*DBInfo


### PR DESCRIPTION
## Overview

Previously only the standard max slice was available. This commit changes it so that the inverse max can be retrieved separately through the `DB` and `Frame` types as well as through the `HTTP` API and `Client`.

See also: https://github.com/pilosa/pilosa/pull/400#issuecomment-289155351