### PR TITLE
fix bug in NewServerCluster where each host was its own coordinator

### DIFF
--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -222,7 +222,7 @@ func TestClusterResize_EmptyNodes(t *testing.T) {
 
 	gossipHost := "localhost"
 	gossipPort := 0
-	seed, coord, err := m0.RunWithTransport(gossipHost, gossipPort, "", nil)
+	seed, coord, err := m0.RunWithTransport(gossipHost, gossipPort, "", pilosa.URI{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func TestClusterResize_EmptyNodes(t *testing.T) {
 	m1 := test.NewMainWithCluster()
 	defer m1.Close()
 
-	seed, coord, err = m1.RunWithTransport(gossipHost, gossipPort, seed, &coord)
+	seed, coord, err = m1.RunWithTransport(gossipHost, gossipPort, seed, coord)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
+		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +261,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, &coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
 			if err != nil {
 				return err
 			}
@@ -284,7 +284,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
+		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -305,7 +305,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, &coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
 			if err != nil {
 				return err
 			}
@@ -330,7 +330,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
+		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -360,7 +360,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, &coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
 			if err != nil {
 				return err
 			}
@@ -385,7 +385,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", nil)
+		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -415,7 +415,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, &coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
 			if err != nil {
 				return err
 			}

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -85,7 +85,7 @@ func runMainWithCluster(size int) ([]*Main, error) {
 	for i := 0; i < size; i++ {
 		m := NewMainWithCluster()
 
-		gossipSeed, coordinator, err = m.RunWithTransport(gossipHost, gossipPort, gossipSeed, &coordinator)
+		gossipSeed, coordinator, err = m.RunWithTransport(gossipHost, gossipPort, gossipSeed, coordinator)
 		if err != nil {
 			return nil, errors.Wrap(err, "RunWithTransport")
 		}
@@ -132,7 +132,7 @@ func (m *Main) Reopen() error {
 }
 
 // RunWithTransport runs Main and returns the dynamically allocated gossip port.
-func (m *Main) RunWithTransport(host string, bindPort int, joinSeed string, coordinator *pilosa.URI) (seed string, coord pilosa.URI, err error) {
+func (m *Main) RunWithTransport(host string, bindPort int, joinSeed string, coordinator pilosa.URI) (seed string, coord pilosa.URI, err error) {
 	defer close(m.Started)
 
 	/*
@@ -185,12 +185,7 @@ func (m *Main) RunWithTransport(host string, bindPort int, joinSeed string, coor
 		return seed, coord, err
 	}
 
-	if coordinator != nil {
-		coord = *coordinator
-	} else {
-		coord = m.Server.URI
-	}
-	m.Server.Cluster.Coordinator = coord
+	m.Server.Cluster.Coordinator = coordinator
 	m.Server.Cluster.Static = false
 
 	// Initialize server.
@@ -199,7 +194,7 @@ func (m *Main) RunWithTransport(host string, bindPort int, joinSeed string, coor
 		return seed, coord, err
 	}
 
-	return seed, coord, nil
+	return seed, m.Server.Cluster.Coordinator, nil
 }
 
 // URL returns the base URL string for accessing the running program.

--- a/test/pilosa_test.go
+++ b/test/pilosa_test.go
@@ -10,7 +10,14 @@ import (
 )
 
 func TestNewCluster(t *testing.T) {
-	cluster := test.MustRunMainWithCluster(t, 3)
+	numNodes := 3
+	cluster := test.MustRunMainWithCluster(t, numNodes)
+	coordinator := cluster[0].Server.Cluster.Coordinator
+	for i := 1; i < numNodes; i++ {
+		if coordi := cluster[i].Server.Cluster.Coordinator; coordi != coordinator {
+			t.Fatalf("node %d does not have the same coordinator as node 0. '%v' and '%v' respectively", i, coordi, coordinator)
+		}
+	}
 
 	response, err := http.Get("http://" + cluster[0].Server.Addr().String() + "/status")
 	if err != nil {


### PR DESCRIPTION
## Overview

This PR contains the code from #1076 after addressing merge conflicts.

now using concrete URI values everywhere instead of pointers to them

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
