### PR TITLE
avoid overflow bug in differenceRunArray

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2504,6 +2504,8 @@ func differenceRunArray(a, b *container) *container {
 
 	bidx := 0
 	vb := b.array[bidx]
+
+RUNLOOP:
 	for _, run := range a.runs {
 		start := run.start
 		for vb < run.start {
@@ -2515,6 +2517,9 @@ func differenceRunArray(a, b *container) *container {
 		}
 		for vb >= run.start && vb <= run.last {
 			if vb == start {
+				if vb == 65535 { // overflow
+					break RUNLOOP
+				}
 				start++
 				bidx++
 				if bidx >= len(b.array) {
@@ -2525,6 +2530,9 @@ func differenceRunArray(a, b *container) *container {
 			}
 			output.runs = append(output.runs, interval16{start: start, last: vb - 1})
 			output.n += int(vb - start)
+			if vb == 65535 { // overflow
+				break RUNLOOP
+			}
 			start = vb + 1
 			bidx++
 			if bidx >= len(b.array) {

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -1479,6 +1479,16 @@ func TestDifferenceRunArray(t *testing.T) {
 			array: []uint16{0, 9, 10, 11, 12, 13, 14, 17, 19, 25, 27},
 			exp:   []interval16{{start: 1, last: 8}, {start: 15, last: 16}, {start: 20, last: 24}, {start: 26, last: 26}, {start: 28, last: 28}},
 		},
+		{
+			runs:  []interval16{{start: 0, last: 20}, {start: 65533, last: 65535}},
+			array: []uint16{65533, 65534, 65535},
+			exp:   []interval16{{start: 0, last: 20}},
+		},
+		{
+			runs:  []interval16{{start: 0, last: 20}, {start: 65530, last: 65535}},
+			array: []uint16{37, 65535},
+			exp:   []interval16{{start: 0, last: 20}, {start: 65530, last: 65534}},
+		},
 	}
 	for i, test := range tests {
 		a.runs = test.runs


### PR DESCRIPTION
## Overview

When the final value in the array was `65535` and the run also spanned `65535`, then an overflow caused the run `{0, 65535}` to be appended to the run slice. This PR prevents that by breaking out of the run loop before getting to the overflow.

Fixes #1103 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
