### PR TITLE
make sure glide is installed before `glide install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ $(GLIDE):
 	make glide
 
 vendor: $(GLIDE) glide.yaml
+ifndef GLIDE
+	curl https://glide.sh/get | sh
+endif
 	glide install
 
 glide.lock: glide glide.yaml


### PR DESCRIPTION
If glide is not installed, then $(GLIDE) is empty, so I guess the $(GLIDE)
target gets ignored? The impetus for this is that `make install` was failing on
a fresh ubuntu instance saying glide wasn't found.