### PR TITLE
Implements BETWEEN for Range queries.

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -644,7 +644,10 @@ func (f *Fragment) fieldRangeLT(bitDepth uint, predicate uint64, allowEquality b
 		}
 
 		// If bit is set then add columns for set bits to exclude.
-		keep = keep.Union(b.Difference(row))
+		// Don't bother to compute this on the final iteration.
+		if i > 0 {
+			keep = keep.Union(b.Difference(row))
+		}
 	}
 
 	return b, nil
@@ -676,7 +679,53 @@ func (f *Fragment) fieldRangeGT(bitDepth uint, predicate uint64, allowEquality b
 		}
 
 		// If bit is unset then add columns with set bit to keep.
-		keep = keep.Union(b.Intersect(row))
+		// Don't bother to compute this on the final iteration.
+		if i > 0 {
+			keep = keep.Union(b.Intersect(row))
+		}
+	}
+
+	return b, nil
+}
+
+func (f *Fragment) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
+	return f.fieldRangeBetween(bitDepth, predicateMin, predicateMax)
+}
+
+func (f *Fragment) fieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
+	b := f.Row(uint64(bitDepth))
+	keep1 := NewBitmap() // GTE
+	keep2 := NewBitmap() // LTE
+
+	// Filter any bits that don't match the current bit value.
+	for i := int(bitDepth - 1); i >= 0; i-- {
+		row := f.Row(uint64(i))
+		bit1 := (predicateMin >> uint(i)) & 1
+		bit2 := (predicateMax >> uint(i)) & 1
+
+		// GTE predicateMin
+		// If bit is set then remove all unset columns not already kept.
+		if bit1 == 1 {
+			b = b.Difference(b.Difference(row).Difference(keep1))
+		} else {
+			// If bit is unset then add columns with set bit to keep.
+			// Don't bother to compute this on the final iteration.
+			if i > 0 {
+				keep1 = keep1.Union(b.Intersect(row))
+			}
+		}
+
+		// LTE predicateMin
+		// If bit is zero then remove all set columns not in excluded bitmap.
+		if bit2 == 0 {
+			b = b.Difference(row.Difference(keep2))
+		} else {
+			// If bit is set then add columns for set bits to exclude.
+			// Don't bother to compute this on the final iteration.
+			if i > 0 {
+				keep2 = keep2.Union(b.Difference(row))
+			}
+		}
 	}
 
 	return b, nil

--- a/fragment.go
+++ b/fragment.go
@@ -689,10 +689,6 @@ func (f *Fragment) fieldRangeGT(bitDepth uint, predicate uint64, allowEquality b
 }
 
 func (f *Fragment) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
-	return f.fieldRangeBetween(bitDepth, predicateMin, predicateMax)
-}
-
-func (f *Fragment) fieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
 	b := f.Row(uint64(bitDepth))
 	keep1 := NewBitmap() // GTE
 	keep2 := NewBitmap() // LTE

--- a/fragment_test.go
+++ b/fragment_test.go
@@ -378,6 +378,54 @@ func TestFragment_FieldRange(t *testing.T) {
 			t.Fatalf("unexpected bits: %+v", b.Bits())
 		}
 	})
+
+	t.Run("BETWEEN", func(t *testing.T) {
+		f := test.MustOpenFragment("i", "f", pilosa.ViewStandard, 0, "")
+		defer f.Close()
+
+		// Set values.
+		if _, err := f.SetFieldValue(1000, bitDepth, 382); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(2000, bitDepth, 300); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(3000, bitDepth, 2817); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(4000, bitDepth, 301); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(5000, bitDepth, 1); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(6000, bitDepth, 0); err != nil {
+			t.Fatal(err)
+		}
+
+		// Query for fields greater than (ending with unset bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 300, 2817); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 2000, 3000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+
+		// Query for fields greater than (ending with set bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 301, 2817); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 3000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+
+		// Query for fields greater than or equal to (ending with unset bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 301, 2816); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+
+		// Query for fields greater than or equal to (ending with set bit).
+		if b, err := f.FieldRangeBetween(bitDepth, 300, 2816); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 2000, 4000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+	})
 }
 
 // Ensure a fragment can snapshot correctly.

--- a/frame_test.go
+++ b/frame_test.go
@@ -16,9 +16,11 @@ package pilosa_test
 
 import (
 	"io/ioutil"
+	"reflect"
 	"testing"
 
 	"github.com/pilosa/pilosa"
+	"github.com/pilosa/pilosa/pql"
 	"github.com/pilosa/pilosa/test"
 )
 
@@ -339,4 +341,131 @@ func TestFrame_DeleteView(t *testing.T) {
 	} else if view == view2 {
 		t.Fatal("failed to create new view")
 	}
