### PR TITLE
FieldNotNull for more efficient BETWEEN queries

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -720,7 +720,7 @@ func (e *Executor) executeFieldRangeSlice(ctx context.Context, index string, c *
 	// BETWEEN a,b(in)   BETWEEN/frag.FieldRangeBetween()
 	// BETWEEN a,b(out)  BETWEEN/frag.FieldNotNull()
 	// EQ <int>          frag.FieldRange
-	// NEQ <int>         (not implemented: frag.FieldRange)
+	// NEQ <int>         frag.FieldRange
 
 	// Handle `!= null`.
 	if cond.Op == pql.NEQ && cond.Value == nil {

--- a/executor_test.go
+++ b/executor_test.go
@@ -777,6 +777,13 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 		} else if !reflect.DeepEqual([]uint64{SliceWidth, SliceWidth + 1, SliceWidth + 2}, result[0].(*pilosa.Bitmap).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
+		// NEQ -<int>
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo != -20)`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+			//t.Fatalf("unexpected result: %s", spew.Sdump(result))
+			t.Fatalf("unexpected result: %s", result[0].(*pilosa.Bitmap).Bits())
+		}
 	})
 
 	t.Run("LT", func(t *testing.T) {

--- a/executor_test.go
+++ b/executor_test.go
@@ -764,6 +764,14 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 		}
 	})
 
+	t.Run("NEQ", func(t *testing.T) {
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo != null)`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result))
+		}
+	})
+
 	t.Run("LT", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo < 20)`), nil, nil); err != nil {
 			t.Fatal(err)

--- a/executor_test.go
+++ b/executor_test.go
@@ -796,6 +796,23 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 		}
 	})
 
+	t.Run("BETWEEN", func(t *testing.T) {
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo >< [1, 1000])`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result))
+		}
+	})
+
+	// Ensure that the FieldNotNull code path gets run.
+	t.Run("FieldNotNull", func(t *testing.T) {
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo >< [0, 1000])`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result))
+		}
+	})
+
 	t.Run("BelowMin", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo == 0)`), nil, nil); err != nil {
 			t.Fatal(err)

--- a/executor_test.go
+++ b/executor_test.go
@@ -765,9 +765,16 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	})
 
 	t.Run("NEQ", func(t *testing.T) {
+		// NEQ null
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo != null)`), nil, nil); err != nil {
 			t.Fatal(err)
 		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result))
+		}
+		// NEQ <int>
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo != 20)`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{SliceWidth, SliceWidth + 1, SliceWidth + 2}, result[0].(*pilosa.Bitmap).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})

--- a/fragment.go
+++ b/fragment.go
@@ -730,6 +730,11 @@ func (f *Fragment) fieldRangeGT(bitDepth uint, predicate uint64, allowEquality b
 	return b, nil
 }
 
+// FieldNotNull returns the not-null row (stored at bitDepth).
+func (f *Fragment) FieldNotNull(bitDepth uint) (*Bitmap, error) {
+	return f.Row(uint64(bitDepth)), nil
+}
+
 func (f *Fragment) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
 	b := f.Row(uint64(bitDepth))
 	keep1 := NewBitmap() // GTE

--- a/fragment.go
+++ b/fragment.go
@@ -619,6 +619,8 @@ func (f *Fragment) FieldRange(op pql.Token, bitDepth uint, predicate uint64) (*B
 	switch op {
 	case pql.EQ:
 		return f.fieldRangeEQ(bitDepth, predicate)
+	case pql.NEQ:
+		return f.fieldRangeNEQ(bitDepth, predicate)
 	case pql.LT, pql.LTE:
 		return f.fieldRangeLT(bitDepth, predicate, op == pql.LTE)
 	case pql.GT, pql.GTE:
@@ -643,6 +645,22 @@ func (f *Fragment) fieldRangeEQ(bitDepth uint, predicate uint64) (*Bitmap, error
 			b = b.Difference(row)
 		}
 	}
+
+	return b, nil
+}
+
+func (f *Fragment) fieldRangeNEQ(bitDepth uint, predicate uint64) (*Bitmap, error) {
+	// Start with set of columns with values set.
+	b := f.Row(uint64(bitDepth))
+
+	// Get the equal bitmap.
+	eq, err := f.fieldRangeEQ(bitDepth, predicate)
+	if err != nil {
+		return nil, err
+	}
+
+	// Not-null minus the equal bitmap.
+	b = b.Difference(eq)
 
 	return b, nil
 }

--- a/fragment_test.go
+++ b/fragment_test.go
@@ -283,6 +283,29 @@ func TestFragment_FieldRange(t *testing.T) {
 		}
 	})
 
