### PR TITLE
docker update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,25 @@
-FROM golang:1.8.0
+FROM golang:1.8.1
 
 MAINTAINER Pilosa Corp. <dev@pilosa.com>
 
 ARG ldflags=''
+ARG GLIDE="https://github.com/Masterminds/glide/releases/download/v0.12.3/glide-v0.12.3-linux-amd64.tar.gz"
+ARG GLIDE_HASH="d6d3816c70fba716466e7381a9c06cb31565a3b87acb5bad9dd3beb0a9f9b0f8"
 
 EXPOSE 10101
 VOLUME /data
 
-RUN echo 'data-dir = "/data"' > /config
-
-RUN git clone --depth 1 https://github.com/Masterminds/glide.git /go/src/github.com/Masterminds/glide \
-    && cd /go/src/github.com/Masterminds/glide \
-    && git fetch --tags --depth 1 \
-    && git checkout tags/v0.12.3 -b build \
-    && make build \
-    && mv ./glide /go/bin \
-    && cd / \
-    && rm -r /go/src/github.com/Masterminds/glide
-
 COPY . /go/src/github.com/pilosa/pilosa
 
-RUN cd /go/src/github.com/pilosa/pilosa \
+RUN wget ${GLIDE} -O /go/glide.tar.gz -q \
+    && tar xf /go/glide.tar.gz \
+    && mv /go/linux-amd64/glide /go/bin \
+    && [ "$(sha256sum /go/bin/glide | cut -d' ' -f1)" = "$GLIDE_HASH" ] \
+    && cd /go/src/github.com/pilosa/pilosa \
     && make vendor \
     && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa \
-    && rm -rf /go/src /go/pkg
+    && mv /go/bin/pilosa /pilosa \
+    && rm -rf /go
 
-ENTRYPOINT ["/go/bin/pilosa"]
-CMD ["server", "--config", "/config"]
+ENTRYPOINT ["/pilosa"]
+CMD ["server", "--data-dir", "/data"]

--- a/Makefile
+++ b/Makefile
@@ -62,5 +62,6 @@ endif
 
 docker:
 	docker build -t "pilosa:$(VERSION)" \
-		--build-arg ldflags="-X main.Version=$(VERSION) -X main.BuildTime=$(BUILD_TIME)" .
+		--build-arg ldflags="-X github.com/pilosa/pilosa/cmd.Version=$(VERSION) \
+		-X github.com/pilosa/pilosa/cmd.BuildTime=$(BUILD_TIME)" .
 	@echo "Created image: pilosa:$(VERSION)"


### PR DESCRIPTION
I've removed the micro docker stuff from this PR and only include updates that fix pilosa binary version, etc. since docker recently introduced a new feature called multistage builds which enables creating the micro image without a build container.

Also, our submission to the official images may require us to keep the docker stuff in its own repo.