### PR TITLE
add action to handle timestamp

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -140,7 +140,16 @@ curl localhost:10101/index/repository/input-definition/stargazer \
                          }
                      ], 
                      "name": "stargazer_id"
-                 }
+                 },
+                 {
+                      "actions": [
+                          {
+                              "frame": "stargazer", 
+                              "valueDestination": "set-timestamp"
+                          }
+                      ], 
+                      "name": "time_value
+                  }
              ] 
          }'
 ```
@@ -151,7 +160,7 @@ We can also set `repo_id` for multiple frames at the same time by providing fiel
  - value-to-row: The value for this field is used as the `rowID`.
  - single-row-boolean: The value must be a boolean, and this specifies `SetBit()` or `ClearBit()`, a `rowID` must be specified for this destination type.
  - mapping: The value for this field is used to lookup a `rowID` in a map. A valueMap is required for this destination type.
-
+ - set-timestamp: The value for this field is used to lookup timestamp and set timestamp for the whole frame
 
 #### Import Data Using an Input Definition
 
@@ -167,6 +176,7 @@ curl localhost:10101/index/repository/input/stargazer \
                  "language_id": "Go", 
                  "repo_id": 91720568, 
                  "stargazer_id": 513114
+                 "time_value": "2017-05-18T20:40"
              }, 
              {
                  "language_id": "Python", 
@@ -182,6 +192,7 @@ The data input above is equivalent to the following `SetBit()` operations:
 curl localhost:10101/index/repository/query \
      -X POST \
      -d 'SetBit(frame="stargazer", repo_id=91720568, stargazer_id=513114)
+        'SetBit(frame="stargazer", repo_id=91720568, stargazer_id=513114, timestamp="2017-05-18T20:40")
          SetBit(frame="language", repo_id=91720568, language_id=5)
          SetBit(frame="language", repo_id=95122322, language_id=17)
      '

--- a/handler.go
+++ b/handler.go
@@ -1661,22 +1661,35 @@ func (h *Handler) InputJSONDataParser(req map[string]interface{}, index *Index, 
 	if err != nil {
 		return nil, err
 	}
-	// if field in input data is not in defined definition, return error
-	var columnLabel string
+	// If field in input data is not in defined definition, return error.
+	var colValue uint64
 	validFields := make(map[string]bool)
-	timestampFrame := make(map[string]string)
+	timestampFrame := make(map[string]int64)
 	for _, field := range inputDef.Fields() {
 		validFields[field.Name] = true
 		if field.PrimaryKey {
-			columnLabel = field.Name
+			columnLabel := field.Name
+			value, ok := req[columnLabel]
+			if !ok {
+				return nil, fmt.Errorf("columnLabel required")
+			}
+			rawValue, ok := value.(float64) // The default JSON marshalling will interpret this as a float
+			if !ok {
+				return nil, fmt.Errorf("float64 require, got value:%s, type: %s", value, reflect.TypeOf(value))
+			}
+			colValue = uint64(rawValue)
 		}
-		// finding frame that need to add timestamp
+		// Find frame that need to add timestamp.
 		for _, action := range field.Actions {
 			if action.ValueDestination == InputSetTimestamp {
-				timestampFrame[action.Frame] = field.Name
+				timestampFrame[action.Frame], err = GetTimeStamp(req, field.Name)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
+
 	for key := range req {
 		_, ok := validFields[key]
 		if !ok {
@@ -1691,35 +1704,12 @@ func (h *Handler) InputJSONDataParser(req map[string]interface{}, index *Index, 
 		if _, ok := req[field.Name]; !ok {
 			continue
 		}
-		value, ok := req[columnLabel]
-		if !ok {
-			return nil, fmt.Errorf("columnLabel required")
-		}
-		colValue, ok := value.(float64)
-		if !ok {
-			return nil, fmt.Errorf("float64 require, got value:%s, type: %s", value, reflect.TypeOf(value))
-		}
 
 		// Looking into timestampFrame map and set timestamp to the whole frame
-		var timestamp string
 		for _, action := range field.Actions {
 			frame := action.Frame
-			timeField, ok := timestampFrame[action.Frame]
-			if !ok {
-				timestamp = ""
-			} else {
-				tmstamp, ok := req[timeField]
-				if !ok {
-					timestamp = ""
-				} else {
-					timestamp, ok = tmstamp.(string)
-					if !ok {
-						return nil, fmt.Errorf("set-timestamp value must be in time format: YYYY-MM-DD, having: %v", req[timeField])
-					}
-				}
-			}
-
-			bit, err := HandleAction(action, req[field.Name], uint64(colValue), timestamp)
+			timestamp := timestampFrame[action.Frame]
+			bit, err := HandleAction(action, req[field.Name], colValue, timestamp)
 			if err != nil {
 				return nil, fmt.Errorf("error handling action: %s, err: %s", action.ValueDestination, err)
 			}
@@ -1729,4 +1719,24 @@ func (h *Handler) InputJSONDataParser(req map[string]interface{}, index *Index, 
 		}
 	}
 	return setBits, nil
+}
+
+// GetTimeStamp retrieves unix timestamp from Input data.
+func GetTimeStamp(data map[string]interface{}, timeField string) (int64, error) {
+	tmstamp, ok := data[timeField]
+	if !ok {
+		return 0, nil
+	}
+
+	timestamp, ok := tmstamp.(string)
+	if !ok {
+		return 0, fmt.Errorf("set-timestamp value must be in time format: YYYY-MM-DD, has: %v", data[timeField])
+	}
+
+	v, err := time.Parse(TimeFormat, timestamp)
+	if err != nil {
+		return 0, err
+	}
+
+	return v.Unix(), nil
 }

--- a/handler_test.go
+++ b/handler_test.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"testing"
 
-	"fmt"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/internal"

--- a/handler_test.go
+++ b/handler_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	"fmt"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/internal"
@@ -1279,7 +1280,7 @@ var defaultBody = `
 					 "actions":[
 						{
 						   "frame":"add-ons",
-						   "valueDestination":"set_timestamp"
+						   "valueDestination":"set-timestamp"
 
 						}
 					 ]
