### PR TITLE
remove check that prohibits frames being ranked and range enabled

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -27,7 +27,8 @@
 [[projects]]
   name = "github.com/boltdb/bolt"
   packages = ["."]
-  revision = "4b1ebc1869ad66568b313d0dc410e2be72670dda"
+  revision = "2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8"
+  version = "v1.3.1"
 
 [[projects]]
   name = "github.com/davecgh/go-spew"
@@ -44,8 +45,8 @@
 [[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  revision = "100ba4e885062801d56799d78530b73b178a78f3"
+  version = "v0.4"
 
 [[projects]]
   branch = "master"
@@ -230,6 +231,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e8e78a7c61547d8f4d967c8deac9334b3151e7c10c4f7909e80758956e9c8204"
+  inputs-digest = "31c4441a0f52174a7a9e794fbcd7d1d752d4cdfe288d3b28ac588e6d2d5cfce6"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/index.go
+++ b/index.go
@@ -440,8 +440,6 @@ func (i *Index) createFrame(name string, opt FrameOptions) (*Frame, error) {
 	if opt.RangeEnabled {
 		if opt.InverseEnabled {
 			return nil, ErrInverseRangeNotAllowed
-		} else if opt.CacheType != "" && opt.CacheType != CacheTypeNone {
-			return nil, ErrRangeCacheNotAllowed
 		}
 	} else {
 		if len(opt.Fields) > 0 {

--- a/index_test.go
+++ b/index_test.go
@@ -140,14 +140,14 @@ func TestIndex_CreateFrame(t *testing.T) {
 			}
 		})
 
-		t.Run("ErrRangeCacheNotAllowed", func(t *testing.T) {
+		t.Run("ErrRangeCacheAllowed", func(t *testing.T) {
 			index := test.MustOpenIndex()
 			defer index.Close()
 
 			if _, err := index.CreateFrame("f", pilosa.FrameOptions{
 				RangeEnabled: true,
 				CacheType:    pilosa.CacheTypeRanked,
-			}); err != pilosa.ErrRangeCacheNotAllowed {
+			}); err != nil {
 				t.Fatal(err)
 			}
 		})


### PR DESCRIPTION
## Overview

I don't think there is any reason for frames not have both a ranked cache, and range fields.

Having this ability makes generic ingest a bit easier to implement.

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
