### PR TITLE
Removes column/row labels for input definition. Resolves #810

### DIFF
--- a/docs/input-definition.md
+++ b/docs/input-definition.md
@@ -44,6 +44,7 @@ curl localhost:10101/index/repository/input-definition/stargazer \
              ],
              "fields": [
                  {
+                     "name": "repo_id", 
                      "primaryKey": true
                  },
                  {
@@ -104,7 +105,7 @@ curl localhost:10101/index/repository/input/stargazer \
      -X POST \
      -d '[
              {
-                 "columnID": 91720568, 
+                 "repo_id": 91720568, 
                  "language_id": "Go", 
                  "stargazer_id": 513114,
                  "time_value": "2017-05-18T20:40"

--- a/docs/input-definition.md
+++ b/docs/input-definition.md
@@ -44,10 +44,6 @@ curl localhost:10101/index/repository/input-definition/stargazer \
              ],
              "fields": [
                  {
-                     "name": "repo_id", 
-                     "primaryKey": true
-                 }, 
-                 {
                      "actions": [
                          {
                              "frame": "language", 
@@ -105,8 +101,8 @@ curl localhost:10101/index/repository/input/stargazer \
      -X POST \
      -d '[
              {
+                 "columnID": 91720568, 
                  "language_id": "Go", 
-                 "repo_id": 91720568, 
                  "stargazer_id": 513114,
                  "time_value": "2017-05-18T20:40"
              }, 

--- a/docs/input-definition.md
+++ b/docs/input-definition.md
@@ -44,6 +44,9 @@ curl localhost:10101/index/repository/input-definition/stargazer \
              ],
              "fields": [
                  {
+                     "primaryKey": true
+                 },
+                 {
                      "actions": [
                          {
                              "frame": "language", 

--- a/handler.go
+++ b/handler.go
@@ -1760,8 +1760,7 @@ func (h *Handler) handlePostInputDefinition(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	// Validation the input definition with the curent index's ColumnLabel.
-	if err := req.Validate(index.ColumnLabel()); err != nil {
+	if err := req.Validate(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -1908,10 +1907,13 @@ func (h *Handler) InputJSONDataParser(req map[string]interface{}, index *Index, 
 	for _, field := range inputDef.Fields() {
 		validFields[field.Name] = true
 		if field.PrimaryKey {
-			columnLabel := field.Name
-			value, ok := req[columnLabel]
+			primaryKey := field.Name
+			if primaryKey != DefaultColumnLabel {
+				return nil, fmt.Errorf("Primary key field should have the name: %s", DefaultColumnLabel)
+			}
+			value, ok := req[primaryKey]
 			if !ok {
-				return nil, fmt.Errorf("columnLabel required")
+				return nil, fmt.Errorf("primary key does not exist")
 			}
 			rawValue, ok := value.(float64) // The default JSON marshalling will interpret this as a float
 			if !ok {

--- a/handler.go
+++ b/handler.go
@@ -1907,11 +1907,7 @@ func (h *Handler) InputJSONDataParser(req map[string]interface{}, index *Index, 
 	for _, field := range inputDef.Fields() {
 		validFields[field.Name] = true
 		if field.PrimaryKey {
-			primaryKey := field.Name
-			if primaryKey != DefaultColumnLabel {
-				return nil, fmt.Errorf("Primary key field should have the name: %s", DefaultColumnLabel)
-			}
-			value, ok := req[primaryKey]
+			value, ok := req[field.Name]
 			if !ok {
 				return nil, fmt.Errorf("primary key does not exist")
 			}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1587,7 +1587,7 @@ func TestHandler_CreateInput(t *testing.T) {
 	}
 	inputBody := []byte(`
 			[{
-				"columnID": 1,
+				"id": 1,
 				"cabType": "yellow",
 				"distanceMiles": 8,
 				"withPet": true,
@@ -1668,14 +1668,14 @@ func TestInput_JSON(t *testing.T) {
 		err  string
 	}{
 		{json: `[{
-				"columnID": 1,
+				"id": 1,
 				"cabType": "yellow",
 				"distanceMiles": 8,
 				"nofield": true
 				}]`,
 			err: "field not found: nofield"},
 		{json: `[{
-				"columnID": "abc",
+				"id": "abc",
 				"cabType": "yellow",
 				"distanceMiles": 8,
 				"withPet": true
@@ -1688,21 +1688,21 @@ func TestInput_JSON(t *testing.T) {
 				}]`,
 			err: "primary key does not exist"},
 		{json: `[{
-				"columnID": 1,
+				"id": 1,
 				"cabType": "yellow",
 				"distanceMiles": 8,
 				"withPet": true
 				}`,
 			err: "unexpected EOF"},
 		{json: `[{
-				"columnID": 1,
+				"id": 1,
 				"cabType": "yellow",
 				"distanceMiles": 8,
 				"noFrame": 1
 				}]`,
 			err: "Frame not found: foo"},
 		{json: `[{
-				"columnID": 1,
+				"id": 1,
 				"cabType": "yellow",
 				"distanceMiles": 8,
 				"time_value": 12345

--- a/handler_test.go
+++ b/handler_test.go
@@ -1309,6 +1309,43 @@ func TestHandler_DuplicatePrimaryKey(t *testing.T) {
 		t.Fatalf("unexpected body: %s", body)
 	}
 
+	// Ensure throwing error if there's no primary key
+	hldr.MustCreateIndexIfNotExists("i1", pilosa.IndexOptions{ColumnLabel: "id"})
+	unmatchColumnBody := []byte(`
+			{
+			"frames":[{
+				"name":"event-time",
+				"options":{
+					"timeQuantum": "YMD",
+					"inverseEnabled": false,
+					"cacheType": "ranked"
+				}
+			}],
+			"fields": [
+				{
+					"name": "foo",
+					"actions": [
+						{
+							"frame": "cab-type",
+							"valueDestination": "mapping",
+							"valueMap": {
+								"Green": 1,
+								"Yellow": 2
+							}
+						}
+					]
+				}
+			]
+		}`)
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, test.MustNewHTTPRequest("POST", "/index/i1/input-definition/input1", bytes.NewBuffer(unmatchColumnBody)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	} else if body := w.Body.String(); body != pilosa.ErrInputDefinitionHasPrimaryKey.Error()+"\n" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+
 	// Eusure throwing error if request body is invalid.
 	jsonErrorBody := []byte(`
 			{

--- a/index.go
+++ b/index.go
@@ -687,7 +687,8 @@ func (i *Index) createInputDefinition(pb *internal.InputDefinition) (*InputDefin
 
 	for _, fr := range pb.Frames {
 		opt := FrameOptions{
-			RowLabel:       fr.Meta.RowLabel,
+			// Deprecating row labels per #810. So, setting the default row label here.
+			RowLabel:       DefaultRowLabel,
 			InverseEnabled: fr.Meta.InverseEnabled,
 			CacheType:      fr.Meta.CacheType,
 			CacheSize:      fr.Meta.CacheSize,

--- a/index_test.go
+++ b/index_test.go
@@ -309,14 +309,14 @@ func TestIndex_CreateInputDefinition(t *testing.T) {
 	// Create Input Definition.
 	frames := internal.Frame{Name: "f", Meta: &internal.FrameMeta{RowLabel: "row"}}
 	action := internal.InputDefinitionAction{Frame: "f", ValueDestination: "mapping", ValueMap: map[string]uint64{"Green": 1}}
-	fields := internal.InputDefinitionField{PrimaryKey: true, InputDefinitionActions: []*internal.InputDefinitionAction{&action}}
-	def := internal.InputDefinition{Name: "test", Frames: []*internal.Frame{&frames}, Fields: []*internal.InputDefinitionField{&fields}}
+	field := internal.InputDefinitionField{Name: "id", PrimaryKey: true, InputDefinitionActions: []*internal.InputDefinitionAction{&action}}
+	def := internal.InputDefinition{Name: "test", Frames: []*internal.Frame{&frames}, Fields: []*internal.InputDefinitionField{&field}}
 	inputDef, err := index.CreateInputDefinition(&def)
 	if err != nil {
 		t.Fatal(err)
 	} else if inputDef.Frames()[0].Name != frames.Name {
 		t.Fatalf("unexpected input definition frames %v", inputDef.Frames())
-	} else if inputDef.Fields()[0].Name != pilosa.DefaultColumnLabel {
+	} else if inputDef.Fields()[0].Name != field.Name {
 		t.Fatalf("unexpected input definition actions %v", inputDef.Fields())
 	}
 }

--- a/index_test.go
+++ b/index_test.go
@@ -309,14 +309,14 @@ func TestIndex_CreateInputDefinition(t *testing.T) {
 	// Create Input Definition.
 	frames := internal.Frame{Name: "f", Meta: &internal.FrameMeta{RowLabel: "row"}}
 	action := internal.InputDefinitionAction{Frame: "f", ValueDestination: "mapping", ValueMap: map[string]uint64{"Green": 1}}
-	fields := internal.InputDefinitionField{Name: "id", PrimaryKey: true, InputDefinitionActions: []*internal.InputDefinitionAction{&action}}
+	fields := internal.InputDefinitionField{PrimaryKey: true, InputDefinitionActions: []*internal.InputDefinitionAction{&action}}
 	def := internal.InputDefinition{Name: "test", Frames: []*internal.Frame{&frames}, Fields: []*internal.InputDefinitionField{&fields}}
 	inputDef, err := index.CreateInputDefinition(&def)
 	if err != nil {
 		t.Fatal(err)
 	} else if inputDef.Frames()[0].Name != frames.Name {
 		t.Fatalf("unexpected input definition frames %v", inputDef.Frames())
-	} else if inputDef.Fields()[0].Name != fields.Name {
+	} else if inputDef.Fields()[0].Name != pilosa.DefaultColumnLabel {
 		t.Fatalf("unexpected input definition actions %v", inputDef.Fields())
 	}
 }

--- a/input_definition.go
+++ b/input_definition.go
@@ -131,9 +131,7 @@ func (i *InputDefinition) LoadDefinition(pb *internal.InputDefinition) error {
 	}
 
 	if len(pb.Fields) > 0 && !primaryKeyGiven {
-		// primary field is required if there are other fields.
-		// add it if it doesn't exist.
-		i.fields = append(i.fields, InputDefDefaultPrimaryKeyField())
+		return ErrInputDefinitionHasPrimaryKey
 	}
 
 	return nil
@@ -335,16 +333,7 @@ func (i *InputDefinitionInfo) Encode() *internal.InputDefinition {
 	for _, f := range i.Frames {
 		def.Frames = append(def.Frames, f.Encode())
 	}
-	primaryKeyGiven := false
 	for _, f := range i.Fields {
-		if f.PrimaryKey {
-			f.Name = DefaultColumnLabel
-			primaryKeyGiven = true
-		}
-		def.Fields = append(def.Fields, f.Encode())
-	}
-	if len(i.Fields) > 0 && !primaryKeyGiven {
-		f := InputDefDefaultPrimaryKeyField()
 		def.Fields = append(def.Fields, f.Encode())
 	}
 	return &def
@@ -401,12 +390,4 @@ func HandleAction(a Action, value interface{}, colID uint64, timestamp int64) (*
 		return nil, fmt.Errorf("Unrecognized Value Destination: %s in Action", a.ValueDestination)
 	}
 	return &bit, err
-}
-
-func InputDefDefaultPrimaryKeyField() InputDefinitionField {
-	return InputDefinitionField{
-		Name:       DefaultColumnLabel,
-		PrimaryKey: true,
-		Actions:    []Action{},
-	}
 }

--- a/input_definition.go
+++ b/input_definition.go
@@ -105,7 +105,6 @@ func (i *InputDefinition) LoadDefinition(pb *internal.InputDefinition) error {
 
 	for _, field := range pb.Fields {
 		var actions []Action
-		fieldName := field.Name
 		for _, action := range field.InputDefinitionActions {
 			actions = append(actions, Action{
 				Frame:            action.Frame,
@@ -116,14 +115,11 @@ func (i *InputDefinition) LoadDefinition(pb *internal.InputDefinition) error {
 		}
 
 		if field.PrimaryKey {
-			// Deprecating column labels per #810.
-			// So, setting the default column label here.
-			fieldName = DefaultColumnLabel
 			primaryKeyGiven = true
 		}
 
 		inputField := InputDefinitionField{
-			Name:       fieldName,
+			Name:       field.Name,
 			PrimaryKey: field.PrimaryKey,
 			Actions:    actions,
 		}
@@ -296,6 +292,9 @@ func (i *InputDefinitionInfo) Validate() error {
 
 	// Validate columnLabel and duplicate primaryKey.
 	for _, field := range i.Fields {
+		if field.Name == "" {
+			return ErrInputDefinitionNameRequired
+		}
 		for _, action := range field.Actions {
 			if err := action.Validate(); err != nil {
 				return err

--- a/input_definition_test.go
+++ b/input_definition_test.go
@@ -64,6 +64,7 @@ func TestInputDefinition_Encoding(t *testing.T) {
 			}],
 			"fields": [
 				{
+					"name": "id",
 					"primaryKey": true
 				},
 				{
@@ -173,7 +174,7 @@ func TestActionValidation(t *testing.T) {
 		t.Fatalf("Expected duplicate rowID with other field error, actual error: %s", err)
 	}
 
-	field = pilosa.InputDefinitionField{PrimaryKey: true}
+	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true}
 	field1 = pilosa.InputDefinitionField{Name: "test", PrimaryKey: false}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field, field1}}
 	err = info.Validate()

--- a/input_definition_test.go
+++ b/input_definition_test.go
@@ -64,6 +64,9 @@ func TestInputDefinition_Encoding(t *testing.T) {
 			}],
 			"fields": [
 				{
+					"primaryKey": true
+				},
+				{
 					"name": "cabType",
 					"actions": [
 						{
@@ -92,9 +95,9 @@ func TestInputDefinition_Encoding(t *testing.T) {
 		t.Fatalf("unexpected frame meta data: %v", internalDef)
 	} else if len(internalDef.Fields) != 2 {
 		t.Fatalf("unexpected number of Fields: %d", len(internalDef.Fields))
-	} else if len(internalDef.Fields[0].InputDefinitionActions) != 1 {
+	} else if len(internalDef.Fields[1].InputDefinitionActions) != 1 {
 		t.Fatalf("unexpected number of Actions: %v", internalDef.Fields[1].InputDefinitionActions)
-	} else if internalDef.Fields[0].InputDefinitionActions[0].ValueDestination != "mapping" {
+	} else if internalDef.Fields[1].InputDefinitionActions[0].ValueDestination != "mapping" {
 		t.Fatalf("unexpected ValueDestination: %v", internalDef.Fields[1].InputDefinitionActions[0])
 	}
 }

--- a/input_definition_test.go
+++ b/input_definition_test.go
@@ -64,10 +64,6 @@ func TestInputDefinition_Encoding(t *testing.T) {
 			}],
 			"fields": [
 				{
-					"name": "id",
-					"primaryKey": true
-				},
-				{
 					"name": "cabType",
 					"actions": [
 						{
@@ -96,9 +92,9 @@ func TestInputDefinition_Encoding(t *testing.T) {
 		t.Fatalf("unexpected frame meta data: %v", internalDef)
 	} else if len(internalDef.Fields) != 2 {
 		t.Fatalf("unexpected number of Fields: %d", len(internalDef.Fields))
-	} else if len(internalDef.Fields[1].InputDefinitionActions) != 1 {
+	} else if len(internalDef.Fields[0].InputDefinitionActions) != 1 {
 		t.Fatalf("unexpected number of Actions: %v", internalDef.Fields[1].InputDefinitionActions)
-	} else if internalDef.Fields[1].InputDefinitionActions[0].ValueDestination != "mapping" {
+	} else if internalDef.Fields[0].InputDefinitionActions[0].ValueDestination != "mapping" {
 		t.Fatalf("unexpected ValueDestination: %v", internalDef.Fields[1].InputDefinitionActions[0])
 	}
 }
@@ -110,14 +106,14 @@ func TestActionValidation(t *testing.T) {
 	action := pilosa.Action{Frame: "f", ValueDestination: pilosa.InputSingleRowBool, ValueMap: map[string]uint64{"Green": 1}}
 	field := pilosa.InputDefinitionField{Name: "id", PrimaryKey: false, Actions: []pilosa.Action{action}}
 	info := pilosa.InputDefinitionInfo{Fields: []pilosa.InputDefinitionField{field}}
-	err := info.Validate("id")
+	err := info.Validate()
 	if err != pilosa.ErrInputDefinitionAttrsRequired {
 		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrInputDefinitionAttrsRequired, err)
 	}
 
 	frame := pilosa.InputFrame{Name: "f", Options: pilosa.FrameOptions{RowLabel: "row"}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if !strings.Contains(err.Error(), "rowID required for single-row-boolean") {
 		t.Fatalf("Expected rowID required for single-row-boolean error, actual error: %s", err)
 	}
@@ -126,7 +122,7 @@ func TestActionValidation(t *testing.T) {
 	action = pilosa.Action{Frame: "f", ValueDestination: pilosa.InputSingleRowBool, RowID: &rowID}
 	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true, Actions: []pilosa.Action{action}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if err != pilosa.ErrName {
 		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrName, err)
 	}
@@ -135,23 +131,15 @@ func TestActionValidation(t *testing.T) {
 	action = pilosa.Action{ValueDestination: pilosa.InputSingleRowBool, RowID: &rowID}
 	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true, Actions: []pilosa.Action{action}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if err != pilosa.ErrFrameRequired {
 		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrFrameRequired, err)
 	}
 
 	action = pilosa.Action{Frame: "f", ValueDestination: pilosa.InputSingleRowBool, RowID: &rowID}
-	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true, Actions: []pilosa.Action{action}}
-	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("test")
-	if err != pilosa.ErrInputDefinitionColumnLabel {
-		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrInputDefinitionColumnLabel, err)
-	}
-
-	action = pilosa.Action{Frame: "f", ValueDestination: pilosa.InputSingleRowBool, RowID: &rowID}
 	field = pilosa.InputDefinitionField{Name: "x", PrimaryKey: false, Actions: []pilosa.Action{action}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if err != pilosa.ErrInputDefinitionHasPrimaryKey {
 		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrInputDefinitionHasPrimaryKey, err)
 	}
@@ -159,7 +147,7 @@ func TestActionValidation(t *testing.T) {
 	action = pilosa.Action{Frame: "f", ValueDestination: "value-to-ROW", ValueMap: map[string]uint64{"Green": 1}}
 	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true, Actions: []pilosa.Action{action}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if !strings.Contains(err.Error(), "invalid ValueDestination") {
 		t.Fatalf("Expected invalid ValueDestination error, actual error: %s", err)
 	}
@@ -167,7 +155,7 @@ func TestActionValidation(t *testing.T) {
 	action = pilosa.Action{Frame: "f", ValueDestination: pilosa.InputMapping, RowID: &rowID}
 	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true, Actions: []pilosa.Action{action}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if err != pilosa.ErrInputDefinitionValueMap {
 		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrInputDefinitionValueMap, err)
 	}
@@ -177,15 +165,15 @@ func TestActionValidation(t *testing.T) {
 	action1 := pilosa.Action{Frame: "f", ValueDestination: pilosa.InputSingleRowBool, RowID: &rowID}
 	field1 := pilosa.InputDefinitionField{Name: "id", PrimaryKey: true, Actions: []pilosa.Action{action1}}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field, field1}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if !strings.Contains(err.Error(), "duplicate rowID with other field") {
 		t.Fatalf("Expected duplicate rowID with other field error, actual error: %s", err)
 	}
 
-	field = pilosa.InputDefinitionField{Name: "id", PrimaryKey: true}
+	field = pilosa.InputDefinitionField{PrimaryKey: true}
 	field1 = pilosa.InputDefinitionField{Name: "test", PrimaryKey: false}
 	info = pilosa.InputDefinitionInfo{Frames: []pilosa.InputFrame{frame}, Fields: []pilosa.InputDefinitionField{field, field1}}
-	err = info.Validate("id")
+	err = info.Validate()
 	if err != pilosa.ErrInputDefinitionActionRequired {
 		t.Fatalf("Expect error: %s, actual err: %s", pilosa.ErrInputDefinitionActionRequired, err)
 	}


### PR DESCRIPTION
## Overview

The primary key name defaults to `DefaultColumnLabel`. Primary key field is optional. If not given and there are other fields, a new field with `Name=DefaultColumnLabel, PrimaryKey=true, Actions=[]` is added to the input def.

Fixes #810 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
