### PR TITLE
fix a number of data races

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -14,10 +14,10 @@
   revision = "39b0596a2da3c92787b3319c6b5425a474b4e0da"
 
 [[projects]]
+  branch = "master"
   name = "github.com/DataDog/datadog-go"
   packages = ["statsd"]
-  revision = "0ddda6bee21174ef6c4873647cb0d6ec9cba996f"
-  version = "1.1.0"
+  revision = "4d2e5696ebe914940bd7459d2266fb7d555ea1b7"
 
 [[projects]]
   branch = "master"
@@ -46,8 +46,8 @@
 [[projects]]
   name = "github.com/gogo/protobuf"
   packages = ["proto"]
-  revision = "342cbe0a04158f6dcb03ca0079991a51a4248c02"
-  version = "v0.5"
+  revision = "100ba4e885062801d56799d78530b73b178a78f3"
+  version = "v0.4"
 
 [[projects]]
   branch = "master"
@@ -238,6 +238,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "75badb0bcc3bb356b04af17979e0af61b4b66c5e0a483f09e39cf1f9b5e5de2c"
+  inputs-digest = "d7c279ee1c617ec26e329979b5f92021287ede9701ff41e57c1fecad92ec6b51"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,11 @@
 # This file intentionally left blank as all needed dependencies are imported by
 # the project and thus tracked by `dep`.
 # See https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md for details.
+
+
+[[constraint]]
+  # Required: the root import path of the project being constrained.
+  name = "github.com/DataDog/datadog-go"
+  # Recommended: the version constraint to enforce for the project.
+  # Only one of "branch", "version" or "revision" can be specified.
+  branch = "master"

--- a/server.go
+++ b/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	MaxWritesPerRequest int
 
 	LogOutput io.Writer
+	logger    *log.Logger
 
 	defaultClient InternalClient
 }
@@ -104,9 +105,9 @@ func NewServer() *Server {
 
 		LogOutput: os.Stderr,
 	}
+	s.logger = log.New(s.LogOutput, "", log.LstdFlags)
 
 	s.Handler.Holder = s.Holder
-
 	return s
 }
 
@@ -251,7 +252,7 @@ func GetHTTPClient(t *tls.Config) *http.Client {
 }
 
 // Logger returns a logger that writes to LogOutput
-func (s *Server) Logger() *log.Logger { return log.New(s.LogOutput, "", log.LstdFlags) }
+func (s *Server) Logger() *log.Logger { return s.logger }
 
 func (s *Server) monitorAntiEntropy() {
 	ticker := time.NewTicker(s.AntiEntropyInterval)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -278,24 +278,17 @@ func TestMain_SetColumnAttrsWithColumnOption(t *testing.T) {
 // Ensure program can set bits on one cluster and then restore to a second cluster.
 func TestMain_FrameRestore(t *testing.T) {
 	m0 := MustRunMain()
-	defer m0.Close()
-
-	m1 := MustRunMain()
-	defer m1.Close()
-
-	// Update cluster config.
-	m0.Server.Cluster.Nodes = []*pilosa.Node{
-		{Scheme: "http", Host: m0.Server.URI.HostPort()},
-		{Scheme: "http", Host: m1.Server.URI.HostPort()},
-	}
-	m1.Server.Cluster.Nodes = m0.Server.Cluster.Nodes
+	// TODO: this test used to start a two node cluster, but there was a race
+	// condition with anti-entropy. We need some general code for starting up
+	// arbitrarily sized Pilosa clusters for testing, and then we should
+	// re-instate the multi-node nature of this test.
 
 	// Create frames.
 	client := m0.Client()
 	if err := client.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
-		t.Fatal(err)
+		t.Fatal("create index:", err)
 	} else if err := client.CreateFrame(context.Background(), "i", "f", pilosa.FrameOptions{}); err != nil {
-		t.Fatal(err)
+		t.Fatal("create frame:", err)
 	}
 
 	// Write data on first cluster.
@@ -308,12 +301,12 @@ func TestMain_FrameRestore(t *testing.T) {
 		SetBit(rowID=1, frame="f", columnID=600000)
 		SetBit(rowID=1, frame="f", columnID=800000)
 	`); err != nil {
-		t.Fatal(err)
+		t.Fatal("setting bits:", err)
 	}
 
 	// Query row on first cluster.
 	if res, err := m0.Query("i", "", `Bitmap(rowID=1, frame="f")`); err != nil {
-		t.Fatal(err)
+		t.Fatal("bitmap query:", err)
 	} else if res != `{"results":[{"attrs":{},"bits":[100,1000,100000,200000,400000,600000,800000]}]}`+"\n" {
 		t.Fatalf("unexpected result: %s", res)
 	}
@@ -325,20 +318,20 @@ func TestMain_FrameRestore(t *testing.T) {
 	// Import from first cluster.
 	client, err := pilosa.NewInternalHTTPClient(m2.Server.URI.HostPort(), pilosa.GetHTTPClient(nil))
 	if err != nil {
-		t.Fatal(err)
+		t.Fatal("new client:", err)
 	} else if err := m2.Client().CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
-		t.Fatal(err)
+		t.Fatal("create new index:", err)
 	} else if err := m2.Client().CreateFrame(context.Background(), "i", "f", pilosa.FrameOptions{}); err != nil {
-		t.Fatal(err)
+		t.Fatal("create new frame:", err)
 	} else if err := client.RestoreFrame(context.Background(), m0.Server.URI.HostPort(), "i", "f"); err != nil {
-		t.Fatal(err)
+		t.Fatal("restore frame:", err)
 	}
 
 	// Query row on second cluster.
 	if res, err := m2.Query("i", "", `Bitmap(rowID=1, frame="f")`); err != nil {
-		t.Fatal(err)
+		t.Fatal("another bitmap query:", err)
 	} else if res != `{"results":[{"attrs":{},"bits":[100,1000,100000,200000,400000,600000,800000]}]}`+"\n" {
-		t.Fatalf("unexpected result: %s", res)
+		t.Fatalf("2unexpected result: %s", res)
 	}
 }
 


### PR DESCRIPTION
datadog statsd client contained a race condition - was fixed in master

Server.Logger contained a race where multiple loggers could write to the same
output io.Writer

TestMain_FrameRestore contained a race where it tried to change a cluster's
nodes while it was running (which conflicted with antiEntropy reading that
state).

## Overview

[Describe what this pull request addresses.]

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
