### PR TITLE
bump MaxIdleConns(PerHost) like v0.7

### DIFF
--- a/client.go
+++ b/client.go
@@ -25,6 +25,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"net"
 	"net/http"
 	"net/url"
 	"sort"
@@ -70,7 +71,19 @@ func NewInternalHTTPClientFromURI(defaultURI *URI, options *ClientOptions) *Inte
 	if options == nil {
 		options = &ClientOptions{}
 	}
-	transport := &http.Transport{}
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxIdleConns:          1000,
+		MaxIdleConnsPerHost:   200,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
 	if options.TLS != nil {
 		transport.TLSClientConfig = options.TLS
 	}


### PR DESCRIPTION
## Overview

This helps "connection reset" issues when the cluster is under high query load
from many clients.

This also brings in the default http transport options which were (mistakenly?)
removed by the TLS work. I'm not sure what the ramifications would be of using a
blank http.Transport{} instead of http.DefaultTransport, but it seems best to
avoid a sweeping change.

Fixes #906 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
