### PR TITLE
Set & retrieve field values.

### DIFF
--- a/pilosa.go
+++ b/pilosa.go
@@ -36,12 +36,15 @@ var (
 	ErrFrameInverseDisabled = errors.New("frame inverse disabled")
 	ErrColumnRowLabelEqual  = errors.New("column and row labels cannot be equal")
 
+	ErrFieldNotFound          = errors.New("field not found")
 	ErrFieldNameRequired      = errors.New("field name required")
 	ErrInvalidFieldType       = errors.New("invalid field type")
 	ErrInvalidFieldRange      = errors.New("invalid field range")
 	ErrInverseRangeNotAllowed = errors.New("inverse range not allowed")
 	ErrRangeCacheNotAllowed   = errors.New("range cache not allowed")
 	ErrFrameFieldsNotAllowed  = errors.New("frame fields not allowed")
+	ErrFieldValueTooLow       = errors.New("field value too low")
+	ErrFieldValueTooHigh      = errors.New("field value too high")
 
 	ErrInvalidView      = errors.New("invalid view")
 	ErrInvalidCacheType = errors.New("invalid cache type")

--- a/view.go
+++ b/view.go
@@ -31,6 +31,8 @@ import (
 const (
 	ViewStandard = "standard"
 	ViewInverse  = "inverse"
+
+	ViewFieldPrefix = "field_"
 )
 
 // IsValidView returns true if name is valid.
@@ -276,6 +278,26 @@ func (v *View) ClearBit(rowID, columnID uint64) (changed bool, err error) {
 		return changed, err
 	}
 	return frag.ClearBit(rowID, columnID)
+}
+
+// FieldValue uses a column of bits to read a multi-bit value.
+func (v *View) FieldValue(columnID uint64, bitDepth uint) (value uint64, exists bool, err error) {
+	slice := columnID / SliceWidth
+	frag, err := v.CreateFragmentIfNotExists(slice)
+	if err != nil {
+		return value, exists, err
+	}
+	return frag.FieldValue(columnID, bitDepth)
+}
+
+// SetFieldValue uses a column of bits to set a multi-bit value.
+func (v *View) SetFieldValue(columnID uint64, bitDepth uint, value uint64) (changed bool, err error) {
+	slice := columnID / SliceWidth
+	frag, err := v.CreateFragmentIfNotExists(slice)
+	if err != nil {
+		return changed, err
+	}
+	return frag.SetFieldValue(columnID, bitDepth, value)
 }
 
 // IsInverseView returns true if the view is used for storing an inverted representation.


### PR DESCRIPTION
## Overview

This pull request adds support for set/get range values at the `Frame`, `View`, and `Fragment` levels.

Fixes #617.


## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [x] Ensure that any changes to external docs have been included in this pull request.
- [x] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [x] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [x] Check that tests have been written and that they cover the new functionality.
- [x] Run tests and ensure they pass.
- [x] Build and run the code, performing any applicable integration testing.
