### PR TITLE
Makefile updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ ifndef GLIDE
 	curl https://glide.sh/get | sh
 endif
 
-vendor: glide glide.yaml
+$(GLIDE):
+	make glide
+
+vendor: $(GLIDE) glide.yaml
 	glide install
 
 glide.lock: glide glide.yaml

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: glide vendor-update docker pilosa crossbuild install generate statik
+.PHONY: glide vendor-update docker pilosa crossbuild install generate statik release
 
 GLIDE := $(shell command -v glide 2>/dev/null)
 STATIK := $(shell command -v statik 2>/dev/null)
@@ -39,6 +39,13 @@ pilosa: vendor
 crossbuild: vendor
 	mkdir -p build/pilosa-$(IDENTIFIER)
 	make pilosa FLAGS="-o build/pilosa-$(IDENTIFIER)/pilosa"
+	cp {LICENSE,README.md} build/pilosa-$(IDENTIFIER)
+	tar -cvz -C build -f build/pilosa-$(IDENTIFIER).tar.gz pilosa-$(IDENTIFIER)/
+	@echo "Created release build: build/pilosa-$(IDENTIFIER).tar.gz"
+
+release:
+	make crossbuild GOOS=linux GOARCH=amd64
+	make crossbuild GOOS=darwin GOARCH=amd64
 
 install: vendor
 	go install -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION := $(shell git describe --tags 2> /dev/null || echo unknown)
 IDENTIFIER := $(VERSION)-$(GOOS)-$(GOARCH)
 CLONE_URL=github.com/pilosa/pilosa
 BUILD_TIME=`date -u +%FT%T%z`
-LDFLAGS=-ldflags "-X github.com/pilosa/pilosa/cmd.Version=$(VERSION) -X github.com/pilosa/pilosa/cmd.BuildTime=$(BUILD_TIME)"
+LDFLAGS="-X github.com/pilosa/pilosa/cmd.Version=$(VERSION) -X github.com/pilosa/pilosa/cmd.BuildTime=$(BUILD_TIME)"
 
 default: test pilosa
 
@@ -31,14 +31,14 @@ test: vendor
 	go test $(shell cd $(GOPATH)/src/$(CLONE_URL); go list ./... | grep -v vendor)
 
 pilosa: vendor
-	go build $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
+	go build -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
 
 crossbuild: vendor
 	mkdir -p build/pilosa-$(IDENTIFIER)
 	make pilosa FLAGS="-o build/pilosa-$(IDENTIFIER)/pilosa"
 
 install: vendor
-	go install $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
+	go install -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
 
 .protoc-gen-gofast: vendor
 ifndef PROTOC
@@ -61,7 +61,5 @@ ifndef STATIK
 endif
 
 docker:
-	docker build -t "pilosa:$(VERSION)" \
-		--build-arg ldflags="-X github.com/pilosa/pilosa/cmd.Version=$(VERSION) \
-		-X github.com/pilosa/pilosa/cmd.BuildTime=$(BUILD_TIME)" .
+	docker build -t "pilosa:$(VERSION)" --build-arg ldflags=$(LDFLAGS) .
 	@echo "Created image: pilosa:$(VERSION)"


### PR DESCRIPTION
This includes a fix that prevents `glide install` from running on every build, makes the docker target use the LDFLAGS variable, and adds a release target.