### PR TITLE
Don't include an equal sign in the string representation of a Condition

### DIFF
--- a/pql/ast.go
+++ b/pql/ast.go
@@ -161,7 +161,14 @@ func (c *Call) String() string {
 		if i > 0 {
 			buf.WriteString(", ")
 		}
-		fmt.Fprintf(&buf, "%v=%s", key, FormatValue(c.Args[key]))
+		// If the Arg value is a Condition, then don't include
+		// the equal sign in the string representation.
+		switch v := c.Args[key].(type) {
+		case *Condition:
+			fmt.Fprintf(&buf, "%v %s", key, v.String())
+		default:
+			fmt.Fprintf(&buf, "%v=%s", key, FormatValue(v))
+		}
 	}
 
 	// Write closing.

--- a/pql/ast_test.go
+++ b/pql/ast_test.go
@@ -28,6 +28,18 @@ func TestCall_String(t *testing.T) {
 			t.Fatalf("unexpected string: %s", s)
 		}
 	})
+	t.Run("With Args", func(t *testing.T) {
+		c := &pql.Call{
+			Name: "Range",
+			Args: map[string]interface{}{
+				"frame":  "f",
+				"field0": &pql.Condition{Op: pql.GTE, Value: 10},
+			},
+		}
+		if s := c.String(); s != `Range(field0 >= 10, frame="f")` {
+			t.Fatalf("unexpected string: %s", s)
+		}
+	})
 }
 
 // Ensure call can be converted into a string.


### PR DESCRIPTION
## Overview

Fixes a bug that was causing an error when parsing a range condition in a multi-node cluster.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