@@ -1306,7 +1307,8 @@ func TestHandler_CreateInput(t *testing.T) {
 				"id": 1,
 				"cabType": "yellow",
 				"distanceMiles": 8,
-				"withPet": true
+				"withPet": true,
+				"time_value": "2017-03-20T19:35"
 			}]`)
 	h := test.NewHandler()
 	h.Holder = hldr.Holder
@@ -1328,6 +1330,7 @@ func TestHandler_CreateInput(t *testing.T) {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	}
 
+	// Test successfully ingest data
 	w = httptest.NewRecorder()
 	h.ServeHTTP(w, test.MustNewHTTPRequest("POST", "/index/i0/input/input1", bytes.NewBuffer(inputBody)))
 	if w.Code != http.StatusOK {
@@ -1337,7 +1340,6 @@ func TestHandler_CreateInput(t *testing.T) {
 	}
 
 	// Verify the bits set per frame.
-	// f := index.Frame("cab-type")
 	f0 := index.Frame("distance-miles")
 	v0 := f0.View(pilosa.ViewStandard)
 	fragment0 := v0.Fragment(0)
@@ -1415,6 +1417,13 @@ func TestInput_JSON(t *testing.T) {
 				"noFrame": 1
 				}]`,
 			err: "Frame not found: foo"},
+		{json: `[{
+				"id": 1,
+				"cabType": "yellow",
+				"distanceMiles": 8,
+				"time_value": 12345
+				}]`,
+			err: "set-timestamp value must be in time format: YYYY-MM-DD, having: 12345"},
 	}
 	h := test.NewHandler()
 	h.Holder = hldr.Holder

