### PR TITLE
Refactor higher level view interface.

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -390,16 +390,16 @@ func TestExecutor_Execute_Range(t *testing.T) {
 	}
 
 	// Set bits.
-	f.MustSetBit(1, 2, MustParseTimePtr("1999-12-31 00:00"))
-	f.MustSetBit(1, 3, MustParseTimePtr("2000-01-01 00:00"))
-	f.MustSetBit(1, 4, MustParseTimePtr("2000-01-02 00:00"))
-	f.MustSetBit(1, 5, MustParseTimePtr("2000-02-01 00:00"))
-	f.MustSetBit(1, 6, MustParseTimePtr("2001-01-01 00:00"))
-	f.MustSetBit(1, 7, MustParseTimePtr("2002-01-01 02:00"))
+	f.MustSetBit(pilosa.ViewStandard, 1, 2, MustParseTimePtr("1999-12-31 00:00"))
+	f.MustSetBit(pilosa.ViewStandard, 1, 3, MustParseTimePtr("2000-01-01 00:00"))
+	f.MustSetBit(pilosa.ViewStandard, 1, 4, MustParseTimePtr("2000-01-02 00:00"))
+	f.MustSetBit(pilosa.ViewStandard, 1, 5, MustParseTimePtr("2000-02-01 00:00"))
+	f.MustSetBit(pilosa.ViewStandard, 1, 6, MustParseTimePtr("2001-01-01 00:00"))
+	f.MustSetBit(pilosa.ViewStandard, 1, 7, MustParseTimePtr("2002-01-01 02:00"))
 
