### PR TITLE
Fix panic when iterating over an empty run container.

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -444,7 +444,6 @@ func (b *Bitmap) Difference(other *Bitmap) *Bitmap {
 			output.keys = append(output.keys, key)
 			output.containers = append(output.containers, container)
 		}
-
 	}
 	return output
 }
@@ -893,6 +892,13 @@ func (itr *Iterator) Next() (v uint64, eof bool) {
 			if itr.j == -1 {
 				itr.j++
 			}
+
+			// If the container is empty, move to the next container.
+			if len(c.runs) == 0 {
+				itr.i, itr.j = itr.i+1, -1
+				continue
+			}
+
 			r := c.runs[itr.j]
 			runLength := int(r.last - r.start)
 


### PR DESCRIPTION
## Overview

When the difference of two run containers resulted in an empty
container, that container would be a run container with no runs.
The Iterator was expected there to be at least on run in
`container.runs`. This fix protects against that and adds tests
for that case.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
