### PR TITLE
Add search-friendly documentation for BSI range query syntax

### DIFF
--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -427,7 +427,7 @@ Returns `{{"attrs":{},"bits":[10]}`
 **Spec:**
 
 ```
-Range(<frame=STRING>, <FIELD_NAME, COMPARISON_OPERATOR, integer> )
+Range(<frame=STRING>, <FIELD_NAME, COMPARISON_OPERATOR, COMPARISON_VALUE> )
 ```
 
 **Description:**
@@ -441,7 +441,7 @@ Returns bits that are true for the comparison operator.
 **Examples:**
 
 In our source data, commitactivity was counted over the last year.
-The following Range query returns all repositories having more than 100 commits.
+The following greater-than (GT) Range query returns all repositories having more than 100 commits.
 
 ```
 Range(frame="stats", commitactivity > 100)
@@ -451,6 +451,13 @@ Returns `{{"attrs":{},"bits":[10]}`
 
 * bits are repositories which had at least 100 commits in the last year.
 
+Similar syntax is supported for less-than (LT or `<`), less-than-or-equal (LTE or `<=`), and greater-than-or-equal (GTE or `>=`). An interval with both bounds can be specified with the "BETWEEN" operator `><`, and a two-element list containing the lower and upper bounds of the interval:
+
+```
+Range(frame="stats", commitactivity >< [100, 200])
+```
+
+This is conceptually equivalent to the interval 100 < commitactivity < 200, but this chained comparison syntax is not currently supported. BETWEEN queries syntax is restricted to greater-than and less-than, but any valid interval on the integers can be represented this way.
 
 #### Sum
 

--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -441,7 +441,7 @@ Returns bits that are true for the comparison operator.
 **Examples:**
 
 In our source data, commitactivity was counted over the last year.
-The following greater-than (GT) Range query returns all repositories having more than 100 commits.
+The following greater-than Range query returns all repositories having more than 100 commits.
 
 ```
 Range(frame="stats", commitactivity > 100)
@@ -451,13 +451,25 @@ Returns `{{"attrs":{},"bits":[10]}`
 
 * bits are repositories which had at least 100 commits in the last year.
 
-Similar syntax is supported for less-than (LT or `<`), less-than-or-equal (LTE or `<=`), and greater-than-or-equal (GTE or `>=`). An interval with both bounds can be specified with the "BETWEEN" operator `><`, and a two-element list containing the lower and upper bounds of the interval:
+BSI range queries support the following operators:
+
+ Operator | Name                          | Value              
+----------|-------------------------------|--------------------
+ `>`      | greater-than, GT              | integer            
+ `<`      | less-than, LT                 | integer            
+ `<=`     | less-than-or-equal-to, LTE    | integer            
+ `>=`     | greater-than-or-equal-to, GTE | integer            
+ `==`     | equal-to, EQ                  | integer            
+ `!=`     | not-equal-to, NEQ             | integer or `null`  
+ `><`     | between, BETWEEN              | [integer, integer] 
+
+The `BETWEEN` query specifies an interval with both bounds, using `><` operator, and a two-element list containing the lower and upper bounds of the interval:
 
 ```
 Range(frame="stats", commitactivity >< [100, 200])
 ```
 
-This is conceptually equivalent to the interval 100 < commitactivity < 200, but this chained comparison syntax is not currently supported. BETWEEN queries syntax is restricted to greater-than and less-than, but any valid interval on the integers can be represented this way.
+This is conceptually equivalent to the interval 100 <= commitactivity <= 200, but this chained comparison syntax is not currently supported. `BETWEEN` query syntax is restricted to greater-than-or-equal-to and less-than-or-equal-to, but any valid interval on the integers can be represented this way.
 
 #### Sum
 


### PR DESCRIPTION
## Overview

BSI Range queries support five different operators that, previously, weren't clearly specified anywhere except the source code. Also, the BETWEEN operator is unique to pilosa, and searching for it or "between" in the docs didn't return anything helpful.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
