### PR TITLE
fixed version check when local is greater than pilosa.com

### DIFF
--- a/diagnostics/diagnostics.go
+++ b/diagnostics/diagnostics.go
@@ -172,9 +172,9 @@ func (d *Diagnostics) CompareVersion(value string) error {
 
 	if localVersion[0] < currentVersion[0] { //Major
 		return fmt.Errorf("Warning: You are running Pilosa %s. A newer version (%s) is available: https://github.com/pilosa/pilosa/releases", d.version, value)
-	} else if localVersion[1] < currentVersion[1] { // Minor
+	} else if localVersion[1] < currentVersion[1] && localVersion[0] == currentVersion[0] { // Minor
 		return fmt.Errorf("Warning: You are running Pilosa %s. The latest Minor release is %s: https://github.com/pilosa/pilosa/releases", d.version, value)
-	} else if localVersion[2] < currentVersion[2] { // Patch
+	} else if localVersion[2] < currentVersion[2] && localVersion[0] == currentVersion[0] && localVersion[1] == currentVersion[1] { // Patch
 		return fmt.Errorf("There is a new patch release of Pilosa available: %s: https://github.com/pilosa/pilosa/releases", value)
 	}
 

--- a/diagnostics/diagnostics_test.go
+++ b/diagnostics/diagnostics_test.go
@@ -96,6 +96,11 @@ func TestDiagnosticsVersion_Compare(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Versions should match")
 	}
+	d.SetVersion("v1.7.0")
+	err = d.CompareVersion("0.7.2")
+	if err != nil {
+		t.Fatalf("Local version is greater")
+	}
 }
 
 func TestDiagnosticsVersion_Check(t *testing.T) {


### PR DESCRIPTION
## Overview
Fixes the issue where the local version is greater that the reported latest from Pilosa.com.
Fixes #966 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
