### PR TITLE
Fix dot in env

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -91,7 +91,7 @@ func setAllConfig(v *viper.Viper, flags *pflag.FlagSet, envPrefix string) error 
 
 	// add env to viper
 	v.SetEnvPrefix(envPrefix)
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 	v.AutomaticEnv()
 
 	c := v.GetString("config")

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -45,7 +45,7 @@ func TestServerConfig(t *testing.T) {
 		// TEST 0
 		{
 			args: []string{"server", "--data-dir", actualDataDir, "--cluster.hosts", "example.com:10111,example.com:10110", "--bind", "example.com:10111"},
-			env:  map[string]string{"PILOSA_DATA_DIR": "/tmp/myEnvDatadir", "PILOSA_CLUSTER.POLL_INTERVAL": "3m2s"},
+			env:  map[string]string{"PILOSA_DATA_DIR": "/tmp/myEnvDatadir", "PILOSA_CLUSTER_POLL_INTERVAL": "3m2s"},
 			cfgFileContent: `
 	data-dir = "/tmp/myFileDatadir"
 	bind = "localhost:0"
@@ -71,7 +71,7 @@ func TestServerConfig(t *testing.T) {
 		// TEST 1
 		{
 			args: []string{"server", "--anti-entropy.interval", "9m0s"},
-			env:  map[string]string{"PILOSA_CLUSTER.HOSTS": "example.com:1110,example.com:1111", "PILOSA_BIND": "example.com:1110"},
+			env:  map[string]string{"PILOSA_CLUSTER_HOSTS": "example.com:1110,example.com:1111", "PILOSA_BIND": "example.com:1110"},
 			cfgFileContent: `
 	bind = "localhost:0"
 	data-dir = "` + actualDataDir + `"
@@ -94,7 +94,7 @@ func TestServerConfig(t *testing.T) {
 		// TEST 2
 		{
 			args: []string{"server", "--log-path", logFile.Name(), "--cluster.type", "static"},
-			env:  map[string]string{"PILOSA_PROFILE.CPU_TIME": "1m"},
+			env:  map[string]string{"PILOSA_PROFILE_CPU_TIME": "1m"},
 			cfgFileContent: `
 	bind = "localhost:19444"
 	data-dir = "` + actualDataDir + `"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: Interval at which the cluster will run its anti-entropy routine which makes sure that all replicas of each fragment are in sync.
 * Flag: `--anti-entropy.interval="10m0s"`
-* Env: `PILOSA_ANTI_ENTROPY.INTERVAL="10m0s"`
+* Env: `PILOSA_ANTI_ENTROPY_INTERVAL="10m0s"`
 * Config:
 
     ```toml
@@ -102,7 +102,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: List of hosts in the cluster. Multiple hosts should be comma separated in the flag and env forms.
 * Flag: `--cluster.hosts="localhost:10101"`
-* Env: `PILOSA_CLUSTER.HOSTS="localhost:10101"`
+* Env: `PILOSA_CLUSTER_HOSTS="localhost:10101"`
 * Config:
 
     ```toml
@@ -114,7 +114,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: Polling interval for cluster.
 * Flag: `cluster.poll-interval="1m0s"`
-* Env: `PILOSA_CLUSTER.POLL_INTERVAL="1m0s"`
+* Env: `PILOSA_CLUSTER_POLL_INTERVAL="1m0s"`
 * Config:
 
     ```toml
@@ -126,7 +126,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: Number of hosts each piece of data should be stored on. 
 * Flag: `cluster.replicas=1`
-* Env: `PILOSA_CLUSTER.REPLICAS=1`
+* Env: `PILOSA_CLUSTER_REPLICAS=1`
 * Config:
 
     ```toml
@@ -141,7 +141,7 @@ Any flag that has a value that is a comma separated list on the command line bec
   * http - Messages are transmitted over HTTP.
   * gossip - Messages are transmitted over TCP. Cluster status and node state are kept in sync via internode gossip.
 * Flag: `cluster.type="gossip"`
-* Env: `PILOSA_CLUSTER.TYPE="gossip"`
+* Env: `PILOSA_CLUSTER_TYPE="gossip"`
 * Config:
 
     ```toml
@@ -153,7 +153,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: If this is set to a path, collect a cpu profile and store it there.
 * Flag: `--profile.cpu="/path/to/somewhere"`
-* Env: `PILOSA_PROFILE.CPU="/path/to/somewhere"`
+* Env: `PILOSA_PROFILE_CPU="/path/to/somewhere"`
 * Config:
 
     ```toml
@@ -165,7 +165,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: Amount of time to collect cpu profiling data if `profile.cpu` is set.
 * Flag: `--profile.cpu-time="30s"`
-* Env: `PILOSA_PROFILE.CPU_TIME="30s"
+* Env: `PILOSA_PROFILE_CPU_TIME="30s"
 * Config:
 
     ```toml
@@ -175,7 +175,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 ##### Metric Service
 * Description: Which stats service to use (StatsD or ExpVar).
 * Flag: `--metric.service=statsd`
-* Env: `PILOSA_METRIC.SERVICE=statsd'
+* Env: `PILOSA_METRIC_SERVICE=statsd'
 * Config:
 
     ```toml
@@ -186,7 +186,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 ##### Metric Host
 * Description: Address of the StatsD service host.
 * Flag: `--metric.host=localhost:8125`
-* Env: `PILOSA_METRIC.HOST=localhost:8125'
+* Env: `PILOSA_METRIC_HOST=localhost:8125'
 * Config:
 
     ```toml
@@ -198,7 +198,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 * Description: Polling interval for runtime metrics.
 * Flag: `metric.poll-interval=”0m15s”`
-* Env: `PILOSA_METRIC.POLL_INTERVAL=0m15s`
+* Env: `PILOSA_METRIC_POLL_INTERVAL=0m15s`
 * Config:
 
     ```toml


### PR DESCRIPTION
## Overview

The dot (`.`) cannot be used in bash environment variable names, so any configuration item with a dot in it such as `cluster.hosts` wasn't available as an environment variable (``PILOSA_CLUSTER.HOSTS` is not a valid bash name). This PR replaces dot with underscore for environment variables, so `cluster.hosts` can be used as `PILOSA_CLUSTER_HOSTS` in bash.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
