### PR TITLE
Determine if a Call is inverse or not to correctly map to slices.

### DIFF
--- a/pql/ast.go
+++ b/pql/ast.go
@@ -156,6 +156,30 @@ func (c *Call) String() string {
 	return buf.String()
 }
 
+// SupportsInverse indicates that the call may be on an inverse frame.
+func (c *Call) SupportsInverse() bool {
+	if c.Name == "Bitmap" {
+		return true
+	}
+	return false
+}
+
+// IsInverse specifies if the call is for an inverse view.
+// Return defaults to false unless absolutely sure of inversion.
+func (c *Call) IsInverse(rowLabel, columnLabel string) bool {
+	if c.SupportsInverse() {
+		_, rowOK, rowErr := c.UintArg(rowLabel)
+		_, columnOK, columnErr := c.UintArg(columnLabel)
+		if rowErr != nil || columnErr != nil {
+			return false
+		}
+		if !rowOK && columnOK {
+			return true
+		}
+	}
+	return false
+}
+
 // CopyArgs returns a copy of m.
 func CopyArgs(m map[string]interface{}) map[string]interface{} {
 	other := make(map[string]interface{}, len(m))

--- a/pql/ast_test.go
+++ b/pql/ast_test.go
@@ -15,3 +15,69 @@ func TestCall_String(t *testing.T) {
 		}
 	})
 }
+
+// Ensure call can be converted into a string.
+func TestCall_SupportsInverse(t *testing.T) {
+	t.Run("Bitmap", func(t *testing.T) {
+		q, err := pql.ParseString(`Bitmap()`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].SupportsInverse() != true {
+			t.Fatalf("call should support inverse: %s", q.Calls[0])
+		}
+	})
+	t.Run("Count Bitmap", func(t *testing.T) {
+		q, err := pql.ParseString(`Count(Bitmap())`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].SupportsInverse() == true {
+			t.Fatalf("call should not support inverse: %s", q.Calls[0])
+		}
+	})
+	t.Run("Union Bitmaps", func(t *testing.T) {
+		q, err := pql.ParseString(`Union(Bitmap(), Bitmap())`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].SupportsInverse() == true {
+			t.Fatalf("call should not support inverse: %s", q.Calls[0])
+		}
+	})
+
+}
+
+// Ensure call is correctly determined to be against an inverse view.
+func TestCall_IsInverse(t *testing.T) {
+	t.Run("Bitmap Row", func(t *testing.T) {
+		q, err := pql.ParseString(`Bitmap(frame="f", row=1)`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].IsInverse("row", "col") != false {
+			t.Fatalf("incorrect call inverse: %s", q.Calls[0])
+		}
+	})
+	t.Run("Bitmap Column", func(t *testing.T) {
+		q, err := pql.ParseString(`Bitmap(frame="f", col=1)`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].IsInverse("row", "col") != true {
+			t.Fatalf("incorrect call inverse: %s", q.Calls[0])
+		}
+	})
+	t.Run("Bitmap Column No Label", func(t *testing.T) {
+		q, err := pql.ParseString(`Bitmap(frame="f", col=1)`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].IsInverse("rowX", "colX") != false {
+			t.Fatalf("incorrect call inverse: %s", q.Calls[0])
+		}
+	})
+	t.Run("Count", func(t *testing.T) {
+		q, err := pql.ParseString(`Count(Bitmap(frame="f", col=1))`)
+		if err != nil {
+			t.Fatal(err)
+		} else if q.Calls[0].IsInverse("row", "col") != false {
+			t.Fatalf("incorrect call inverse: %s", q.Calls[0])
+		}
+	})
+
+}


### PR DESCRIPTION
I added this PR to address the issue where the maxSlice for an inverse view is different than the maxSlice for the `Index`. For example:
```
curl -X POST "http://localhost:15000/index/i" -d '{"options":{"columnLabel":"col"}}'
curl -X POST "http://localhost:15000/index/i/frame/f" -d '{"options":{"rowLabel":"row", "inverseEnabled": true}}'
curl -X POST "http://localhost:15000/index/i/query" -d 'SetBit(frame="f", row=6300000, col=2400000)'
```
results in:
maxSlice = 2
inverseMaxSlice = 6

Furthermore (and addressed in the TODO below), a different `Frame` within the same `Index` might have its own inverseMaxSlice.

@benbjohnson my solution here feels a little messy in the `Executor`, but I couldn't figure out a better way to determine `inverse` since that's really determined by the `Call`.

TODO:
- [ ] change `maxInverseSlice()` to either accept a `frame` argument or return a `map[frame]maxSlice`
- [ ] implement `CreateFragmentMessage` in order to share `MaxSlice` among nodes.