--- a/handler_test.go
+++ b/handler_test.go
@@ -1273,6 +1273,16 @@ var defaultBody = `
 
 						}
 					 ]
+				  },
+				  {
+					 "name":"time_value",
+					 "actions":[
+						{
+						   "frame":"add-ons",
+						   "valueDestination":"set_timestamp"
+
+						}
+					 ]
 				  }
 			   ]
 			}`

--- a/index.go
+++ b/index.go
@@ -772,7 +772,7 @@ func (i *Index) InputBits(frame string, bits []*Bit) error {
 
 		// Convert timestamps to time.Time.
 		if bit.Timestamp > 0 {
-			t := time.Unix(0, bit.Timestamp)
+			t := time.Unix(bit.Timestamp, 0)
 			timestamps[i] = &t
 		}
 	}

--- a/input_definition.go
+++ b/input_definition.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pilosa/pilosa/internal"
+	"time"
 )
 
 // Action types.
@@ -29,9 +30,10 @@ const (
 	InputMapping       = "mapping"
 	InputValueToRow    = "value-to-row"
 	InputSingleRowBool = "single-row-boolean"
+	InputSetTimestamp  = "set-timestamp"
 )
 
-var validValueDestination = []string{InputMapping, InputValueToRow, InputSingleRowBool}
+var validValueDestination = []string{InputMapping, InputValueToRow, InputSingleRowBool, InputSetTimestamp}
 
 // InputDefinition represents a container for the data input definition.
 type InputDefinition struct {
@@ -367,6 +369,13 @@ func HandleAction(a Action, value interface{}, colID uint64) (*Bit, error) {
 			return nil, fmt.Errorf("value-to-row value must equate to an integer %v", value)
 		}
 		bit.RowID = uint64(v)
+	case InputSetTimestamp:
+		v, err := time.Parse(TimeFormat, value.(string))
+		if err != nil {
+			return nil, fmt.Errorf("set-timestamp value for :%v must in time format: YYYY-MM-DD", value)
+		}
+		bit.Timestamp = v.Unix()
+
 	default:
 		return nil, fmt.Errorf("Unrecognized Value Destination: %s in Action", a.ValueDestination)
 	}

--- a/input_definition.go
+++ b/input_definition.go
@@ -348,7 +348,7 @@ func HandleAction(a Action, value interface{}, colID uint64, timestamp string) (
 	if timestamp != "" {
 		v, err := time.Parse(TimeFormat, timestamp)
 		if err != nil {
-			return nil, fmt.Errorf("set-timestamp value for :%v must in time format: YYYY-MM-DD", timestamp)
+			return nil, err
 		}
 		bit.Timestamp = v.Unix()
 	}

--- a/input_definition.go
+++ b/input_definition.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/pilosa/pilosa/internal"
-	"time"
 )
 
 // Action types.
