### PR TITLE
Changes configuration cluster.type (string) to cluster.disabled (bool)

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -52,7 +52,7 @@ func TestServerConfig(t *testing.T) {
 	max-writes-per-request = 3000
 
 	[cluster]
-		type = "static"
+		disabled = true
 		replicas = 2
 		hosts = [
 			"localhost:19444",
@@ -78,7 +78,7 @@ func TestServerConfig(t *testing.T) {
 	bind = "localhost:0"
 	data-dir = "` + actualDataDir + `"
 	[cluster]
-		type = "static"
+		disabled = true
 		hosts = [
 			"localhost:19444",
 		]
@@ -92,7 +92,7 @@ func TestServerConfig(t *testing.T) {
 		},
 		// TEST 2
 		{
-			args: []string{"server", "--log-path", logFile.Name(), "--cluster.type", "static"},
+			args: []string{"server", "--log-path", logFile.Name(), "--cluster.disabled", "true"},
 			env:  map[string]string{"PILOSA_PROFILE_CPU_TIME": "1m"},
 			cfgFileContent: `
 	bind = "localhost:19444"

--- a/config_test.go
+++ b/config_test.go
@@ -11,27 +11,15 @@ import (
 func Test_NewConfig(t *testing.T) {
 	c := pilosa.NewConfig()
 
+	if c.Cluster.Disabled != pilosa.DefaultClusterDisabled {
+		t.Fatalf("unexpected Cluster.Disabled: %v", c.Cluster.Disabled)
+	}
+
+	// Ensure that hosts can't be specificed on a non-disabled cluster.
 	c.Cluster.Hosts = []string{c.Bind, "localhost:10102"}
 
 	// Change cluster type from the default (gossip) to an invalid string.
-	c.Cluster.Type = "invalid-type"
-	if err := c.Validate(); err != pilosa.ErrConfigClusterTypeInvalid {
-		t.Fatal(err)
-	}
-
-	// Change cluster type back to gossip.
-	c.Cluster.Type = pilosa.ClusterGossip
-
-	// Check for bind address in cluster hosts.
-	c.Bind = "localhost:1"
-	if err := c.Validate(); err != pilosa.ErrConfigHostsMissing {
-		t.Fatal(err)
-	}
-
-	c.Bind = "localhost:10101"
-	c.Cluster.ReplicaN = 2
-	c.GossipSeed = "localhost:14000"
-	if err := c.Validate(); err != nil {
+	if err := c.Validate(); err != pilosa.ErrConfigClusterEnabledHosts {
 		t.Fatal(err)
 	}
 }

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -35,9 +35,9 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	SetTLSConfig(flags, &srv.Config.TLS.CertificatePath, &srv.Config.TLS.CertificateKeyPath, &srv.Config.TLS.SkipVerify)
 
 	// Cluster
+	flags.BoolVarP(&srv.Config.Cluster.Disabled, "cluster.disabled", "", srv.Config.Cluster.Disabled, "Disabled multi-node cluster communication (used for testing)")
 	flags.StringVarP(&srv.Config.Cluster.Coordinator, "cluster.coordinator", "", "", "Host that will act as cluster coordinator during startup and resizing.")
 	flags.IntVarP(&srv.Config.Cluster.ReplicaN, "cluster.replicas", "", 1, "Number of hosts each piece of data should be stored on.")
-	flags.StringVarP(&srv.Config.Cluster.Type, "cluster.type", "", "gossip", "Determine how the cluster handles membership and state sharing. Choose from [static, gossip]")
 	flags.StringSliceVarP(&srv.Config.Cluster.Hosts, "cluster.hosts", "", []string{}, "Comma separated list of hosts in cluster.")
 	flags.DurationVarP((*time.Duration)(&srv.Config.Cluster.LongQueryTime), "cluster.long-query-time", "", time.Minute, "Duration that will trigger log and stat messages for slow queries.")
 

--- a/pilosa.go
+++ b/pilosa.go
@@ -73,8 +73,7 @@ var (
 	ErrQueryRequired    = errors.New("query required")
 	ErrTooManyWrites    = errors.New("too many write commands")
 
-	ErrConfigClusterTypeInvalid = errors.New("invalid cluster type")
-	ErrConfigHostsMissing       = errors.New("missing bind address in cluster hosts")
+	ErrConfigClusterEnabledHosts = errors.New("providing hosts to a non-disabled cluster is not allowed")
 )
 
 // Regular expression to validate index and frame names.

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -217,7 +217,7 @@ func TestClusterResize_EmptyNode(t *testing.T) {
 // Ensure that a cluster of empty nodes comes up in a NORMAL state.
 func TestClusterResize_EmptyNodes(t *testing.T) {
 	// Configure node0
-	m0 := test.NewMain()
+	m0 := test.NewMainWithCluster()
 	defer m0.Close()
 
 	gossipHost := "localhost"
@@ -228,7 +228,7 @@ func TestClusterResize_EmptyNodes(t *testing.T) {
 	}
 
 	// Configure node1
-	m1 := test.NewMain()
+	m1 := test.NewMainWithCluster()
 	defer m1.Close()
 
 	seed, coord, err = m1.RunWithTransport(gossipHost, gossipPort, seed, &coord)
@@ -247,7 +247,7 @@ func TestClusterResize_EmptyNodes(t *testing.T) {
 func TestClusterResize_AddNode(t *testing.T) {
 	t.Run("NoData", func(t *testing.T) {
 		// Configure node0
-		m0 := test.NewMain()
+		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
 		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
@@ -256,7 +256,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		}
 
 		// Configure node1
-		m1 := test.NewMain()
+		m1 := test.NewMainWithCluster()
 		defer m1.Close()
 
 		var eg errgroup.Group
@@ -281,7 +281,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 	})
 	t.Run("WithIndex", func(t *testing.T) {
 		// Configure node0
-		m0 := test.NewMain()
+		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
 		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
@@ -300,7 +300,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		}
 
 		// Configure node1
-		m1 := test.NewMain()
+		m1 := test.NewMainWithCluster()
 		defer m1.Close()
 
 		var eg errgroup.Group
@@ -327,7 +327,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 	t.Run("ContinuousSlices", func(t *testing.T) {
 
 		// Configure node0
-		m0 := test.NewMain()
+		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
 		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
@@ -355,7 +355,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		}
 
 		// Configure node1
-		m1 := test.NewMain()
+		m1 := test.NewMainWithCluster()
 		defer m1.Close()
 
 		var eg errgroup.Group
@@ -382,7 +382,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 	t.Run("SkippedSlice", func(t *testing.T) {
 
 		// Configure node0
-		m0 := test.NewMain()
+		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
 		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
@@ -410,7 +410,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		}
 
 		// Configure node1
-		m1 := test.NewMain()
+		m1 := test.NewMainWithCluster()
 		defer m1.Close()
 
 		var eg errgroup.Group

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -269,7 +269,7 @@ func TestMain_SetColumnAttrsWithColumnOption(t *testing.T) {
 
 // Ensure program can set bits on one cluster and then restore to a second cluster.
 func TestMain_FrameRestore(t *testing.T) {
-	mains1 := test.NewMainArrayWithCluster(2)
+	mains1 := test.MustRunMainWithCluster(t, 2)
 	m10 := mains1[0]
 	m11 := mains1[1]
 
@@ -303,7 +303,7 @@ func TestMain_FrameRestore(t *testing.T) {
 	}
 
 	// Start second cluster.
-	mains2 := test.NewMainArrayWithCluster(2)
+	mains2 := test.MustRunMainWithCluster(t, 2)
 	m20 := mains2[0]
 	defer m20.Close()
 	m21 := mains2[1]

--- a/test/pilosa_test.go
+++ b/test/pilosa_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestNewCluster(t *testing.T) {
-	cluster := test.MustNewServerCluster(t, 3)
+	cluster := test.MustRunMainWithCluster(t, 3)
 
-	response, err := http.Get("http://" + cluster.Servers[0].Server.Addr().String() + "/status")
+	response, err := http.Get("http://" + cluster[0].Server.Addr().String() + "/status")
 	if err != nil {
 		t.Fatalf("getting schema: %v", err)
 	}


### PR DESCRIPTION
## Overview

Changes the configuration parameter `Cluster.Type` (which was a string option of `[none, static, gossip]`) to `Cluster.Disabled` which is a boolean.

Based on a discussion in #595.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
