### PR TITLE
set container.n in differenceRunRun

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2621,6 +2621,7 @@ func differenceRunRun(a, b *container) *container {
 		}
 	}
 
+	output.n = output.count()
 	return output
 }
 

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -1601,6 +1601,7 @@ func TestDifferenceRunRun(t *testing.T) {
 		aruns []interval16
 		bruns []interval16
 		exp   []interval16
+		expn  int
 	}{
 		{
 			// this tests all six overlap combinations
@@ -1609,6 +1610,7 @@ func TestDifferenceRunRun(t *testing.T) {
 			aruns: []interval16{{start: 3, last: 6}, {start: 13, last: 16}, {start: 24, last: 26}, {start: 33, last: 38}, {start: 43, last: 46}, {start: 53, last: 56}},
 			bruns: []interval16{{start: 1, last: 8}, {start: 11, last: 14}, {start: 21, last: 23}, {start: 35, last: 37}, {start: 44, last: 48}, {start: 57, last: 59}},
 			exp:   []interval16{{start: 15, last: 16}, {start: 24, last: 26}, {start: 33, last: 34}, {start: 38, last: 38}, {start: 43, last: 43}, {start: 53, last: 56}},
+			expn:  13,
 		},
 	}
 	for i, test := range tests {
@@ -1619,6 +1621,9 @@ func TestDifferenceRunRun(t *testing.T) {
 		ret := differenceRunRun(a, b)
 		if !reflect.DeepEqual(ret.runs, test.exp) {
 			t.Fatalf("test #%v expected %v, but got %v", i, test.exp, ret.runs)
+		}
+		if ret.n != test.expn {
+			t.Fatalf("test #%v expected n=%v, but got n=%v", i, test.expn, ret.n)
 		}
 	}
 }


### PR DESCRIPTION
## Overview
The method `differenceRunRun` was creating an output container (with default n=0), and n was never getting updated. Normally this was handled by the `differenceRunIterator`, but that's not used in `differenceRunRun`.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
