### PR TITLE
Minor docs fix, indent in JSON

### DIFF
--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -92,27 +92,27 @@ pdk.BitMapper{
 These same objects are represented in the JSON definition file:
 ```go
 {
-    "Fields": [
-        "Trip_distance": 10,
-     ]
-"Mappers": [
+    "Fields": {
+        "Trip_distance": 10
+    },
+    "Mappers": [
         {
             "Name": "lfm0",
             "Min": -0.5,
             "Max": 3600.5,
             "Res": 3600
-        },
+        }
     ],
     "BitMappers": [
         {
             "Frame": "dist_miles",
             "Mapper": {
                 "Name": "lfm0"
-         },
+            },
             "Parsers": [
                 {"Name": "FloatParser"}
             ],
-            "Fields": "Trip_distance",
+            "Fields": "Trip_distance"
         }
     ]
 }

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -99,7 +99,7 @@ These same objects are represented in the JSON definition file:
         {
             "Name": "lfm0",
             "Min": -0.5,
-         "Max": 3600.5,
+            "Max": 3600.5,
             "Res": 3600
         },
     ],


### PR DESCRIPTION
Properly indent `Fields.Mappers.Max` field in example JSON.