### PR TITLE
Countrange bug

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -197,6 +197,7 @@ func (b *Bitmap) CountRange(start, end uint64) (n uint64) {
 	if len(b.keys) == 0 {
 		return
 	}
+
 	skey := highbits(start)
 	ekey := highbits(end)
 
@@ -233,7 +234,11 @@ func (b *Bitmap) CountRange(start, end uint64) (n uint64) {
 
 	// Count containers in between.
 	for x := i + 1; x < j; x++ {
+		if ekey < b.keys[x] {
+			break
+		}
 		n += uint64(b.containers[x].n)
+
 	}
 
 	return n

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -234,6 +234,8 @@ func (b *Bitmap) CountRange(start, end uint64) (n uint64) {
 
 	// Count containers in between.
 	for x := i + 1; x < j; x++ {
+		// Ensure that current container is inside the requested range since
+		// keys to not have to be consecutive
 		if ekey < b.keys[x] {
 			break
 		}

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -209,38 +209,29 @@ func (b *Bitmap) CountRange(start, end uint64) (n uint64) {
 		return uint64(b.containers[i].countRange(int(lowbits(start)), int(lowbits(end))))
 	}
 
-	// Count first partial container.
 	if i < 0 {
-		// start is before container, so we should start counting
-		// at first container that has value
-		if skey < b.keys[0] {
-			i = -1
-		} else {
-			i = -i
-		}
+		// start's container did not exist
+		// set i to the index of the first container we have with values higher than start
+		i = -i - 1
 	} else {
+		// Count first partial container and advance i so we don't recount it
 		n += uint64(b.containers[i].countRange(int(lowbits(start)), maxContainerVal+1))
+		i += 1
 	}
 
 	// Count last container.
 	if j < 0 {
-		j = -j
-		if j > len(b.containers) {
-			j = len(b.containers)
-		}
+		// end's container did not exist
+		// set j to the index of the first container with values higher than end (or len(containers))
+		j = -j - 1
 	} else {
+		// end's container exists, count it up to end
 		n += uint64(b.containers[j].countRange(0, int(lowbits(end))))
 	}
 
 	// Count containers in between.
-	for x := i + 1; x < j; x++ {
-		// Ensure that current container is inside the requested range since
-		// keys do not have to be consecutive
-		if ekey < b.keys[x] {
-			break
-		}
+	for x := i; x < j; x++ {
 		n += uint64(b.containers[x].n)
-
 	}
 
 	return n

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -235,7 +235,7 @@ func (b *Bitmap) CountRange(start, end uint64) (n uint64) {
 	// Count containers in between.
 	for x := i + 1; x < j; x++ {
 		// Ensure that current container is inside the requested range since
-		// keys to not have to be consecutive
+		// keys do not have to be consecutive
 		if ekey < b.keys[x] {
 			break
 		}

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2865,7 +2865,8 @@ func (*op) size() int { return 1 + 8 + 4 }
 func highbits(v uint64) uint64 { return uint64(v >> 16) }
 func lowbits(v uint64) uint16  { return uint16(v & 0xFFFF) }
 
-// search32 returns the index of v in a.
+// search32 returns the index of value in a. If value is not found, it works the
+// same way as search64.
 func search32(a []uint16, value uint16) int {
 	// Optimize for elements and the last element.
 	n := len(a)
@@ -2902,7 +2903,13 @@ func search32(a []uint16, value uint16) int {
 	return -(lo + 1)
 }
 
-// search64 returns the index of v in a.
+// search64 returns the index of value in a. If value is not found, -1 * (1 +
+// the index where v would be if it were inserted) is returned. This is done in
+// order to both signal that value was not found (negative number), and also
+// return information about where v would go if it were inserted. The +1 offset
+// is necessary due to the case where v is not found, but would go at index 0.
+// since negative 0 is no different from positive 0, we offset the returned
+// negative indices by 1. See the test for this function for examples.
 func search64(a []uint64, value uint64) int {
 	// Optimize for elements and the last element.
 	n := len(a)

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -2310,3 +2310,81 @@ func Test_BufBitmapIterator_UnreadPanic(t *testing.T) {
 	itr.unread()
 	itr.unread()
 }
+
+func TestSearc64(t *testing.T) {
+	tests := []struct {
+		a     []uint64
+		value uint64
+		exp   int
+	}{
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 5,
+			exp:   1,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 1,
+			exp:   0,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 0,
+			exp:   -1,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 2,
+			exp:   -2,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 7,
+			exp:   -3,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 11,
+			exp:   -4,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 13,
+			exp:   -5,
+		},
+		{
+			a:     []uint64{1, 5, 10, 12},
+			value: 3843534,
+			exp:   -5,
+		},
+		{
+			a:     []uint64{},
+			value: 3843534,
+			exp:   -1,
+		},
+		{
+			a:     []uint64{},
+			value: 0,
+			exp:   -1,
+		},
+		{
+			a:     []uint64{0},
+			value: 0,
+			exp:   0,
+		},
+		{
+			a:     []uint64{0},
+			value: 1,
+			exp:   -2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%d in %v", test.value, test.a), func(t *testing.T) {
+			actual := search64(test.a, test.value)
+			if actual != test.exp {
+				t.Errorf("got: %d, exp: %d", actual, test.exp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

A few bugs in Bitmap.CountRange code. Both occurred in the case where `search64` returned a negative number because the container key was not found in the list of container keys. The negative number returned is `-1 * (<index where the number should be> + 1)` That  `+ 1` was not being taken into account in the CountRange method, although it is taken into account at other locations where `search64` is used in roaring.go. The reason `search64` doesn't just return the negative index is because the index might be 0 in which case there would be no way to distinguish between "value was found at position 0" and "value was not found but would be located at position 0" 

Fixes #770 and one other bug which was discovered during the process but not ticketed.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
