### PR TITLE
add omitempty to Pair.ID

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -313,7 +313,7 @@ func (p BitmapPairs) Less(i, j int) bool { return p[i].Count > p[j].Count }
 
 // Pair holds an id/count pair.
 type Pair struct {
-	ID    uint64 `json:"id"`
+	ID    uint64 `json:"id,omitempty"`
 	Key   string `json:"key,omitempty"`
 	Count uint64 `json:"count"`
 }


### PR DESCRIPTION
## Overview

In order to enterprise `TopN` queries to return a `Key` without an `ID`, then `Pair.ID` must support json `omitempty`.


## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
