### PR TITLE
WIP: don't block joining nodes while coordinator loads data.

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -308,17 +308,6 @@ func TestCluster_Resize(t *testing.T) {
 // TestTestCluster ensures that general cluster functionality works as expected.
 func TestCluster_ResizeStates(t *testing.T) {
 
-	/* test conditions:
-	x- single node, no data, comes up in NORMAL with topology
-	x- single node, in topology, comes up NORMAL
-	x- single node, not in topology, raises error
-	x- two node, no data, comes up in NORMAL, with topology
-	x- two node, in topology, comes up NORMAL
-	x- two node, STARTING, not in topology, raises error
-	x- two node, NORMAL, not in topology, triggers resize
-	x- resize of nodes with data moves data appropriately
-	*/
-
 	t.Run("Single node, no data", func(t *testing.T) {
 		tc := test.NewTestCluster(1)
 

--- a/holder.go
+++ b/holder.go
@@ -80,21 +80,20 @@ func NewHolder() *Holder {
 
 // Peek reads the root data directory for the holder
 // without actually loading any data into memory.
-func (h *Holder) Peek() error {
-	if err := os.MkdirAll(h.Path, 0777); err != nil {
-		return err
-	}
+// HasData is returned, and h.hasData is set.
+func (h *Holder) Peek() bool {
+	h.hasData = false
 
 	// Open path to read all index directories.
 	f, err := os.Open(h.Path)
 	if err != nil {
-		return err
+		return false
 	}
 	defer f.Close()
 
 	fis, err := f.Readdir(0)
 	if err != nil {
-		return err
+		return false
 	}
 
 	for _, fi := range fis {
@@ -105,7 +104,7 @@ func (h *Holder) Peek() error {
 		break
 	}
 
-	return nil
+	return h.hasData
 }
 
 // Open initializes the root data directory for the holder.

--- a/holder_test.go
+++ b/holder_test.go
@@ -266,6 +266,60 @@ func TestHolder_Open(t *testing.T) {
 	})
 }
 
+func TestHolder_HasData(t *testing.T) {
+	t.Run("IndexDirectory", func(t *testing.T) {
+		h := test.MustOpenHolder()
+		defer h.Close()
+
+		if h.HasData() {
+			t.Fatal("expected HasData to return false")
+		}
+
+		if _, err := h.CreateIndex("test", pilosa.IndexOptions{}); err != nil {
+			t.Fatal(err)
+		}
+
+		if !h.HasData() {
+			t.Fatal("expected HasData to return true")
+		}
+	})
+
+	t.Run("Peek", func(t *testing.T) {
+		h := test.NewHolder()
+
+		if hasData := h.Peek(); hasData != false {
+			t.Fatal("expected Peek to return false")
+		} else if h.HasData() {
+			t.Fatal("expected HasData to return false")
+		}
+
+		// Create an index directory to indicate data exists.
+		if err := os.Mkdir(h.IndexPath("test"), 0777); err != nil {
+			t.Fatal(err)
+		}
+
+		if hasData := h.Peek(); hasData != true {
+			t.Fatal("expected Peek to return true")
+		} else if !h.HasData() {
+			t.Fatal("expected HasData to return true")
+		}
+	})
+
+	t.Run("Peek at missing directory", func(t *testing.T) {
+		h := test.NewHolder()
+
+		// Ensure that hasData is false when trying to peek into
+		// a directory that doesn't exist.
+		h.Path = "bad-path"
+
+		if hasData := h.Peek(); hasData != false {
+			t.Fatal("expected Peek to return false")
+		} else if h.HasData() {
+			t.Fatal("expected HasData to return false")
+		}
+	})
+}
+
 /*
 func TestHolder_Schema(t *testing.T) {
 	t.Run("Schema", func(t *testing.T) {

--- a/server.go
+++ b/server.go
@@ -149,9 +149,7 @@ func (s *Server) Open() error {
 	// Don't actually load the data until after the Cluster
 	// management starts.
 	s.Holder.LogOutput = s.LogOutput
-	if err := s.Holder.Peek(); err != nil {
-		return fmt.Errorf("peeking at the Holder: %v", err)
-	}
+	s.Holder.Peek()
 
 	// Start the BroadcastReceiver.
 	if err := s.BroadcastReceiver.Start(s); err != nil {

--- a/test/cluster.go
+++ b/test/cluster.go
@@ -255,6 +255,13 @@ func (t *TestCluster) Open() error {
 			return err
 		}
 	}
+
+	// Start the listener on the coordinator.
+	if len(t.Clusters) == 0 {
+		return nil
+	}
+	t.Clusters[0].ListenForJoins()
+
 	return nil
 }
 


### PR DESCRIPTION
Implements a Holder.Peek() function, and breaks out
Cluster.ListenForJoins() into a separate method that can be started
after the Holder finishes loading data.

TODO:
- [x] test Holder.Peek()
