### PR TITLE
Test create input definition across 2 servers

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -494,6 +494,29 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 	if maxSlices1["i"] != 2 {
 		t.Fatalf("unexpected maxSlice on node1: %d", maxSlices1["i"])
 	}
+
+	// Write input definition to the first node.
+	if _, err := m0.CreateDefinition("i", "test", `{
+			"frames": [{"name": "event-time",
+						"options": {
+							"cacheType": "ranked",
+							"timeQuantum": "YMD"
+						}}],
+			"fields": [{"name": "id",
+						"primaryKey": true
+						}]}
+		`); err != nil {
+		t.Fatal(err)
+	}
+
+	frame0 := m0.Server.Holder.Frame("i", "event-time")
+	if frame0 == nil {
+		t.Fatal("frame not found")
+	}
+	frame1 := m1.Server.Holder.Frame("i", "event-time")
+	if frame1 == nil {
+		t.Fatal("frame not found")
+	}
 }
 
 // availablePorts returns a slice of ports that can be used for testing.
@@ -609,6 +632,15 @@ func (m *Main) Client() *pilosa.Client {
 // Query executes a query against the program through the HTTP API.
 func (m *Main) Query(index, rawQuery, query string) (string, error) {
 	resp := MustDo("POST", m.URL()+fmt.Sprintf("/index/%s/query?", index)+rawQuery, query)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("invalid status: %d, body=%s", resp.StatusCode, resp.Body)
+	}
+	return resp.Body, nil
+}
+
+// CreateDefinition.
+func (m *Main) CreateDefinition(index, def, query string) (string, error) {
+	resp := MustDo("POST", m.URL()+fmt.Sprintf("/index/%s/input-definition/%s", index, def), query)
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("invalid status: %d, body=%s", resp.StatusCode, resp.Body)
 	}


### PR DESCRIPTION
Test create input definition across 2 servers

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
