### PR TITLE
Add Holder test coverage.

### DIFF
--- a/view.go
+++ b/view.go
@@ -144,7 +144,7 @@ func (v *View) openFragments() error {
 
 		frag := v.newFragment(v.FragmentPath(slice), slice)
 		if err := frag.Open(); err != nil {
-			return fmt.Errorf("open fragment: slice=%s, err=%s", frag.Slice(), err)
+			return fmt.Errorf("open fragment: slice=%d, err=%s", frag.Slice(), err)
 		}
 		frag.RowAttrStore = v.RowAttrStore
 		v.fragments[frag.Slice()] = frag


### PR DESCRIPTION
## Overview

Adds test coverage for various failing `Holder.Open()` scenarios.

Fixes #583.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
