### PR TITLE
Allow explicit time quantum during frame creation.

### DIFF
--- a/index.go
+++ b/index.go
@@ -377,7 +377,11 @@ func (i *Index) createFrame(name string, opt FrameOptions) (*Frame, error) {
 	}
 
 	// Default the time quantum to what is set on the Index.
-	if err := f.SetTimeQuantum(i.timeQuantum); err != nil {
+	timeQuantum := i.timeQuantum
+	if opt.TimeQuantum != "" {
+		timeQuantum = opt.TimeQuantum
+	}
+	if err := f.SetTimeQuantum(timeQuantum); err != nil {
 		f.Close()
 		return nil, err
 	}

--- a/index_test.go
+++ b/index_test.go
@@ -34,23 +34,43 @@ func TestIndex_CreateFrameIfNotExists(t *testing.T) {
 	}
 }
 
-// Ensure index defaults the time quantum on new frames.
+// Ensure index is assigned the correct time quantum on creation.
 func TestIndex_CreateFrame_TimeQuantum(t *testing.T) {
-	index := MustOpenIndex()
-	defer index.Close()
+	t.Run("Explicit", func(t *testing.T) {
+		index := MustOpenIndex()
+		defer index.Close()
 
-	// Set index time quantum.
-	if err := index.SetTimeQuantum(pilosa.TimeQuantum("YM")); err != nil {
-		t.Fatal(err)
-	}
+		// Set index time quantum.
+		if err := index.SetTimeQuantum(pilosa.TimeQuantum("YM")); err != nil {
+			t.Fatal(err)
+		}
 
-	// Create frame.
-	f, err := index.CreateFrame("f", pilosa.FrameOptions{})
-	if err != nil {
-		t.Fatal(err)
-	} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YM") {
-		t.Fatalf("unexpected frame time quantum: %s", q)
-	}
+		// Create frame with explicit quantum.
+		f, err := index.CreateFrame("f", pilosa.FrameOptions{TimeQuantum: pilosa.TimeQuantum("YMDH")})
+		if err != nil {
+			t.Fatal(err)
+		} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YMDH") {
+			t.Fatalf("unexpected frame time quantum: %s", q)
+		}
+	})
+
+	t.Run("Inherited", func(t *testing.T) {
+		index := MustOpenIndex()
+		defer index.Close()
+
+		// Set index time quantum.
+		if err := index.SetTimeQuantum(pilosa.TimeQuantum("YM")); err != nil {
+			t.Fatal(err)
+		}
+
+		// Create frame.
+		f, err := index.CreateFrame("f", pilosa.FrameOptions{})
+		if err != nil {
+			t.Fatal(err)
+		} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YM") {
+			t.Fatalf("unexpected frame time quantum: %s", q)
+		}
+	})
 }
 
 // Ensure index can delete a frame.


### PR DESCRIPTION
Changes the `Index.CreateFrame()` function to use the `TimeQuantum` field in the options. If it is blank then it is defaulted to the time quantum of the index.