### PR TITLE
add lock around Node.status to avoid race condition

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -42,8 +42,15 @@ type Node struct {
 	Scheme string `json:"scheme"`
 	Host   string `json:"host"`
 
-	mu     sync.Mutex
+	mu     sync.RWMutex
 	status *internal.NodeStatus `json:"status"`
+}
+
+// Status gets the NodeStatus.
+func (n *Node) Status() *internal.NodeStatus {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.status
 }
 
 // SetStatus sets the NodeStatus.
@@ -203,7 +210,7 @@ func (c *Cluster) Status() *internal.ClusterStatus {
 func encodeClusterStatus(a []*Node) []*internal.NodeStatus {
 	other := make([]*internal.NodeStatus, len(a))
 	for i := range a {
-		other[i] = a[i].status
+		other[i] = a[i].Status()
 	}
 	return other
 }

--- a/cluster.go
+++ b/cluster.go
@@ -17,6 +17,7 @@ package pilosa
 import (
 	"encoding/binary"
 	"hash/fnv"
+	"sync"
 	"time"
 
 	"github.com/pilosa/pilosa/internal"
@@ -41,16 +42,21 @@ type Node struct {
 	Scheme string `json:"scheme"`
 	Host   string `json:"host"`
 
+	mu     sync.Mutex
 	status *internal.NodeStatus `json:"status"`
 }
 
 // SetStatus sets the NodeStatus.
 func (n *Node) SetStatus(s *internal.NodeStatus) {
+	n.mu.Lock()
 	n.status = s
+	n.mu.Unlock()
 }
 
 // SetState sets the Node.status.state.
 func (n *Node) SetState(s string) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
 	if n.status == nil {
 		n.status = &internal.NodeStatus{}
 	}


### PR DESCRIPTION
## Overview

race detector found multiple goroutines calling `MergeRemoteState` which writes to `Node.status`.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
