### PR TITLE
Check for duplicate attributes under read lock on insert.

### DIFF
--- a/attr_test.go
+++ b/attr_test.go
@@ -18,6 +18,8 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"runtime"
+	"sync"
 	"testing"
 
 	"github.com/pilosa/pilosa"
@@ -141,6 +143,38 @@ func NewAttrStore() *AttrStore {
 	os.Remove(f.Name())
 
 	return &AttrStore{AttrStore: pilosa.NewAttrStore(f.Name())}
+}
+
+func BenchmarkAttrStore_Duplicate(b *testing.B) {
+	s := MustOpenAttrStore()
+	defer s.Close()
+
+	// Set attributes.
+	const n = 5
+	for i := 0; i < n; i++ {
+		if err := s.SetAttrs(uint64(i), map[string]interface{}{"A": 100, "B": "foo", "C": true, "D": 100.2}); err != nil {
+			b.Fatal(err)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	// Update attributes with an existing subset.
+	cpuN := runtime.GOMAXPROCS(0)
+	var wg sync.WaitGroup
+	for i := 0; i < cpuN; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < b.N/cpuN; j++ {
+				if err := s.SetAttrs(uint64(j%n), map[string]interface{}{"A": int64(100), "B": "foo", "D": 100.2}); err != nil {
+					b.Fatal(err)
+				}
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 // MustOpenAttrStore returns a new, opened attribute store at a temporary path. Panic on error.


### PR DESCRIPTION
## Overview

Changes the behavior of `AttrStore.SetAttrs()` to first verify that the attributes haven't changed using a read-only lock before obtaining a write lock to update the attributes.

Since the write lock serializes access, the previous insert time sufferred lock contention when inserting a lot of duplicate attributes. With the `RWMutex`, reads can be done in parallel so multiple requests don't block each other.


## Benchmark

Below is a simple benchmark showing the performance at 1, 5, & 10 goroutines:

### Before

```
BenchmarkAttrStore_Duplicate          100000      137120 ns/op      8428 B/op       76 allocs/op
BenchmarkAttrStore_Duplicate-5        100000      417459 ns/op      8431 B/op       76 allocs/op
BenchmarkAttrStore_Duplicate-10       100000      139466 ns/op      8433 B/op       76 allocs/op
```

### After

```
BenchmarkAttrStore_Duplicate        20000000         703 ns/op       368 B/op        5 allocs/op
BenchmarkAttrStore_Duplicate-5      100000000        213 ns/op       368 B/op        5 allocs/op
BenchmarkAttrStore_Duplicate-10     100000000        223 ns/op       368 B/op        5 allocs/op
```