### PR TITLE
Fix failing tests when IPv6 is disabled.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ glide.lock: glide glide.yaml
 vendor-update: glide.lock
 
 test: vendor
-	go test $(shell cd $(GOPATH)/src/$(CLONE_URL); go list ./... | grep -v vendor)
+	go test $(shell cd $(GOPATH)/src/$(CLONE_URL); go list ./... | grep -v vendor) $(TESTFLAGS)
 
 pilosa: vendor
 	go build -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/cmd"
+	_ "github.com/pilosa/pilosa/test"
 )
 
 func TestServerHelp(t *testing.T) {

--- a/pilosa_test.go
+++ b/pilosa_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pilosa/pilosa"
+	_ "github.com/pilosa/pilosa/test"
 )
 
 func TestValidateName(t *testing.T) {

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/pilosa/pilosa/pql"
+	_ "github.com/pilosa/pilosa/test"
 )
 
 // Ensure the parser can parse PQL.

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -25,6 +25,7 @@ import (
 	"testing/quick"
 
 	"github.com/pilosa/pilosa/roaring"
+	_ "github.com/pilosa/pilosa/test"
 )
 
 // Ensure an empty bitmap returns false if checking for existence.

--- a/server.go
+++ b/server.go
@@ -56,6 +56,7 @@ type Server struct {
 
 	// Cluster configuration.
 	// Host is replaced with actual host after opening if port is ":0".
+	Network string
 	Host    string
 	Cluster *Cluster
 
@@ -80,6 +81,8 @@ func NewServer() *Server {
 		Broadcaster:       NopBroadcaster,
 		BroadcastReceiver: NopBroadcastReceiver,
 
+		Network: "tcp",
+
 		AntiEntropyInterval: DefaultAntiEntropyInterval,
 		PollingInterval:     DefaultPollingInterval,
 		MetricInterval:      0,
@@ -103,7 +106,7 @@ func (s *Server) Open() error {
 	}
 
 	// Open HTTP listener to determine port (if specified as :0).
-	ln, err := net.Listen("tcp", ":"+port)
+	ln, err := net.Listen(s.Network, ":"+port)
 	if err != nil {
 		return fmt.Errorf("net.Listen: %v", err)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/httpbroadcast"
 	"github.com/pilosa/pilosa/server"
+	"github.com/pilosa/pilosa/test"
 )
 
 // Ensure program can process queries and maintain consistency.
@@ -542,6 +543,7 @@ func NewMain() *Main {
 	}
 
 	m := &Main{Command: server.NewCommand(os.Stdin, os.Stdout, os.Stderr)}
+	m.Server.Network = *test.Network
 	m.Config.DataDir = path
 	m.Config.Host = "localhost:0"
 	m.Command.Stdin = &m.Stdin
@@ -580,7 +582,10 @@ func (m *Main) Reopen() error {
 	// Create new main with the same config.
 	config := m.Config
 	m.Command = server.NewCommand(os.Stdin, os.Stdout, os.Stderr)
+	m.Server.Network = *test.Network
 	m.Config = config
+
+	println("dbg/network", *test.Network)
 
 	// Run new program.
 	if err := m.Run(); err != nil {

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pilosa/pilosa/statsd"
+	_ "github.com/pilosa/pilosa/test"
 )
 
 func TestStatsClient_WithTags(t *testing.T) {

--- a/test/test.go
+++ b/test/test.go
@@ -1,0 +1,8 @@
+package test
+
+import "flag"
+
+// Test flags.
+var (
+	Network = flag.String("network", "tcp", "network name")
+)


### PR DESCRIPTION
## Overview

Turning off IPv6 causes the tests to fail because the Go `net.Listen()` function obtains a `[::]` address when using a `localhost:0` bind address. Looking through the Go source code, I don't see a good way to fix that.

This change adds a test flag to allow users to specify the network name when running the test:

```sh
go test github.com/pilosa/pilosa/server -network tcp4
```

Fixes #348