+}
+
+// Ensure a field can adjust to its baseValue.
+func TestField_BaseValue(t *testing.T) {
+	f0 := &pilosa.Field{
+		Name: "f0",
+		Type: pilosa.FieldTypeInt,
+		Min:  -100,
+		Max:  900,
+	}
+	f1 := &pilosa.Field{
+		Name: "f1",
+		Type: pilosa.FieldTypeInt,
+		Min:  0,
+		Max:  1000,
+	}
+
+	f2 := &pilosa.Field{
+		Name: "f2",
+		Type: pilosa.FieldTypeInt,
+		Min:  100,
+		Max:  1100,
+	}
+
+	t.Run("Normal Condition", func(t *testing.T) {
+
+		for _, tt := range []struct {
+			f             *pilosa.Field
+			op            pql.Token
+			val           int64
+			expBaseValue  uint64
+			expOutOfRange bool
+		}{
+			// LT
+			{f0, pql.LT, 5, 105, false},
+			{f0, pql.LT, -8, 92, false},
+			{f0, pql.LT, -108, 0, true},
+			{f0, pql.LT, 1005, 1000, false},
+			{f0, pql.LT, 0, 100, false},
+
+			{f1, pql.LT, 5, 5, false},
+			{f1, pql.LT, -8, 0, true},
+			{f1, pql.LT, 1005, 1000, false},
+			{f1, pql.LT, 0, 0, false},
+
+			{f2, pql.LT, 5, 0, true},
+			{f2, pql.LT, -8, 0, true},
+			{f2, pql.LT, 105, 5, false},
+			{f2, pql.LT, 1105, 1000, false},
+
+			// GT
+			{f0, pql.GT, -105, 0, false},
+			{f0, pql.GT, 5, 105, false},
+			{f0, pql.GT, 905, 0, true},
+			{f0, pql.GT, 0, 100, false},
+
+			{f1, pql.GT, 5, 5, false},
+			{f1, pql.GT, -8, 0, false},
+			{f1, pql.GT, 1005, 0, true},
+			{f1, pql.GT, 0, 0, false},
+
+			{f2, pql.GT, 5, 0, false},
+			{f2, pql.GT, -8, 0, false},
+			{f2, pql.GT, 105, 5, false},
+			{f2, pql.GT, 1105, 0, true},
+
+			// EQ
+			{f0, pql.EQ, -105, 0, true},
+			{f0, pql.EQ, 5, 105, false},
+			{f0, pql.EQ, 905, 0, true},
+			{f0, pql.EQ, 0, 100, false},
+
+			{f1, pql.EQ, 5, 5, false},
+			{f1, pql.EQ, -8, 0, true},
+			{f1, pql.EQ, 1005, 0, true},
+			{f1, pql.EQ, 0, 0, false},
+
+			{f2, pql.EQ, 5, 0, true},
+			{f2, pql.EQ, -8, 0, true},
+			{f2, pql.EQ, 105, 5, false},
+			{f2, pql.EQ, 1105, 0, true},
+		} {
+			bv, oor := tt.f.BaseValue(tt.op, tt.val)
+			if oor != tt.expOutOfRange {
+				t.Fatalf("baseValue calculation on %s op %s, expected outOfRange %v, got %v", tt.f.Name, tt.op, tt.expOutOfRange, oor)
+			} else if !reflect.DeepEqual(bv, tt.expBaseValue) {
+				t.Fatalf("baseValue calculation on %s, expected value %v, got %v", tt.f.Name, tt.expBaseValue, bv)
+			}
+		}
+	})
+
+	t.Run("Betwween Condition", func(t *testing.T) {
+		for _, tt := range []struct {
+			f               *pilosa.Field
+			predMin         int64
+			predMax         int64
+			expBaseValueMin uint64
+			expBaseValueMax uint64
+			expOutOfRange   bool
+		}{
+
+			{f0, -205, -105, 0, 0, true},
+			{f0, -105, 80, 0, 180, false},
+			{f0, 5, 20, 105, 120, false},
+			{f0, 20, 1005, 120, 1000, false},
+			{f0, 1005, 2000, 0, 0, true},
+
+			{f1, -105, -5, 0, 0, true},
+			{f1, -5, 20, 0, 20, false},
+			{f1, 5, 20, 5, 20, false},
+			{f1, 20, 1005, 20, 1000, false},
+			{f1, 1005, 2000, 0, 0, true},
+
+			{f2, 5, 95, 0, 0, true},
+			{f2, 95, 120, 0, 20, false},
+			{f2, 105, 120, 5, 20, false},
+			{f2, 120, 1105, 20, 1000, false},
+			{f2, 1105, 2000, 0, 0, true},
+		} {
+			min, max, oor := tt.f.BaseValueBetween(tt.predMin, tt.predMax)
+			if oor != tt.expOutOfRange {
+				t.Fatalf("baseValueBetween calculation on %s, expected outOfRange %v, got %v", tt.f.Name, tt.expOutOfRange, oor)
+			} else if !reflect.DeepEqual(min, tt.expBaseValueMin) || !reflect.DeepEqual(max, tt.expBaseValueMax) {
+				t.Fatalf("baseValueBetween calculation on %s, expected min/max %v/%v, got %v/%v", tt.f.Name, tt.expBaseValueMin, tt.expBaseValueMax, min, max)
+			}
+		}
+	})
 }

