### PR TITLE
webui style update

### DIFF
--- a/webui/assets/style.css
+++ b/webui/assets/style.css
@@ -224,6 +224,7 @@ em{
   padding: 15px;
   margin-bottom: 15px;
   word-break: break-all;
+  overflow-wrap: break-word;
   overflow:hidden;
 }
 
@@ -231,7 +232,6 @@ em{
 .result-output{
   background-color: #edf9f7;
   border-left: solid 4px #1db598;
-  word-wrap: break-word;
 }
 
 .result-error{

--- a/webui/assets/style.css
+++ b/webui/assets/style.css
@@ -231,6 +231,7 @@ em{
 .result-output{
   background-color: #edf9f7;
   border-left: solid 4px #1db598;
+  word-wrap: break-word;
 }
 
 .result-error{


### PR DESCRIPTION
Noticed in the web console running the query from getting started tutorial Bitmap(frame="stargazer", stargazer_id=14) would overflow the resulting text.

## Overview

Text escaping its div container. Did not create an issue since this is a small css fix for some minor aesthetics. 

Fixes #
I looked at the existing issues but did not see anything related to this. 

## Pull request checklist

- [X] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [X] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [X] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
