### PR TITLE
disable diagnostics in server tests

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -594,6 +594,7 @@ func NewMain() *Main {
 // MustRunMain returns a new, running Main. Panic on error.
 func MustRunMain() *Main {
 	m := NewMain()
+	m.Config.Metric.Diagnostics = false // Disable diagnostics.
 	if err := m.Run(); err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Overview

There is a race condition where the diagnostics background job is requesting data from memberlist. In some cases, memberlist hasn't finished opening and causes a panic in the background job. This PR turns off the diagnostics job for tests in `pilosa/server`.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
