### PR TITLE
adjust columnN range to avoid divide-by-zero error in travisCI

### DIFF
--- a/fragment_test.go
+++ b/fragment_test.go
@@ -176,7 +176,7 @@ func TestFragment_SetFieldValue(t *testing.T) {
 		if err := quick.Check(func(bitDepth uint, columnN uint64, values []uint64) bool {
 			// Limit bit depth & maximum values.
 			bitDepth = (bitDepth % 62) + 1
-			columnN = (columnN % 100)
+			columnN = (columnN % 99) + 1
 			for i := range values {
 				values[i] = values[i] % (1 << bitDepth)
 			}


### PR DESCRIPTION
## Overview
Randomized tests were failing in travisCI when a column size was set to 0 in the test.
This fix prevents columnN from being 0.