### PR TITLE
roaring: fix vet issues with the assembly code

### DIFF
--- a/roaring/assembly_amd64.s
+++ b/roaring/assembly_amd64.s
@@ -1,6 +1,6 @@
 #include "textflag.h"
 
-TEXT ·hasAsm(SB),4,$0
+TEXT ·hasAsm(SB),4,$0-1
 	MOVQ $1, AX
 	CPUID
 	SHRQ $23, CX
@@ -8,14 +8,14 @@ TEXT ·hasAsm(SB),4,$0
 	MOVB CX, ret+0(FP)
 	RET
 
-TEXT ·POPCNTQ(SB),NOSPLIT,$0-8
-	MOVQ x+0(FP), BP
+TEXT ·POPCNTQ(SB),NOSPLIT,$0-16
+	MOVQ memory+0(FP), BP
 	POPCNTQ BP, BX
 	MOVQ BX, ret+8(FP)
 	RET
 
-TEXT ·BSFQ(SB),NOSPLIT,$0-8
-	MOVQ x+0(FP), BP
+TEXT ·BSFQ(SB),NOSPLIT,$0-16
+	MOVQ memory+0(FP), BP
 	BSFQ BP, BX
 	MOVQ BX, ret+8(FP)
 	RET
@@ -24,8 +24,8 @@ TEXT ·BSFQ(SB),NOSPLIT,$0-8
 
 TEXT ·popcntSliceAsm(SB),4,$0-32
 XORQ	AX, AX
-MOVQ	s+0(FP), SI
-MOVQ	s+8(FP), CX
+MOVQ	s_base+0(FP), SI
+MOVQ	s_len+8(FP), CX
 TESTQ	CX, CX
 JZ		popcntSliceEnd
 popcntSliceLoop:
@@ -39,8 +39,8 @@ RET
 
 TEXT ·popcntMaskSliceAsm(SB),4,$0-56
 XORQ	AX, AX
-MOVQ	s+0(FP), SI
-MOVQ	s+8(FP), CX
+MOVQ	s_base+0(FP), SI
+MOVQ	s_len+8(FP), CX
 TESTQ	CX, CX
 JZ		popcntMaskSliceEnd
 MOVQ	m+24(FP), DI
@@ -59,8 +59,8 @@ RET
 
 TEXT ·popcntAndSliceAsm(SB),4,$0-56
 XORQ	AX, AX
-MOVQ	s+0(FP), SI
-MOVQ	s+8(FP), CX
+MOVQ	s_base+0(FP), SI
+MOVQ	s_len+8(FP), CX
 TESTQ	CX, CX
 JZ		popcntAndSliceEnd
 MOVQ	m+24(FP), DI
@@ -78,8 +78,8 @@ RET
 
 TEXT ·popcntOrSliceAsm(SB),4,$0-56
 XORQ	AX, AX
-MOVQ	s+0(FP), SI
-MOVQ	s+8(FP), CX
+MOVQ	s_base+0(FP), SI
+MOVQ	s_len+8(FP), CX
 TESTQ	CX, CX
 JZ		popcntOrSliceEnd
 MOVQ	m+24(FP), DI
@@ -97,8 +97,8 @@ RET
 
 TEXT ·popcntXorSliceAsm(SB),4,$0-56
 XORQ	AX, AX
-MOVQ	s+0(FP), SI
-MOVQ	s+8(FP), CX
+MOVQ	s_base+0(FP), SI
+MOVQ	s_len+8(FP), CX
 TESTQ	CX, CX
 JZ		popcntXorSliceEnd
 MOVQ	m+24(FP), DI


### PR DESCRIPTION
assembly_amd64.s:3: [amd64] hasAsm: wrong argument size 0; expected $...-1
assembly_amd64.s:11: [amd64] POPCNTQ: wrong argument size 8; expected $...-16
assembly_amd64.s:12: [amd64] POPCNTQ: unknown variable x; offset 0 is memory+0(FP)
assembly_amd64.s:17: [amd64] BSFQ: wrong argument size 8; expected $...-16
assembly_amd64.s:18: [amd64] BSFQ: unknown variable x; offset 0 is memory+0(FP)
assembly_amd64.s:28: [amd64] popcntSliceAsm: invalid offset s+8(FP); expected s+0(FP), s_base+0(FP), s_len+8(FP), or s_cap+16(FP)
assembly_amd64.s:43: [amd64] popcntMaskSliceAsm: invalid offset s+8(FP); expected s+0(FP), s_base+0(FP), s_len+8(FP), or s_cap+16(FP)
assembly_amd64.s:63: [amd64] popcntAndSliceAsm: invalid offset s+8(FP); expected s+0(FP), s_base+0(FP), s_len+8(FP), or s_cap+16(FP)
assembly_amd64.s:82: [amd64] popcntOrSliceAsm: invalid offset s+8(FP); expected s+0(FP), s_base+0(FP), s_len+8(FP), or s_cap+16(FP)
assembly_amd64.s:101: [amd64] popcntXorSliceAsm: invalid offset s+8(FP); expected s+0(FP), s_base+0(FP), s_len+8(FP), or s_cap+16(FP)