@@ -341,17 +340,11 @@ func (i *InputDefinition) AddFrame(frame InputFrame) error {
 // HandleAction Process the input data with its action and return a bit to be imported later
 // Note: if the Bit should not be set then nil is returned with no error
 // From the JSON marshalling the possible types are: float64, boolean, string
-func HandleAction(a Action, value interface{}, colID uint64, timestamp string) (*Bit, error) {
+func HandleAction(a Action, value interface{}, colID uint64, timestamp int64) (*Bit, error) {
 	var err error
 	var bit Bit
 	bit.ColumnID = colID
-	if timestamp != "" {
-		v, err := time.Parse(TimeFormat, timestamp)
-		if err != nil {
-			return nil, err
-		}
-		bit.Timestamp = v.Unix()
-	}
+	bit.Timestamp = timestamp
 
 	switch a.ValueDestination {
 	case InputMapping:

--- a/input_definition_test.go
+++ b/input_definition_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/internal"
 	"github.com/pilosa/pilosa/test"
+	"time"
 )
 
 func TestInputDefinition_Open(t *testing.T) {
@@ -266,6 +267,22 @@ func TestHandleAction(t *testing.T) {
 	b, err = pilosa.HandleAction(action, value, colID)
 	if b != nil {
 		t.Fatalf("Expected Ignore values that are not type string")
+	}
+
+	action.ValueDestination = pilosa.InputSetTimestamp
+	value = "2017-03-20T19:35"
+	parsedTime, _ := time.Parse(pilosa.TimeFormat, value.(string))
+	b, err = pilosa.HandleAction(action, value, colID)
+	if b == nil {
+		t.Fatalf("Expected return bit")
+	} else if b.Timestamp != parsedTime.Unix() {
+		t.Fatalf("Timestamp is not set correctly")
+	}
+
+	value = "12345677"
+	b, err = pilosa.HandleAction(action, value, colID)
+	if !strings.Contains(err.Error(), "set-timestamp value for :12345677 must in time format: YYYY-MM-DD") {
+		t.Fatal("Expect invalid timestamp format")
 	}
 
 	action.ValueDestination = "test"

--- a/input_definition_test.go
+++ b/input_definition_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/internal"
 	"github.com/pilosa/pilosa/test"
-	"time"
 )
 
 func TestInputDefinition_Open(t *testing.T) {
@@ -197,7 +196,7 @@ func TestHandleAction(t *testing.T) {
 	colID := uint64(0)
 	rowID := uint64(100)
 	action := pilosa.Action{ValueDestination: pilosa.InputSingleRowBool, RowID: &rowID}
-	timestamp := ""
+	timestamp := int64(0)
 
 	value = 1
 	b, err := pilosa.HandleAction(action, value, colID, timestamp)
@@ -270,21 +269,9 @@ func TestHandleAction(t *testing.T) {
 		t.Fatalf("Expected Ignore values that are not type string")
 	}
 
-	action.ValueDestination = pilosa.InputSetTimestamp
-	timestamp = "2017-03-20T19:35"
-	parsedTime, _ := time.Parse(pilosa.TimeFormat, timestamp)
-	b, err = pilosa.HandleAction(action, value, colID, timestamp)
-	if b == nil {
-		t.Fatalf("Expected return bit")
-	} else if b.Timestamp != parsedTime.Unix() {
-		t.Fatalf("Timestamp is not set correctly")
-	}
-
 	action.ValueDestination = "test"
-	timestamp = ""
 	b, err = pilosa.HandleAction(action, value, colID, timestamp)
 	if !strings.Contains(err.Error(), "Unrecognized Value Destination") {
 		t.Fatalf("Expected Unrecognized Value Destination error, actual error: %s", err)
 	}
-
 }

--- a/input_definition_test.go
+++ b/input_definition_test.go
@@ -272,18 +272,12 @@ func TestHandleAction(t *testing.T) {
 
 	action.ValueDestination = pilosa.InputSetTimestamp
 	timestamp = "2017-03-20T19:35"
-	parsedTime, _ := time.Parse(pilosa.TimeFormat, value.(string))
+	parsedTime, _ := time.Parse(pilosa.TimeFormat, timestamp)
 	b, err = pilosa.HandleAction(action, value, colID, timestamp)
 	if b == nil {
 		t.Fatalf("Expected return bit")
 	} else if b.Timestamp != parsedTime.Unix() {
 		t.Fatalf("Timestamp is not set correctly")
-	}
-
-	value = "12345677"
-	b, err = pilosa.HandleAction(action, value, colID, timestamp)
-	if !strings.Contains(err.Error(), "set-timestamp value for :12345677 must in time format: YYYY-MM-DD") {
-		t.Fatal("Expect invalid timestamp format")
 	}
 
 	action.ValueDestination = "test"


### PR DESCRIPTION
## Overview

Update input definition to handle adding timestamp. 
@travisturner: this doesn't block the input-definition, I can send another PR to master after check in input-definition if you have no time to review this now. Still need to update getting-start repo & doc with timestamp though

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
