### PR TITLE
add some statsd calls to HolderSyncer

### DIFF
--- a/holder_test.go
+++ b/holder_test.go
@@ -404,6 +404,7 @@ func TestHolderSyncer_SyncHolder(t *testing.T) {
 		URI:          uri,
 		Cluster:      cluster,
 		RemoteClient: pilosa.GetHTTPClient(nil),
+		Stats:        pilosa.NopStatsClient,
 	}
 
 	if err := syncer.SyncHolder(); err != nil {

--- a/server.go
+++ b/server.go
@@ -302,6 +302,7 @@ func (s *Server) monitorAntiEntropy() {
 		syncer.Cluster = s.Cluster
 		syncer.Closing = s.closing
 		syncer.RemoteClient = s.RemoteClient
+		syncer.Stats = s.Holder.Stats.WithTags("HolderSyncer")
 
 		// Sync holders.
 		if err := syncer.SyncHolder(); err != nil {


### PR DESCRIPTION
## Overview
This PR adds a few stats (timers and histograms) around the AntiEntropy process.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
