### PR TITLE
Enables auto-creating the schema on imports; Resolves #765

### DIFF
--- a/client.go
+++ b/client.go
@@ -339,6 +339,22 @@ func (c *Client) Import(ctx context.Context, index, frame string, slice uint64, 
 	return nil
 }
 
+func (c *Client) EnsureIndex(ctx context.Context, name string, options IndexOptions) error {
+	err := c.CreateIndex(ctx, name, options)
+	if err == nil || err == ErrIndexExists {
+		return nil
+	}
+	return err
+}
+
+func (c *Client) EnsureFrame(ctx context.Context, indexName string, frameName string, options FrameOptions) error {
+	err := c.CreateFrame(ctx, indexName, frameName, options)
+	if err == nil || err == ErrFrameExists {
+		return nil
+	}
+	return err
+}
+
 // MarshalImportPayload marshalls the import parameters into a protobuf byte slice.
 func MarshalImportPayload(index, frame string, slice uint64, bits []Bit) ([]byte, error) {
 	// Separate row and column IDs to reduce allocations.

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/ctl"
 )
 
@@ -49,12 +50,20 @@ omitted. If it is present then its format should be YYYY-MM-DDTHH:MM.
 			return nil
 		},
 	}
+
 	flags := importCmd.Flags()
 	flags.StringVarP(&Importer.Host, "host", "", "localhost:10101", "host:port of Pilosa.")
 	flags.StringVarP(&Importer.Index, "index", "i", "", "Pilosa index to import into.")
 	flags.StringVarP(&Importer.Frame, "frame", "f", "", "Frame to import into.")
 	flags.IntVarP(&Importer.BufferSize, "buffer-size", "s", 10000000, "Number of bits to buffer/sort before importing.")
 	flags.BoolVarP(&Importer.Sort, "sort", "", false, "Enables sorting before import.")
+	flags.BoolVarP(&Importer.CreateSchema, "create", "e", false, "Create the schema if it does not exist before import.")
+	flags.Var(&Importer.IndexOptions.TimeQuantum, "index-time-quantum", "Time quantum for the index")
+	flags.Var(&Importer.FrameOptions.TimeQuantum, "frame-time-quantum", "Time quantum for the frame")
+	flags.BoolVar(&Importer.FrameOptions.InverseEnabled, "frame-inverse-enabled", false, "Enable inverse frame")
+	flags.BoolVar(&Importer.FrameOptions.RangeEnabled, "frame-range-enabled", false, "Enabled range encoded frame")
+	flags.StringVar(&Importer.FrameOptions.CacheType, "frame-cache-type", pilosa.CacheTypeRanked, "Cache type for the frame; valid values: none, lru, ranked")
+	flags.Uint32Var(&Importer.FrameOptions.CacheSize, "frame-cache-size", 50000, "Cache size for the frame")
 
 	return importCmd
 }

--- a/ctl/import_test.go
+++ b/ctl/import_test.go
@@ -71,11 +71,9 @@ func TestImportCommand_Run(t *testing.T) {
 	s.Handler.Holder = hldr.Holder
 	cm.Host = s.Host()
 
-	http.DefaultClient.Do(MustNewHTTPRequest("POST", s.URL+"/index/i", strings.NewReader("")))
-	http.DefaultClient.Do(MustNewHTTPRequest("POST", s.URL+"/index/i/frame/f", strings.NewReader("")))
-
 	cm.Index = "i"
 	cm.Frame = "f"
+	cm.CreateSchema = true
 	cm.Paths = []string{file.Name()}
 	err = cm.Run(ctx)
 	if err != nil {

--- a/time.go
+++ b/time.go
@@ -53,6 +53,23 @@ func (q TimeQuantum) Valid() bool {
 	}
 }
 
+// The following methods are required to implement pflag Value interface.
+
+// Set sets the time quantum value.
+func (q *TimeQuantum) Set(value string) error {
+	*q = TimeQuantum(value)
+	return nil
+}
+
+func (q TimeQuantum) String() string {
+	return string(q)
+}
+
+// Type returns the type of a time quantum value.
+func (q TimeQuantum) Type() string {
+	return "TimeQuantum"
+}
+
 // ParseTimeQuantum parses v into a time quantum.
 func ParseTimeQuantum(v string) (TimeQuantum, error) {
 	q := TimeQuantum(strings.ToUpper(v))


### PR DESCRIPTION
## Overview

Implements auto-creating the schema on import

Resolves #765 

Example:
```
$ pilosa import --sort --create -i repo -f stargazer stargazer.csv --frame-inverse-enabled --index-time-quantum YM --frame-cache-size 3000
```

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
