### PR TITLE
Fix edge case with Range() calls outside field Min/Max. Fixes #876.

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -803,6 +803,12 @@ func (e *Executor) executeFieldRangeSlice(ctx context.Context, index string, c *
 			return NewBitmap(), nil
 		}
 
+		// LT[E] and GT[E] should return all not-null if selected range fully encompases valid field range.
+		if (cond.Op == pql.LT && value > field.Max) || (cond.Op == pql.LTE && value >= field.Max) ||
+			(cond.Op == pql.GT && value < field.Min) || (cond.Op == pql.GTE && value <= field.Min) {
+			return frag.FieldNotNull(field.BitDepth())
+		}
+
 		// outOfRange for NEQ should return all not-null.
 		if outOfRange && cond.Op == pql.NEQ {
 			return frag.FieldNotNull(field.BitDepth())

--- a/executor_test.go
+++ b/executor_test.go
@@ -741,6 +741,15 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	if _, err := idx.CreateFrame("edge", pilosa.FrameOptions{
+		RangeEnabled: true,
+		Fields: []*pilosa.Field{
+			{Name: "foo", Type: pilosa.FieldTypeInt, Min: -100, Max: 100},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
 	if _, err := e.Execute(context.Background(), "i", test.MustParse(`
 		SetBit(frame=f, rowID=0, columnID=0)
 		SetBit(frame=f, rowID=0, columnID=`+strconv.Itoa(SliceWidth+1)+`)
@@ -751,6 +760,8 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 		SetFieldValue(frame=f, foo=20, columnID=`+strconv.Itoa((5*SliceWidth)+100)+`)
 		SetFieldValue(frame=f, foo=60, columnID=`+strconv.Itoa(SliceWidth+1)+`)
 		SetFieldValue(frame=other, foo=1000, columnID=0)
+		SetFieldValue(frame=edge, foo=100, columnID=0)
+		SetFieldValue(frame=edge, foo=-100, columnID=1)
 	`), nil, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -847,6 +858,22 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 			t.Fatal(err)
 		} else if !reflect.DeepEqual([]uint64{}, result[0].(*pilosa.Bitmap).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
+		}
+	})
+
+	t.Run("LTAboveMax", func(t *testing.T) {
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=edge, foo < 200)`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{0, 1}, result[0].(*pilosa.Bitmap).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result[0].(*pilosa.Bitmap).Bits()))
+		}
+	})
+
+	t.Run("GTBelowMin", func(t *testing.T) {
+		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=edge, foo > -200)`), nil, nil); err != nil {
+			t.Fatal(err)
+		} else if !reflect.DeepEqual([]uint64{0, 1}, result[0].(*pilosa.Bitmap).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result[0].(*pilosa.Bitmap).Bits()))
 		}
 	})
 

--- a/frame.go
+++ b/frame.go
@@ -1108,7 +1108,7 @@ func (f *Field) BitDepth() uint {
 
 // BaseValue adjusts the value to align with the range for Field for a certain
 // operation type.
-// TODO: there is an edge case for GT and LT where this returns a baseValue
+// Note: There is an edge case for GT and LT where this returns a baseValue
 // that does not fully encompass the range.
 // ex: Field.Min = 0, Field.Max = 1023
 // BaseValue(LT, 2000) returns 1023, which will perform "LT 1023" and effectively
@@ -1116,6 +1116,8 @@ func (f *Field) BitDepth() uint {
 // Note that in this case (because the range uses the full BitDepth 0 to 1023),
 // we can't simply return 1024.
 // In order to make this work, we effectively need to change the operator to LTE.
+// Executor.executeFieldRangeSlice() takes this into account and returns
+// `frag.FieldNotNull(field.BitDepth())` in such instances.
 func (f *Field) BaseValue(op pql.Token, value int64) (baseValue uint64, outOfRange bool) {
 	if op == pql.GT || op == pql.GTE {
 		if value > f.Max {


### PR DESCRIPTION
## Overview

This modifies Executor.executeFieldRangeSlice() so that LT[E] and GT[E] Range() queries return all not-null if selected range fully encompases valid field range.

Fixes #876

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
