### PR TITLE
Add 32-bit build to release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ pilosa: vendor
 crossbuild: vendor
 	mkdir -p build/pilosa-$(IDENTIFIER)
 	make pilosa FLAGS="-o build/pilosa-$(IDENTIFIER)/pilosa"
-	cp {LICENSE,README.md} build/pilosa-$(IDENTIFIER)
+	cp LICENSE README.md build/pilosa-$(IDENTIFIER)
 	tar -cvz -C build -f build/pilosa-$(IDENTIFIER).tar.gz pilosa-$(IDENTIFIER)/
 	@echo "Created release build: build/pilosa-$(IDENTIFIER).tar.gz"
 

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ crossbuild: vendor
 
 release:
 	make crossbuild GOOS=linux GOARCH=amd64
+	make crossbuild GOOS=linux GOARCH=386
 	make crossbuild GOOS=darwin GOARCH=amd64
 
 install: vendor


### PR DESCRIPTION
`make release` now produces a 32-bit linux binary.