### PR TITLE
Fix infinite loop in bitmap-to-array conversion.

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1992,6 +1992,10 @@ func intersectBitmapRun(a, b *container) *container {
 				if a.bitmapContains(i) {
 					output.array = append(output.array, i)
 				}
+				// If the run ends the container, break to avoid an infinite loop.
+				if i == 65535 {
+					break
+				}
 			}
 		}
 		output.n = len(output.array)

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -623,7 +623,7 @@ func TestIntersectBitmapRunArray(t *testing.T) {
 		},
 		{
 			bitmap: []uint64{0xFFFFFFFFFFFFFFFF, 1, 1, 1, 0xA, 1, 1, 0, 1},
-			runs:   []interval16{{start: 63, last: 10000}},
+			runs:   []interval16{{start: 63, last: 10000}, {start: 65000, last: 65535}},
 			exp:    []uint16{63, 64, 128, 192, 257, 259, 320, 384, 512},
 			expN:   9,
 		},


### PR DESCRIPTION
## Overview

When a run ended the container (i.e. contained column 65535), then the for loop
would increment the 16-bit value to 0, at which point it was still <= 65535.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
