### PR TITLE
provide details on glide checksum mistmach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . /go/src/github.com/pilosa/pilosa
 RUN wget ${GLIDE} -O /go/glide.tar.gz -q \
     && tar xf /go/glide.tar.gz \
     && mv /go/linux-amd64/glide /go/bin \
-    && [ "$(sha256sum /go/bin/glide | cut -d' ' -f1)" = "$GLIDE_HASH" ] \
+    && echo "${GLIDE_HASH}  /go/bin/glide" | shasum -a 256 -c - \
     && cd /go/src/github.com/pilosa/pilosa \
     && make vendor \
     && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa


### PR DESCRIPTION
before:
```
Step 6/13 : RUN wget ${GLIDE} -O /go/glide.tar.gz -q     && tar xf /go/glide.tar.gz     && mv /go/linux-amd64/glide /go/bin     && [ "$(sha256sum /go/bin/glide | cut -d' ' -f1)" = "$GLIDE_HASH" ]     && cd /go/src/github.com/pilosa/pilosa     && make vendor     && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa
 ---> Running in e2a6fcdf5930
The command '/bin/sh -c wget ${GLIDE} -O /go/glide.tar.gz -q     && tar xf /go/glide.tar.gz     && mv /go/linux-amd64/glide /go/bin     && [ "$(sha256sum /go/bin/glide | cut -d' ' -f1)" = "$GLIDE_HASH" ]     && cd /go/src/github.com/pilosa/pilosa     && make vendor     && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa' returned a non-zero code: 1
make: *** [docker] Error 1
```
after:
```
Step 6/13 : RUN wget ${GLIDE} -O /go/glide.tar.gz -q     && tar xf /go/glide.tar.gz     && mv /go/linux-amd64/glide /go/bin     && echo "${GLIDE_HASH}  /go/bin/glide" | shasum -a 256 -c -     && cd /go/src/github.com/pilosa/pilosa     && make vendor     && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa
 ---> Running in 5aaaab387641
shasum: WARNING: 1 computed checksum did NOT match
/go/bin/glide: FAILED
The command '/bin/sh -c wget ${GLIDE} -O /go/glide.tar.gz -q     && tar xf /go/glide.tar.gz     && mv /go/linux-amd64/glide /go/bin     && echo "${GLIDE_HASH}  /go/bin/glide" | shasum -a 256 -c -     && cd /go/src/github.com/pilosa/pilosa     && make vendor     && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa' returned a non-zero code: 1
make: *** [docker] Error 1
```