### PR TITLE
added endpoint protection for cluster resize

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -186,7 +186,7 @@ func NewCluster() *Cluster {
 		closing:     make(chan struct{}),
 
 		LogOutput: os.Stderr,
-		prefect:   &DefaultSecurityManager{},
+		prefect:   &NopSecurityManager{},
 	}
 }
 
@@ -228,20 +228,20 @@ func (c *Cluster) NodeSet() []URI {
 }
 
 func (c *Cluster) setState(state string) {
-	if c.State != state { //only on new state, perform routing change
-		switch state {
-		case ClusterStateResizing:
-			c.prefect.SetRestricted()
-		case ClusterStateNormal:
-			c.prefect.SetNormal()
-			// Don't change routing for these new states
-			// ClusterStateStarting
-			// ResizeJobStateRunning
-			// ResizeJobStateDone
-			// ResizeJobStateAborted
-
-		}
+	// Ignore cases where the state hasn't changed.
+	if state == c.State {
+		return
 	}
+
+	switch state {
+	case ClusterStateResizing:
+		c.prefect.SetRestricted()
+	case ClusterStateNormal:
+		c.prefect.SetNormal()
+		// Don't change routing for these states:
+		// - ClusterStateStarting
+	}
+
 	c.State = state
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -167,6 +167,7 @@ type Cluster struct {
 	// Close management
 	wg      sync.WaitGroup
 	closing chan struct{}
+	prefect SecurityManager
 
 	// The writer for any logging.
 	LogOutput io.Writer
@@ -185,6 +186,7 @@ func NewCluster() *Cluster {
 		closing:     make(chan struct{}),
 
 		LogOutput: os.Stderr,
+		prefect:   &DefaultSecurityManager{},
 	}
 }
 
@@ -226,6 +228,20 @@ func (c *Cluster) NodeSet() []URI {
 }
 
 func (c *Cluster) setState(state string) {
+	if c.State != state { //only on new state, perform routing change
+		switch state {
+		case ClusterStateResizing:
+			c.prefect.SetRestricted()
+		case ClusterStateNormal:
+			c.prefect.SetNormal()
+			// Don't change routing for these new states
+			// ClusterStateStarting
+			// ResizeJobStateRunning
+			// ResizeJobStateDone
+			// ResizeJobStateAborted
+
+		}
+	}
 	c.State = state
 }
 

--- a/handler.go
+++ b/handler.go
@@ -125,6 +125,7 @@ func loadCommon(router *mux.Router, handler *Handler) {
 	router.PathPrefix("/debug/pprof/").Handler(http.DefaultServeMux).Methods("GET")
 	router.HandleFunc("/debug/vars", handler.handleExpvar).Methods("GET")
 	router.HandleFunc("/slices/max", handler.handleGetSlicesMax).Methods("GET") // TODO: deprecate, but it's being used by the client (for backups)
+	router.HandleFunc("/fragment/data", handler.handleGetFragmentData).Methods("GET")
 	router.HandleFunc("/hosts", handler.handleGetHosts).Methods("GET")
 }
 
@@ -141,7 +142,6 @@ func loadNormal(router *mux.Router, handler *Handler) {
 	router.HandleFunc("/export", handler.handleGetExport).Methods("GET")
 	router.HandleFunc("/fragment/block/data", handler.handleGetFragmentBlockData).Methods("GET")
 	router.HandleFunc("/fragment/blocks", handler.handleGetFragmentBlocks).Methods("GET")
-	router.HandleFunc("/fragment/data", handler.handleGetFragmentData).Methods("GET")
 	router.HandleFunc("/fragment/data", handler.handlePostFragmentData).Methods("POST")
 	router.HandleFunc("/fragment/nodes", handler.handleGetFragmentNodes).Methods("GET")
 	router.HandleFunc("/import", handler.handlePostImport).Methods("POST")

--- a/handler.go
+++ b/handler.go
@@ -95,25 +95,29 @@ func NewHandler() *Handler {
 	return handler
 }
 
-// BuildRouters creates a Gorilla Mux http routers for both normal and restricted enpoints.
+// BuildRouters creates Gorilla Mux http routers for both normal and restricted endpoints.
 func BuildRouters(handler *Handler) {
+	// Normal router.
 	router := mux.NewRouter()
 	loadCommon(router, handler)
 	loadNormal(router, handler)
 	handler.NormalRouter = router
+
+	// Restricted router.
 	router = mux.NewRouter()
 	loadCommon(router, handler)
 	loadRestricted(router, handler)
 	handler.RestrictedRouter = router
+
 	handler.SetNormal()
 }
 
-// SetNormal a method of the SecurityManager interface which provides normal URI routing
+// SetNormal is a method of the SecurityManager interface which provides normal URI routing.
 func (h *Handler) SetNormal() {
 	h.Router = h.NormalRouter
 }
 
-// SetRestricted a method of the SecurityManager interface which provides restricted URI routing
+// SetRestricted is a method of the SecurityManager interface which provides restricted URI routing.
 func (h *Handler) SetRestricted() {
 	h.Router = h.RestrictedRouter
 }

--- a/security_manager.go
+++ b/security_manager.go
@@ -1,0 +1,22 @@
+package pilosa
+
+// SecurityManager provides the ability to limit access to restricted endpoints
+// during cluster configuration
+type SecurityManager interface {
+	SetRestricted()
+	SetNormal()
+}
+
+// DefaultSecurityManager provides a no-op implimentation of the SecurityManager interface
+type DefaultSecurityManager struct {
+}
+
+// SetRestricted no-op
+func (sdm *DefaultSecurityManager) SetRestricted() {
+
+}
+
+// SetNormal no-op
+func (sdm *DefaultSecurityManager) SetNormal() {
+
+}

--- a/security_manager.go
+++ b/security_manager.go
@@ -1,22 +1,22 @@
 package pilosa
 
 // SecurityManager provides the ability to limit access to restricted endpoints
-// during cluster configuration
+// during cluster configuration.
 type SecurityManager interface {
 	SetRestricted()
 	SetNormal()
 }
 
-// DefaultSecurityManager provides a no-op implimentation of the SecurityManager interface
-type DefaultSecurityManager struct {
+// NopSecurityManager provides a no-op implementation of the SecurityManager interface.
+type NopSecurityManager struct {
 }
 
-// SetRestricted no-op
-func (sdm *DefaultSecurityManager) SetRestricted() {
+// SetRestricted no-op.
+func (sdm *NopSecurityManager) SetRestricted() {
 
 }
 
-// SetNormal no-op
-func (sdm *DefaultSecurityManager) SetNormal() {
+// SetNormal no-op.
+func (sdm *NopSecurityManager) SetNormal() {
 
 }


### PR DESCRIPTION
## Overview

In order to guarantee system state, only applicable endpoints are exposed.  This is achived by providing two different router mux, a restricted router and the normal router.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [x] Run tests and ensure they pass.
- [x] Build and run the code, performing any applicable integration testing.