--- a/pilosa.go
+++ b/pilosa.go
@@ -60,6 +60,7 @@ var (
 	ErrFieldValueTooLow       = errors.New("field value too low")
 	ErrFieldValueTooHigh      = errors.New("field value too high")
 	ErrInvalidRangeOperation  = errors.New("invalid range operation")
+	ErrInvalidBetweenValue    = errors.New("invalid value for between operation")
 
 	ErrInvalidView      = errors.New("invalid view")
 	ErrInvalidCacheType = errors.New("invalid cache type")

--- a/pql/ast.go
+++ b/pql/ast.go
@@ -220,6 +220,31 @@ func (cond *Condition) String() string {
 	return fmt.Sprintf("%s %s", cond.Op.String(), FormatValue(cond.Value))
 }
 
+// IntSliceValue reads cond.Value as a slice of uint64.
+// If the value is a slice of uint64 it will convert
+// it to []int64. Otherwise, if it is not a []int64 it will return an error.
+func (cond *Condition) IntSliceValue() ([]int64, error) {
+	val := cond.Value
+
+	switch tval := val.(type) {
+	case []interface{}:
+		ret := make([]int64, len(tval))
+		for i, v := range tval {
+			switch tv := v.(type) {
+			case int64:
+				ret[i] = tv
+			case uint64:
+				ret[i] = int64(tv)
+			default:
+				return nil, fmt.Errorf("unexpected value type %T in IntSliceValue, val %v", tv, tv)
+			}
+		}
+		return ret, nil
+	default:
+		return nil, fmt.Errorf("unexpected type %T in IntSliceValue, val %v", tval, tval)
+	}
+}
+
 func FormatValue(v interface{}) string {
 	switch v := v.(type) {
 	case string:

--- a/pql/ast_test.go
+++ b/pql/ast_test.go
@@ -15,6 +15,7 @@
 package pql_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/pilosa/pilosa/pql"
@@ -26,6 +27,31 @@ func TestCall_String(t *testing.T) {
 		c := &pql.Call{Name: "Bitmap"}
 		if s := c.String(); s != `Bitmap()` {
 			t.Fatalf("unexpected string: %s", s)
+		}
+	})
+}
+
+// Ensure condition can handle values for BETWEEN operator.
+func TestCondition_Value(t *testing.T) {
+	t.Run("Between Values", func(t *testing.T) {
+		for _, tt := range []struct {
+			val []interface{}
+			exp []int64
+		}{
+			{[]interface{}{int64(4), int64(8)}, []int64{4, 8}},
+			{[]interface{}{uint64(4), uint64(8)}, []int64{4, 8}},
+			{[]interface{}{uint64(1), uint64(2), uint64(3)}, []int64{1, 2, 3}},
+		} {
+			c := &pql.Condition{
+				Op:    pql.BETWEEN,
+				Value: tt.val,
+			}
+			v, err := c.IntSliceValue()
+			if err != nil {
+				t.Fatal(err)
+			} else if !reflect.DeepEqual(v, tt.exp) {
+				t.Fatalf("invalid between values. expected: %v, got %v", tt.exp, v)
+			}
 		}
 	})
 }

--- a/pql/parser.go
+++ b/pql/parser.go
@@ -165,7 +165,7 @@ func (p *Parser) parseArgs() (map[string]interface{}, error) {
 		var op Token
 		switch tok, pos, lit := p.scanIgnoreWhitespace(); tok {
 		case ASSIGN:
-		case EQ, LT, LTE, GT, GTE:
+		case EQ, LT, LTE, GT, GTE, BETWEEN:
 			op = tok
 		default:
 			return nil, parseErrorf(pos, "expected equals sign or comparison operator, found %q", lit)

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -172,7 +172,7 @@ func TestParser_Parse(t *testing.T) {
 
 	// Parse with condition arguments.
 	t.Run("WithCondition", func(t *testing.T) {
-		q, err := pql.ParseString(`MyCall(key=foo, x == 12.25, y >= 100)`)
+		q, err := pql.ParseString(`MyCall(key=foo, x == 12.25, y >= 100, z >< [4,8])`)
 		if err != nil {
 			t.Fatal(err)
 		} else if !reflect.DeepEqual(q.Calls[0],
@@ -182,6 +182,7 @@ func TestParser_Parse(t *testing.T) {
 					"key": "foo",
 					"x":   &pql.Condition{Op: pql.EQ, Value: 12.25},
 					"y":   &pql.Condition{Op: pql.GTE, Value: int64(100)},
+					"z":   &pql.Condition{Op: pql.BETWEEN, Value: []interface{}{int64(4), int64(8)}},
 				},
 			},
 		) {

--- a/pql/scanner.go
+++ b/pql/scanner.go
@@ -73,8 +73,11 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 		s.unread()
 		return LT, pos, string(ch)
 	case '>':
-		if next := s.read(); next == '=' {
+		next := s.read()
+		if next == '=' {
 			return GTE, pos, ">="
+		} else if next == '<' {
+			return BETWEEN, pos, "><"
 		}
 		s.unread()
 		return GT, pos, string(ch)

--- a/pql/scanner_test.go
+++ b/pql/scanner_test.go
@@ -42,6 +42,7 @@ func TestScanner_Scan(t *testing.T) {
 		{name: "LTE", s: `<=`, tok: pql.LTE, lit: `<=`},
 		{name: "GT", s: `>`, tok: pql.GT, lit: `>`},
 		{name: "GTE", s: `>=`, tok: pql.GTE, lit: `>=`},
+		{name: "BETWEEN", s: `><`, tok: pql.BETWEEN, lit: `><`},
 		{name: "COMMA", s: `,`, tok: pql.COMMA, lit: `,`},
 		{name: "LPAREN", s: `(`, tok: pql.LPAREN, lit: `(`},
 		{name: "RPAREN", s: `)`, tok: pql.RPAREN, lit: `)`},

--- a/pql/token.go
+++ b/pql/token.go
@@ -37,17 +37,18 @@ const (
 	ALL
 	keyword_end
 
-	ASSIGN // =
-	EQ     // ==
-	LT     // <
-	LTE    // <=
-	GT     // >
-	GTE    // >=
-	COMMA  // ,
-	LPAREN // (
-	RPAREN // )
-	LBRACK // (
-	RBRACK // )
+	ASSIGN  // =
+	EQ      // ==
+	LT      // <
+	LTE     // <=
+	GT      // >
+	GTE     // >=
+	BETWEEN // ><
+	COMMA   // ,
+	LPAREN  // (
+	RPAREN  // )
+	LBRACK  // (
+	RBRACK  // )
 )
 
 var tokens = [...]string{
@@ -61,17 +62,18 @@ var tokens = [...]string{
 
 	ALL: "ALL",
 
-	ASSIGN: "=",
-	EQ:     "==",
-	LT:     "<",
-	LTE:    "<=",
-	GT:     ">",
-	GTE:    ">=",
-	COMMA:  ",",
-	LPAREN: "(",
-	RPAREN: ")",
-	LBRACK: "(",
-	RBRACK: ")",
+	ASSIGN:  "=",
+	EQ:      "==",
+	LT:      "<",
+	LTE:     "<=",
+	GT:      ">",
+	GTE:     ">=",
+	BETWEEN: "><",
+	COMMA:   ",",
+	LPAREN:  "(",
+	RPAREN:  ")",
+	LBRACK:  "(",
+	RBRACK:  ")",
 }
 
 var keywords map[string]Token

--- a/view.go
+++ b/view.go
@@ -329,6 +329,20 @@ func (v *View) FieldRange(op pql.Token, bitDepth uint, predicate uint64) (*Bitma
 	return bm, nil
 }
 
+// FieldRangeBetween returns bitmaps with a field value encoding matching any
+// value between predicateMin and predicateMax.
+func (v *View) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
+	bm := NewBitmap()
+	for _, frag := range v.Fragments() {
+		other, err := frag.FieldRangeBetween(bitDepth, predicateMin, predicateMax)
+		if err != nil {
+			return nil, err
+		}
+		bm = bm.Union(other)
+	}
+	return bm, nil
+}
+
 // IsInverseView returns true if the view is used for storing an inverted representation.
 func IsInverseView(name string) bool {
 	return strings.HasPrefix(name, ViewInverse)


### PR DESCRIPTION
The PQL looks like:
```
Range(frame=f, field0 >< [200,610])
```

One thing I noticed while implementing this is that it doesn't seem
like `FieldRange()` is used in either `Frame` or `View`; the Executor
calls `Fragment.FieldRange()` directly. The problem with this is that
the offset logic is calculated in the Frame, but since the Executor
doesn't go through Frame, then the Executor also has to calculate
the offset before calling `Fragment.FieldRange`. We should unify this
logic somewhere. Note, this applies to both `FieldRange` and
`FieldRangeBetween`.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
