### PR TITLE
Add inverse TopN() support.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -279,7 +279,7 @@ func (e *Executor) executeBitmapCallSlice(ctx context.Context, index string, c *
 // This first performs the TopN() to determine the top results and then
 // requeries to retrieve the full counts for each of the top results.
 func (e *Executor) executeTopN(ctx context.Context, index string, c *pql.Call, slices []uint64, opt *ExecOptions) ([]Pair, error) {
-	rowIDs, _, err := c.UintSliceArg("ids")
+	idsArg, _, err := c.UintSliceArg("ids")
 	if err != nil {
 		return nil, fmt.Errorf("executeTopN: %v", err)
 	}
@@ -296,7 +296,7 @@ func (e *Executor) executeTopN(ctx context.Context, index string, c *pql.Call, s
 
 	// If this call is against specific ids, or we didn't get results,
 	// or we are part of a larger distributed query then don't refetch.
-	if len(pairs) == 0 || len(rowIDs) > 0 || opt.Remote {
+	if len(pairs) == 0 || len(idsArg) > 0 || opt.Remote {
 		return pairs, nil
 	}
 	// Only the original caller should refetch the full counts.
@@ -344,6 +344,7 @@ func (e *Executor) executeTopNSlices(ctx context.Context, index string, c *pql.C
 // executeTopNSlice executes a TopN call for a single slice.
 func (e *Executor) executeTopNSlice(ctx context.Context, index string, c *pql.Call, slice uint64) ([]Pair, error) {
 	frame, _ := c.Args["frame"].(string)
+	inverse, _ := c.Args["inverse"].(bool)
 	n, _, err := c.UintArg("n")
 	if err != nil {
 		return nil, fmt.Errorf("executeTopNSlice: %v", err)
@@ -380,7 +381,13 @@ func (e *Executor) executeTopNSlice(ctx context.Context, index string, c *pql.Ca
 		frame = DefaultFrame
 	}
 
-	f := e.Holder.Fragment(index, frame, ViewStandard, slice)
+	// Determine view.
+	view := ViewStandard
+	if inverse {
+		view = ViewInverse
+	}
+
+	f := e.Holder.Fragment(index, frame, view, slice)
 	if f == nil {
 		return nil, nil
 	}

--- a/pql/ast.go
+++ b/pql/ast.go
@@ -184,16 +184,20 @@ func (c *Call) String() string {
 
 // SupportsInverse indicates that the call may be on an inverse frame.
 func (c *Call) SupportsInverse() bool {
-	if c.Name == "Bitmap" {
-		return true
-	}
-	return false
+	return c.Name == "Bitmap" || c.Name == "TopN"
 }
 
 // IsInverse specifies if the call is for an inverse view.
 // Return defaults to false unless absolutely sure of inversion.
 func (c *Call) IsInverse(rowLabel, columnLabel string) bool {
 	if c.SupportsInverse() {
+		// Top-n has an explicit inverse flag.
+		if c.Name == "TopN" {
+			inverse, _ := c.Args["inverse"].(bool)
+			return inverse
+		}
+
+		// Bitmap calls use the row/column labels to determine whether inverse.
 		_, rowOK, rowErr := c.UintArg(rowLabel)
 		_, columnOK, columnErr := c.UintArg(columnLabel)
 		if rowErr != nil || columnErr != nil {


### PR DESCRIPTION
## Overview

The TopN() call now supports an `inverse` boolean argument to specify if the call should operate on the standard view or the inverse view.

Fixes #515.