### PR TITLE
rangeEnable bug: return ErrFrameFieldsNotAllowed if f.rangeEnabled

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -425,7 +425,7 @@ func (f *Frame) CreateField(field *Field) error {
 	defer f.mu.Unlock()
 
 	// Ensure frame supports fields.
-	if f.rangeEnabled {
+	if !f.rangeEnabled {
 		return ErrFrameFieldsNotAllowed
 	}
 
@@ -445,7 +445,7 @@ func (f *Frame) DeleteField(name string) error {
 	defer f.mu.Unlock()
 
 	// Ensure frame supports fields.
-	if f.rangeEnabled {
+	if !f.rangeEnabled {
 		return ErrFrameFieldsNotAllowed
 	}
 

--- a/index.go
+++ b/index.go
@@ -462,6 +462,9 @@ func (i *Index) createFrame(name string, opt FrameOptions) (*Frame, error) {
 	}
 	f.cacheType = opt.CacheType
 
+	// Set range enabled
+	f.rangeEnabled = opt.RangeEnabled
+
 	// Set options.
 	if opt.RowLabel != "" {
 		f.rowLabel = opt.RowLabel


### PR DESCRIPTION
## Overview

- frame's rangeEnable should set = true when creating a frame with option RangeEnable=True
- return ErrFrameFieldsNotAllowed when f.rangeEnabled=False

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
