### PR TITLE
add gossip-seed to configuration docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,19 @@ Any flag that has a value that is a comma separated list on the command line bec
     data-dir = "~/.pilosa"
     ```
 
+#### Gossip Seed
+
+* Description: When using the gossip [Cluster Type]({{< ref "#cluster-type" >}}), this specifies which internal host should be used to initialize membership in the cluster. Typcially this can be the address of any available host in the cluster. For example, when starting a three-node cluster made up of `node0`, `node1`, and `node2`, the `gossip-seed` for all three nodes can be configured to be the address of `node0`.
+* Flag: `--gossip-seed="localhost:11101"`
+* Env: `PILOSA_GOSSIP_SEED="localhost:11101"`
+* Config:
+
+    ```toml
+    [cluster]
+    type = "gossip"
+    gossip-seed = "localhost:11101"
+    ```
+
 #### Profile CPU
 
 * Description: If this is set to a path, collect a cpu profile and store it there.


### PR DESCRIPTION
## Overview

Adds configuration docs for `gossip-seed` as requested by #717.
