### PR TITLE
Fix CountOpenFiles() fatal crash

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -373,10 +373,14 @@ func tempMkdir(t *testing.T) string {
 func TestCountOpenFiles(t *testing.T) {
 	// Windows is not supported yet
 	if runtime.GOOS == "windows" {
-		return
+		t.Skip("Skipping unsupported CountOpenFiles test on Windows.")
 	}
-	if pilosa.CountOpenFiles() == 0 {
-		t.Error("Invalid open file handle count")
+	count, err := pilosa.CountOpenFiles()
+	if err != nil {
+		t.Errorf("CountOpenFiles failed: %s", err)
+	}
+	if count == 0 {
+		t.Error("CountOpenFiles returned invalid value 0.")
 	}
 }
 


### PR DESCRIPTION
## Overview

This causes CountOpenFiles to return an error instead of crashing if it can't call out to `lsof`.

Fixes #967 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
