### PR TITLE
Enable diagnostics via build constraint to prevent from running in tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /go/src/github.com/pilosa/pilosa
 
 RUN cd /go/src/github.com/pilosa/pilosa \
     && make vendor \
-    && CGO_ENABLED=0 go install -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa
+    && CGO_ENABLED=0 go install -tags release -a -ldflags "$ldflags" github.com/pilosa/pilosa/cmd/pilosa
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ cover-viz: cover
 	go tool cover -html=build/coverage/all.out
 
 pilosa: vendor
-	go build -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
+	go build -tags release -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
 
 release-build: vendor
 ifdef DOCKER_BUILD
@@ -114,7 +114,7 @@ docker:
 	@echo "Created image: pilosa:$(VERSION)"
 
 docker-build:
-	docker run --rm -v $(PWD):/go/src/$(CLONE_URL) -w /go/src/$(CLONE_URL) -e GOOS=$(GOOS) -e GOARCH=$(GOARCH) $(DOCKER_GOLANG_IMAGE) go build -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
+	docker run --rm -v $(PWD):/go/src/$(CLONE_URL) -w /go/src/$(CLONE_URL) -e GOOS=$(GOOS) -e GOARCH=$(GOARCH) $(DOCKER_GOLANG_IMAGE) go build -tags release -ldflags $(LDFLAGS) $(FLAGS) $(CLONE_URL)/cmd/pilosa
 
 docker-test:
 	docker run --rm -v $(PWD):/go/src/$(CLONE_URL) -w /go/src/$(CLONE_URL) $(DOCKER_GOLANG_IMAGE) go test $(TESTFLAGS) $(PKGS)

--- a/server/default.go
+++ b/server/default.go
@@ -1,0 +1,10 @@
+// +build !release
+//
+// This file sets defaults to be overridden by release.go
+
+package server
+
+import "time"
+
+// DefaultDiagnosticsInterval is the default sync frequency diagnostic metrics. A value of 0 disables diagnostics.
+const DefaultDiagnosticsInterval = time.Duration(0)

--- a/server/release.go
+++ b/server/release.go
@@ -1,0 +1,10 @@
+// +build release
+//
+// This file sets release-specific variables.
+
+package server
+
+import "time"
+
+// DefaultDiagnosticsInterval is the default sync frequency diagnostic metrics.
+const DefaultDiagnosticsInterval = 1 * time.Hour

--- a/server/server.go
+++ b/server/server.go
@@ -45,9 +45,6 @@ func init() {
 const (
 	// DefaultDataDir is the default data directory.
 	DefaultDataDir = "~/.pilosa"
-
-	// DefaultDiagnosticsInterval is the default sync frequency diagnostic metrics.
-	DefaultDiagnosticsInterval = 1 * time.Hour
 )
 
 // Command represents the state of the pilosa server command.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -539,7 +539,6 @@ func NewMainArrayWithCluster(size int) []*Main {
 // MustRunMain returns a new, running Main. Panic on error.
 func MustRunMain() *Main {
 	m := NewMain()
-	m.Config.Metric.Diagnostics = false // Disable diagnostics.
 	if err := m.Run(); err != nil {
 		panic(err)
 	}

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -41,7 +41,6 @@ func newServer() (*server.Command, error) {
 
 	s.Config.GossipSeed = "localhost:" + s.Config.GossipPort
 	s.Config.Cluster.Type = "gossip"
-	s.Config.Metric.Diagnostics = false
 	td, err := ioutil.TempDir("", "")
 	if err != nil {
 		return nil, errors.Wrap(err, "temp dir")
@@ -101,7 +100,6 @@ func NewServerCluster(size int) (cluster *Cluster, err error) {
 		cluster.Servers[i] = s
 		hosts[i] = s.Config.Bind
 		s.Config.GossipSeed = cluster.Servers[0].Config.GossipSeed
-		s.Config.Metric.Diagnostics = false // Disable diagnostics.
 
 	}
 


### PR DESCRIPTION
## Overview

This makes sure diagnostics aren't enabled during `go test` or unless the `release` build constraint is enabled. This replaces existing logic that disabled diagnostics by use of config flags.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