-	f.MustSetBit(1, 2, MustParseTimePtr("1999-12-30 00:00"))  // too early
-	f.MustSetBit(1, 2, MustParseTimePtr("2002-02-01 00:00"))  // too late
-	f.MustSetBit(10, 2, MustParseTimePtr("2001-01-01 00:00")) // different bitmap
+	f.MustSetBit(pilosa.ViewStandard, 1, 2, MustParseTimePtr("1999-12-30 00:00"))  // too early
+	f.MustSetBit(pilosa.ViewStandard, 1, 2, MustParseTimePtr("2002-02-01 00:00"))  // too late
+	f.MustSetBit(pilosa.ViewStandard, 10, 2, MustParseTimePtr("2001-01-01 00:00")) // different bitmap
 
 	e := NewExecutor(idx.Index, NewCluster(1))
 	if res, err := e.Execute(context.Background(), "d", MustParse(`Range(id=1, frame=f, start="1999-12-31T00:00", end="2002-01-01T03:00")`), nil, nil); err != nil {

--- a/frame.go
+++ b/frame.go
@@ -348,28 +348,13 @@ func (f *Frame) newView(path, name string) *View {
 	return view
 }
 
-// SetBit sets a bit within the frame.
-func (f *Frame) SetBit(rowID, colID uint64, t *time.Time) (changed bool, err error) {
-	// Set standard layout bits.
-	if v, err := f.setBit(ViewStandard, rowID, colID, t); err != nil {
-		return changed, err
-	} else if v {
-		changed = v
+// SetBit sets a bit on a view within the frame.
+func (f *Frame) SetBit(name string, rowID, colID uint64, t *time.Time) (changed bool, err error) {
+	// Validate view name.
+	if !IsValidView(name) {
+		return false, ErrInvalidView
 	}
 
-	// Set inverse layout bits.
-	// NOTE: The row & col are transposed for the inverted view.
-	if v, err := f.setBit(ViewInverse, colID, rowID, t); err != nil {
-		return changed, err
-	} else if v {
-		changed = v
-	}
-
-	return changed, nil
-}
-
-// setBit sets a bit for a given layout (default or inverted).
-func (f *Frame) setBit(name string, rowID, colID uint64, t *time.Time) (changed bool, err error) {
 	// Retrieve view. Exit if it doesn't exist.
 	view, err := f.CreateViewIfNotExists(name)
 	if err != nil {
@@ -406,27 +391,12 @@ func (f *Frame) setBit(name string, rowID, colID uint64, t *time.Time) (changed 
 }
 
 // ClearBit clears a bit within the frame.
-func (f *Frame) ClearBit(rowID, colID uint64, t *time.Time) (changed bool, err error) {
-	// Clear standard layout bits.
-	if v, err := f.clearBit(ViewStandard, rowID, colID, t); err != nil {
-		return changed, err
-	} else if v {
-		changed = v
+func (f *Frame) ClearBit(name string, rowID, colID uint64, t *time.Time) (changed bool, err error) {
+	// Validate view name.
+	if !IsValidView(name) {
+		return false, ErrInvalidView
 	}
 
-	// Clear inverse layout bits.
-	// NOTE: The row & col are transposed for the inverted view.
-	if v, err := f.clearBit(ViewInverse, colID, rowID, t); err != nil {
-		return changed, err
-	} else if v {
-		changed = v
-	}
-
-	return changed, nil
-}
-
-// clearBit clears a bit for a given layout (default or inverted).
-func (f *Frame) clearBit(name string, rowID, colID uint64, t *time.Time) (changed bool, err error) {
 	// Retrieve view. Exit if it doesn't exist.
 	view, err := f.CreateViewIfNotExists(name)
 	if err != nil {

--- a/frame_test.go
+++ b/frame_test.go
@@ -119,8 +119,8 @@ func (f *Frame) Reopen() error {
 }
 
 // MustSetBit sets a bit on the frame. Panic on error.
-func (f *Frame) MustSetBit(bitmapID, profileID uint64, t *time.Time) (changed bool) {
-	changed, err := f.SetBit(bitmapID, profileID, t)
+func (f *Frame) MustSetBit(view string, bitmapID, profileID uint64, t *time.Time) (changed bool) {
+	changed, err := f.SetBit(view, bitmapID, profileID, t)
 	if err != nil {
 		panic(err)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -39,12 +39,14 @@ func TestHandler_Schema(t *testing.T) {
 
 	if f, err := d0.CreateFrameIfNotExists("f1", pilosa.FrameOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.SetBit(0, 0, nil); err != nil {
+	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+		t.Fatal(err)
+	} else if _, err := f.SetBit(pilosa.ViewInverse, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if f, err := d1.CreateFrameIfNotExists("f0", pilosa.FrameOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.SetBit(0, 0, nil); err != nil {
+	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := d0.CreateFrameIfNotExists("f0", pilosa.FrameOptions{}); err != nil {
@@ -57,7 +59,7 @@ func TestHandler_Schema(t *testing.T) {
 	h.ServeHTTP(w, MustNewHTTPRequest("GET", "/schema", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", w.Code)
-	} else if body := w.Body.String(); body != `{"dbs":[{"name":"d0","frames":[{"name":"f0"},{"name":"f1","views":[{"name":"inverse"},{"name":"standard"}]}]},{"name":"d1","frames":[{"name":"f0","views":[{"name":"inverse"},{"name":"standard"}]}]}]}`+"\n" {
+	} else if body := w.Body.String(); body != `{"dbs":[{"name":"d0","frames":[{"name":"f0"},{"name":"f1","views":[{"name":"inverse"},{"name":"standard"}]}]},{"name":"d1","frames":[{"name":"f0","views":[{"name":"standard"}]}]}]}`+"\n" {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }
@@ -95,11 +97,11 @@ func TestHandler_MaxSlices_Inverse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f0.SetBit((1*SliceWidth)+1, 30, nil); err != nil {
+	if _, err := f0.SetBit(pilosa.ViewInverse, 30, (1*SliceWidth)+1, nil); err != nil {
 		t.Fatal(err)
-	} else if _, err := f0.SetBit((1*SliceWidth)+2, 30, nil); err != nil {
+	} else if _, err := f0.SetBit(pilosa.ViewInverse, 30, (1*SliceWidth)+2, nil); err != nil {
 		t.Fatal(err)
-	} else if _, err := f0.SetBit((3*SliceWidth)+4, 30, nil); err != nil {
+	} else if _, err := f0.SetBit(pilosa.ViewInverse, 30, (3*SliceWidth)+4, nil); err != nil {
 		t.Fatal(err)
 	}
 
@@ -107,11 +109,11 @@ func TestHandler_MaxSlices_Inverse(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f1.SetBit((0*SliceWidth)+1, 40, nil); err != nil {
+	if _, err := f1.SetBit(pilosa.ViewStandard, 40, (0*SliceWidth)+1, nil); err != nil {
 		t.Fatal(err)
-	} else if _, err := f1.SetBit((0*SliceWidth)+2, 40, nil); err != nil {
+	} else if _, err := f1.SetBit(pilosa.ViewInverse, 40, (0*SliceWidth)+2, nil); err != nil {
 		t.Fatal(err)
-	} else if _, err := f1.SetBit((0*SliceWidth)+4, 40, nil); err != nil {
+	} else if _, err := f1.SetBit(pilosa.ViewInverse, 40, (0*SliceWidth)+4, nil); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pilosa.go
+++ b/pilosa.go
@@ -20,6 +20,8 @@ var (
 	ErrFrameExists   = errors.New("frame already exists")
 	ErrFrameNotFound = errors.New("frame not found")
 
+	ErrInvalidView = errors.New("invalid veiw")
+
 	ErrName = errors.New("invalid database or frame's name, must match [a-z0-9_-]")
 
 	// ErrFragmentNotFound is returned when a fragment does not exist.

--- a/view.go
+++ b/view.go
@@ -17,6 +17,11 @@ const (
 	ViewInverse  = "inverse"
 )
 
+// IsValidView returns true if name is valid.
+func IsValidView(name string) bool {
+	return name == ViewStandard || name == ViewInverse
+}
+
 // View represents a container for frame data.
 type View struct {
 	mu    sync.Mutex


### PR DESCRIPTION
## Overview

Previously the view was handled entirely inside the `Frame` and bits were delegated inside `Frame.SetBit()`. However, the frame doesn't have knowledge to delegate to the correct slice.

This pull request moves the delegation up to the `Executor` so that it can send bits to the correct slice for the standard view and inverse view.