### PR TITLE
Default time quantum on new frames.

### DIFF
--- a/db.go
+++ b/db.go
@@ -368,8 +368,17 @@ func (db *DB) createFrame(name string, opt FrameOptions) (*Frame, error) {
 		return nil, err
 	}
 
-	// Update options.
-	f.SetRowLabel(opt.RowLabel)
+	// Default the time quantum to what is set on the DB.
+	if err := f.SetTimeQuantum(db.timeQuantum); err != nil {
+		f.Close()
+		return nil, err
+	}
+
+	// Set options.
+	if err := f.SetRowLabel(opt.RowLabel); err != nil {
+		f.Close()
+		return nil, err
+	}
 
 	// Add to database's frame lookup.
 	db.frames[name] = f

--- a/db_test.go
+++ b/db_test.go
@@ -34,6 +34,25 @@ func TestDB_CreateFrameIfNotExists(t *testing.T) {
 	}
 }
 
+// Ensure database defaults the time quantum on new frames.
+func TestDB_CreateFrame_TimeQuantum(t *testing.T) {
+	db := MustOpenDB()
+	defer db.Close()
+
+	// Set database time quantum.
+	if err := db.SetTimeQuantum(pilosa.TimeQuantum("YM")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create frame.
+	f, err := db.CreateFrame("f", pilosa.FrameOptions{})
+	if err != nil {
+		t.Fatal(err)
+	} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YM") {
+		t.Fatalf("unexpected frame time quantum: %s", q)
+	}
+}
+
 // Ensure database can delete a frame.
 func TestDB_DeleteFrame(t *testing.T) {
 	db := MustOpenDB()


### PR DESCRIPTION
## Overview

Sets the frame time quantum to the quantum on the parent database when creating a new frame.

Ref: https://github.com/pilosa/pilosa/pull/412#issuecomment-290160971