+	t.Run("NEQ", func(t *testing.T) {
+		f := test.MustOpenFragment("i", "f", pilosa.ViewStandard, 0, "")
+		defer f.Close()
+
+		// Set values.
+		if _, err := f.SetFieldValue(1000, bitDepth, 382); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(2000, bitDepth, 300); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(3000, bitDepth, 2818); err != nil {
+			t.Fatal(err)
+		} else if _, err := f.SetFieldValue(4000, bitDepth, 300); err != nil {
+			t.Fatal(err)
+		}
+
+		// Query for inequality.
+		if b, err := f.FieldRange(pql.NEQ, bitDepth, 300); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual(b.Bits(), []uint64{1000, 3000}) {
+			t.Fatalf("unexpected bits: %+v", b.Bits())
+		}
+	})
+
 	t.Run("LT", func(t *testing.T) {
 		f := test.MustOpenFragment("i", "f", pilosa.ViewStandard, 0, "")
 		defer f.Close()

--- a/frame.go
+++ b/frame.go
@@ -1119,7 +1119,7 @@ func (f *Field) BaseValue(op pql.Token, value int64) (baseValue uint64, outOfRan
 		} else {
 			baseValue = uint64(value - f.Min)
 		}
-	} else if op == pql.EQ {
+	} else if op == pql.EQ || op == pql.NEQ {
 		if value < f.Min || value > f.Max {
 			return baseValue, true
 		}

--- a/pql/parser.go
+++ b/pql/parser.go
@@ -165,7 +165,7 @@ func (p *Parser) parseArgs() (map[string]interface{}, error) {
 		var op Token
 		switch tok, pos, lit := p.scanIgnoreWhitespace(); tok {
 		case ASSIGN:
-		case EQ, LT, LTE, GT, GTE, BETWEEN:
+		case EQ, NEQ, LT, LTE, GT, GTE, BETWEEN:
 			op = tok
 		default:
 			return nil, parseErrorf(pos, "expected equals sign or comparison operator, found %q", lit)

--- a/pql/parser_test.go
+++ b/pql/parser_test.go
@@ -172,7 +172,7 @@ func TestParser_Parse(t *testing.T) {
 
 	// Parse with condition arguments.
 	t.Run("WithCondition", func(t *testing.T) {
-		q, err := pql.ParseString(`MyCall(key=foo, x == 12.25, y >= 100, z >< [4,8])`)
+		q, err := pql.ParseString(`MyCall(key=foo, x == 12.25, y >= 100, z >< [4,8], m != null)`)
 		if err != nil {
 			t.Fatal(err)
 		} else if !reflect.DeepEqual(q.Calls[0],
@@ -183,6 +183,7 @@ func TestParser_Parse(t *testing.T) {
 					"x":   &pql.Condition{Op: pql.EQ, Value: 12.25},
 					"y":   &pql.Condition{Op: pql.GTE, Value: int64(100)},
 					"z":   &pql.Condition{Op: pql.BETWEEN, Value: []interface{}{int64(4), int64(8)}},
+					"m":   &pql.Condition{Op: pql.NEQ, Value: nil},
 				},
 			},
 		) {

--- a/pql/scanner.go
+++ b/pql/scanner.go
@@ -66,6 +66,12 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 		}
 		s.unread()
 		return ASSIGN, pos, string(ch)
+	case '!':
+		if next := s.read(); next == '=' {
+			return NEQ, pos, "!="
+		}
+		s.unread()
+		return ASSIGN, pos, string(ch)
 	case '<':
 		if next := s.read(); next == '=' {
 			return LTE, pos, "<="

--- a/pql/scanner_test.go
+++ b/pql/scanner_test.go
@@ -38,6 +38,7 @@ func TestScanner_Scan(t *testing.T) {
 
 		{name: "ASSIGN", s: `=`, tok: pql.ASSIGN, lit: `=`},
 		{name: "EQ", s: `==`, tok: pql.EQ, lit: `==`},
+		{name: "NEQ", s: `!=`, tok: pql.NEQ, lit: `!=`},
 		{name: "LT", s: `<`, tok: pql.LT, lit: `<`},
 		{name: "LTE", s: `<=`, tok: pql.LTE, lit: `<=`},
 		{name: "GT", s: `>`, tok: pql.GT, lit: `>`},

--- a/pql/token.go
+++ b/pql/token.go
@@ -39,6 +39,7 @@ const (
 
 	ASSIGN  // =
 	EQ      // ==
+	NEQ     // !=
 	LT      // <
 	LTE     // <=
 	GT      // >
@@ -64,6 +65,7 @@ var tokens = [...]string{
 
 	ASSIGN:  "=",
 	EQ:      "==",
+	NEQ:     "!=",
 	LT:      "<",
 	LTE:     "<=",
 	GT:      ">",


### PR DESCRIPTION
## Overview

In the example use-case where a `field` represents a calendar day, and the field's value range is `[0-1439]` such that a value represents a particular minute of the day, then if we want to support a range query that spans days, we can make the query more efficient by returning the `not-null` rows for any full field (day) in the middle of the range.

For example, if we want to query a 48-hour range like `2017-10-03T10:28 to 2017-10-05T10:27`, then we effectively want this:
```
Union(
  Range(frame=f, d20171003 >= 628),
  Range(frame=f, d20171004 >< [0, 1439]),
  Range(frame=f, d20171005 < 628)
)
```
The first pass at this PR doesn't change the query language. The second Range() query in the example above will return the `not-null` row for that field. This applies to any case where the query range is either equal to or outside of the field's min/max values.

Fixes #869

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
