### PR TITLE
WIP: Implements Bitmaps call; fixes #1029

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -821,8 +821,8 @@ func (e *Executor) executeFieldRangeSlice(ctx context.Context, index string, c *
 func (e *Executor) executeUnionSlice(ctx context.Context, index string, c *pql.Call, slice uint64) (*Bitmap, error) {
 	other := NewBitmap()
 	for i, input := range c.Children {
-		if input.Name == "BitmapRange" {
-			err := e.executeBitmapRange(ctx, index, input, slice, func(bm *Bitmap, first bool) {
+		if input.Name == "Bitmaps" {
+			err := e.executeBitmaps(ctx, index, input, slice, func(bm *Bitmap, first bool) {
 				if i == 0 && first {
 					other = bm
 				} else {
@@ -848,7 +848,7 @@ func (e *Executor) executeUnionSlice(ctx context.Context, index string, c *pql.C
 	return other, nil
 }
 
-func (e *Executor) executeBitmapRange(ctx context.Context, index string, c *pql.Call, slice uint64, callback func(bm *Bitmap, first bool)) error {
+func (e *Executor) executeBitmaps(ctx context.Context, index string, c *pql.Call, slice uint64, callback func(bm *Bitmap, first bool)) error {
 	const columnLabel = "columnID"
 	const rowLabel = "rowID"
 

--- a/executor.go
+++ b/executor.go
@@ -821,19 +821,85 @@ func (e *Executor) executeFieldRangeSlice(ctx context.Context, index string, c *
 func (e *Executor) executeUnionSlice(ctx context.Context, index string, c *pql.Call, slice uint64) (*Bitmap, error) {
 	other := NewBitmap()
 	for i, input := range c.Children {
-		bm, err := e.executeBitmapCallSlice(ctx, index, input, slice)
-		if err != nil {
-			return nil, err
-		}
-
-		if i == 0 {
-			other = bm
+		if input.Name == "BitmapRange" {
+			err := e.executeBitmapRange(ctx, index, input, slice, func(bm *Bitmap, first bool) {
+				if i == 0 && first {
+					other = bm
+				} else {
+					other = other.Union(bm)
+				}
+			})
+			if err != nil {
+				return nil, err
+			}
 		} else {
-			other = other.Union(bm)
+			bm, err := e.executeBitmapCallSlice(ctx, index, input, slice)
+			if err != nil {
+				return nil, err
+			}
+			if i == 0 {
+				other = bm
+			} else {
+				other = other.Union(bm)
+			}
 		}
 	}
 	other.InvalidateCount()
 	return other, nil
+}
+
+func (e *Executor) executeBitmapRange(ctx context.Context, index string, c *pql.Call, slice uint64, callback func(bm *Bitmap, first bool)) error {
+	const columnLabel = "columnID"
+	const rowLabel = "rowID"
+
+	frame, _ := c.Args["frame"].(string)
+	if frame == "" {
+		frame = DefaultFrame
+	}
+
+	// Return an error if both the row and column label are specified.
+	rowIDs, rowOK := c.Args[rowLabel]
+	columnIDs, columnOK := c.Args[columnLabel]
+
+	if rowOK && columnOK {
+		return fmt.Errorf("BitmapRange() cannot specify both %s and %s values", rowLabel, columnLabel)
+	} else if !rowOK && !columnOK {
+		return fmt.Errorf("BitmapRange() must specify either %s or %s values", rowLabel, columnLabel)
+	}
+
+	if rowIDs != nil {
+		for i, rowID := range rowIDs.([]interface{}) {
+			call := &pql.Call{
+				Name: "Bitmap",
+				Args: map[string]interface{}{
+					"frame": frame,
+					"rowID": rowID,
+				},
+			}
+			bm, err := e.executeBitmapSlice(ctx, index, call, slice)
+			if err != nil {
+				return err
+			}
+			callback(bm, i == 0)
+		}
+		return nil
+	}
+
+	for i, columnID := range columnIDs.([]interface{}) {
+		call := &pql.Call{
+			Name: "Bitmap",
+			Args: map[string]interface{}{
+				"frame":    frame,
+				"columnID": columnID,
+			},
+		}
+		bm, err := e.executeBitmapSlice(ctx, index, call, slice)
+		if err != nil {
+			return err
+		}
+		callback(bm, i == 0)
+	}
+	return nil
 }
 
 // executeXorSlice executes a xor() call for a local slice.

--- a/pql/scanner.go
+++ b/pql/scanner.go
@@ -97,6 +97,8 @@ func (s *Scanner) Scan() (tok Token, pos Pos, lit string) {
 		return LBRACK, pos, string(ch)
 	case ']':
 		return RBRACK, pos, string(ch)
+	case '~':
+		return DASH, pos, string(ch)
 	default:
 		return ILLEGAL, pos, string(ch)
 	}

--- a/pql/token.go
+++ b/pql/token.go
@@ -50,6 +50,7 @@ const (
 	RPAREN  // )
 	LBRACK  // (
 	RBRACK  // )
+	DASH    // ~
 )
 
 var tokens = [...]string{
@@ -76,6 +77,7 @@ var tokens = [...]string{
 	RPAREN:  ")",
 	LBRACK:  "(",
 	RBRACK:  ")",
+	DASH:    "~",
 }
 
 var keywords map[string]Token


### PR DESCRIPTION
## Overview

Adds `BitmapRange` call and `~` operator.
Called like: `Union(BitmapRange(frame="data", rowID=[29~32]))`

Fixes #1029 

Currently works only together with `Union` calls, but it's trivial to add it to other bitmap calls. I'll do that once this approach is confirmed.

TODO: Misses tests.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
