### PR TITLE
set n based on array length instead of incrementing repeatedly

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1313,10 +1313,10 @@ func intersectArrayArray(a, b *container) *container {
 			j++
 		} else {
 			output.array = append(output.array, va)
-			output.n++
 			i, j = i+1, j+1
 		}
 	}
+	output.n = len(output.array)
 	return output
 }
 


### PR DESCRIPTION
should be a small perf win - except when the output is empty