### PR TITLE
clarify the options in configuration for metrics.service

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -150,9 +150,9 @@ You can opt-out of the Pilosa diagnostics reporting by setting either the comman
 Pilosa can be configured to emit metrics pertaining to its internal processes in one of two formats: Expvar or StatsD. Metric recording is disabled by default.
 The metrics configuration options are: 
 
-  - Host to receive events
-  - Polling interval for runtime metrics
-  - Metric type (StatsD, Expvar).
+  - [Host](../configuration#metrics-host): specify host that receives metric events
+  - [Poll Interval](../configuration#metrics-poll-interval): specify polling interval for runtime metrics
+  - [Service](../configuration#metrics-service): declare type StatsD or Expvar
 
 ##### Tags
 StatsD Tags adhere to the DataDog format (key:value), and we tag the following:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -220,7 +220,7 @@ Any flag that has a value that is a comma separated list on the command line bec
     cpu-time = "30s"
     ```
 ##### Metric Service
-* Description: Which stats service to use (StatsD or ExpVar).
+* Description: Which stats service to use. Choose from [statsd, expvar].
 * Flag: `--metric.service=statsd`
 * Env: `PILOSA_METRIC_SERVICE=statsd'
 * Config:


### PR DESCRIPTION
## Overview

This PR cleans up the `metrics` config options.

Fixes #762

