### PR TITLE
rewrite intersectCountArrayBitmap for perf test

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1228,7 +1228,7 @@ func intersectionCountArrayArray(a, b *container) (n uint64) {
 	return n
 }
 
-func intersectionCountArrayBitmap(a, b *container) (n uint64) {
+func intersectionCountArrayBitmapOld(a, b *container) (n uint64) {
 	// Copy array header so we can shrink it.
 	array := a.array
 	if len(array) == 0 {
@@ -1267,6 +1267,18 @@ func intersectionCountArrayBitmap(a, b *container) (n uint64) {
 		}
 	}
 
+	return n
+}
+
+func intersectionCountArrayBitmap(a, b *container) (n uint64) {
+	for _, val := range a.array {
+		i := val / 64
+		if i >= uint32(len(b.bitmap)) {
+			break
+		}
+		off := val % 64
+		n += (b.bitmap[i] & (1 << off)) >> off
+	}
 	return n
 }
 

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -14,9 +14,7 @@
 
 package roaring
 
-import (
-	"testing"
-)
+import "testing"
 
 func TestBitmapCountRange(t *testing.T) {
 	c := container{}
@@ -38,6 +36,51 @@ func TestBitmapCountRange(t *testing.T) {
 		c.bitmap = test.bitmap
 		if ret := c.bitmapCountRange(test.start, test.end); ret != test.exp {
 			t.Fatalf("test #%v count of %v from %v to %v should be %v but got %v", i, test.bitmap, test.start, test.end, test.exp, ret)
+		}
+	}
+}
+
+func TestIntersectionCountArrayBitmap2(t *testing.T) {
+	a, b := &container{}, &container{}
+	tests := []struct {
+		array  []uint32
+		bitmap []uint64
+		exp    uint64
+	}{
+		{
+			array:  []uint32{0},
+			bitmap: []uint64{1},
+			exp:    1,
+		},
+		{
+			array:  []uint32{0, 1},
+			bitmap: []uint64{3},
+			exp:    2,
+		},
+		{
+			array:  []uint32{64, 128, 129, 2000},
+			bitmap: []uint64{932421, 2},
+			exp:    0,
+		},
+		{
+			array:  []uint32{0, 65, 130, 195},
+			bitmap: []uint64{255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255},
+			exp:    4,
+		},
+		{
+			array:  []uint32{63, 120, 543, 639, 12000},
+			bitmap: []uint64{0x8000000000000000, 0, 0, 0, 0, 0, 0, 0, 0, 0x8000000000000000},
+			exp:    2,
+		},
+	}
+
+	for i, test := range tests {
+		a.array = test.array
+		b.bitmap = test.bitmap
+		ret1 := intersectionCountArrayBitmapOld(a, b)
+		ret2 := intersectionCountArrayBitmap(a, b)
+		if ret1 != ret2 || ret2 != test.exp {
+			t.Fatalf("test #%v intersectCountArrayBitmap fail orig: %v new: %v exp: %v", i, ret1, ret2, test.exp)
 		}
 	}
 }


### PR DESCRIPTION
This is a 15x performance boost to TopN queries with one Bitmap on the NYC taxi dataset. 

e.g. ```TopN(Bitmap(frame=passenger_count, rowID=1), frame=total_amount_dollars)```

Results appear to be the same with both implementations. 

Basically the idea is to iterate over the array container rather than the bitmap container since the bitmap container basically means iterating over each bit of each uint64 (65536 bits), vs guaranteed <4096 uint32s in the array container.

I believe this is strictly faster than the previous implementation, but let me know if there are cases where performance would be lost (or if it's just incorrect).