### PR TITLE
Resume test: TestMain_SendReceiveMessage

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"strings"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -57,6 +59,11 @@ func (g *GossipNodeSet) Nodes() []*pilosa.Node {
 func (g *GossipNodeSet) Start(h pilosa.BroadcastHandler) error {
 	g.handler = h
 	return nil
+}
+
+// Seed returns the gossipSeed determined by the config.
+func (g *GossipNodeSet) Seed() string {
+	return g.config.gossipSeed
 }
 
 // Open implements the NodeSet interface to start network activity.
@@ -122,28 +129,109 @@ type gossipConfig struct {
 	memberlistConfig *memberlist.Config
 }
 
+// newTransport returns a NetTransport based on the memberlist configuration.
+// It will dynamically bind to a port if conf.BindPort is 0.
+// This is useful for test cases where specifiying a port is not reasonable.
+func newTransport(conf *memberlist.Config) (*memberlist.NetTransport, error) {
+	if conf.LogOutput != nil && conf.Logger != nil {
+		return nil, fmt.Errorf("Cannot specify both LogOutput and Logger. Please choose a single log configuration setting.")
+	}
+
+	logDest := conf.LogOutput
+	if logDest == nil {
+		logDest = os.Stderr
+	}
+
+	logger := conf.Logger
+	if logger == nil {
+		logger = log.New(logDest, "", log.LstdFlags)
+	}
+
+	nc := &memberlist.NetTransportConfig{
+		BindAddrs: []string{conf.BindAddr},
+		BindPort:  conf.BindPort,
+		Logger:    logger,
+	}
+
+	// See comment below for details about the retry in here.
+	makeNetRetry := func(limit int) (*memberlist.NetTransport, error) {
+		var err error
+		for try := 0; try < limit; try++ {
+			var nt *memberlist.NetTransport
+			if nt, err = memberlist.NewNetTransport(nc); err == nil {
+				return nt, nil
+			}
+			if strings.Contains(err.Error(), "address already in use") {
+				logger.Printf("[DEBUG] Got bind error: %v", err)
+				continue
+			}
+		}
+
+		return nil, fmt.Errorf("failed to obtain an address: %v", err)
+	}
+
+	// The dynamic bind port operation is inherently racy because
+	// even though we are using the kernel to find a port for us, we
+	// are attempting to bind multiple protocols (and potentially
+	// multiple addresses) with the same port number. We build in a
+	// few retries here since this often gets transient errors in
+	// busy unit tests.
+	limit := 1
+	if conf.BindPort == 0 {
+		limit = 10
+	}
+
+	nt, err := makeNetRetry(limit)
+	if err != nil {
+		return nil, fmt.Errorf("Could not set up network transport: %v", err)
+	}
+	if conf.BindPort == 0 {
+		port := nt.GetAutoBindPort()
+		conf.BindPort = port
+		conf.AdvertisePort = port
+		logger.Printf("[DEBUG] Using dynamic bind port %d", port)
+	}
+
+	return nt, nil
+}
+
 // NewGossipNodeSet returns a new instance of GossipNodeSet.
-func NewGossipNodeSet(name string, gossipHost string, gossipPort int, gossipSeed string, server *pilosa.Server, secretKey []byte) *GossipNodeSet {
+func NewGossipNodeSet(name string, gossipHost string, gossipPort int, gossipSeed string, server *pilosa.Server, secretKey []byte) (*GossipNodeSet, error) {
 	g := &GossipNodeSet{
 		LogOutput: server.LogOutput,
 	}
 
+	conf := memberlist.DefaultLocalConfig()
+	conf.BindPort = gossipPort
+	conf.AdvertisePort = gossipPort
+
 	//TODO: pull memberlist config from pilosa.cfg file
 	g.config = &gossipConfig{
-		memberlistConfig: memberlist.DefaultLocalConfig(),
+		memberlistConfig: conf,
 		gossipSeed:       gossipSeed,
 	}
+
 	g.config.memberlistConfig.Name = name
 	g.config.memberlistConfig.BindAddr = gossipHost
-	g.config.memberlistConfig.BindPort = gossipPort
 	g.config.memberlistConfig.AdvertiseAddr = pilosa.HostToIP(gossipHost)
-	g.config.memberlistConfig.AdvertisePort = gossipPort
 	g.config.memberlistConfig.Delegate = g
 	g.config.memberlistConfig.SecretKey = secretKey
 
 	g.statusHandler = server
 
-	return g
+	// set up the transport
+	transport, err := newTransport(g.config.memberlistConfig)
+	if err != nil {
+		return nil, err
+	}
+	g.config.memberlistConfig.Transport = transport
+
+	// If no gossipSeed is provided, use local host:port.
+	if gossipSeed == "" {
+		g.config.gossipSeed = fmt.Sprintf("%s:%d", gossipHost, g.config.memberlistConfig.BindPort)
+	}
+
+	return g, nil
 }
 
 // SendSync implementation of the Broadcaster interface.

--- a/server/server.go
+++ b/server/server.go
@@ -221,7 +221,10 @@ func (m *Command) SetupServer() error {
 
 		// get the host portion of addr to use for binding
 		gossipHost := uri.Host()
-		gossipNodeSet := gossip.NewGossipNodeSet(uri.HostPort(), gossipHost, gossipPort, gossipSeed, m.Server, gossipKey)
+		gossipNodeSet, err := gossip.NewGossipNodeSet(uri.HostPort(), gossipHost, gossipPort, gossipSeed, m.Server, gossipKey)
+		if err != nil {
+			return err
+		}
 		m.Server.Cluster.NodeSet = gossipNodeSet
 		m.Server.Broadcaster = gossipNodeSet
 		m.Server.BroadcastReceiver = gossipNodeSet


### PR DESCRIPTION
## Overview
Create a custom memberlist NetTransport (which will bind to an available
port when port = 0 in the configuration). This allows us to bind
to dynamic ports in tests while at the same time determining a valid
seed for the cluster.


Fixes #951 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
