### PR TITLE
Catch make() panic in executor

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -769,15 +769,19 @@ func TestExecutor_Execute_ErrSliceIndexTooLarge(t *testing.T) {
 
 	e := NewExecutor(hldr.Holder, NewCluster(1))
 
-	// Set bits.
-	if _, err := e.Execute(context.Background(), "i", MustParse(`SetBit(frame=f, rowID=19042, columnID=406, timestamp="2016-03-15T04:54")`), nil, nil); err != nil {
+	// Set bit with very high columnID
+	if _, err := e.Execute(context.Background(), "i", MustParse(`SetBit(frame=f, rowID=19042, columnID=6018148517796380732, timestamp="2016-03-15T04:54")`), nil, nil); err != nil {
 		t.Fatal(err)
 	}
-
-	if _, err := e.Execute(context.Background(), "i", MustParse(`Bitmap(frame=f, rowID=6018148517796380732)`), nil, nil); err != pilosa.ErrSliceIndexTooLarge {
+	if _, err := e.Execute(context.Background(), "i", MustParse(`Bitmap(frame=f, columnID=6018148517796380732)`), nil, nil); err != pilosa.ErrSliceIndexTooLarge {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if _, err := e.Execute(context.Background(), "i", MustParse(`Bitmap(frame=f, columnID=6018148517796380732)`), nil, nil); err != pilosa.ErrSliceIndexTooLarge {
+
+	// Set bit with very high rowID
+	if _, err := e.Execute(context.Background(), "i", MustParse(`SetBit(frame=f, rowID=6018148517796380732, columnID=402, timestamp="2016-03-15T04:54")`), nil, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Execute(context.Background(), "i", MustParse(`Bitmap(frame=f, rowID=6018148517796380732)`), nil, nil); err != pilosa.ErrSliceIndexTooLarge {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/handler.go
+++ b/handler.go
@@ -268,6 +268,8 @@ func (h *Handler) handlePostQuery(w http.ResponseWriter, r *http.Request) {
 		switch resp.Err {
 		case ErrTooManyWrites:
 			w.WriteHeader(http.StatusRequestEntityTooLarge)
+		case ErrSliceIndexTooLarge:
+			w.WriteHeader(http.StatusNotImplemented)
 		default:
 			w.WriteHeader(http.StatusInternalServerError)
 		}

--- a/pilosa.go
+++ b/pilosa.go
@@ -53,6 +53,8 @@ var (
 	ErrFragmentNotFound = errors.New("fragment not found")
 	ErrQueryRequired    = errors.New("query required")
 	ErrTooManyWrites    = errors.New("too many write commands")
+
+	ErrSliceIndexTooLarge = errors.New("slices must fit in memory")
 )
 
 // Regular expression to validate index and frame names.


### PR DESCRIPTION
## Overview

Prevents an empty response after panic inside make(), when a query is sent with an ID too large for all intermediate slice indices to fit in memory.



Addresses #591

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
