### PR TITLE
remove cluster type http from docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,9 +183,8 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 #### Cluster Type
 
-* Description: Determine how the cluster handles membership and state sharing. Choose from [static, http, gossip].
+* Description: Determine how the cluster handles membership and state sharing. Choose from [static, gossip].
   * static - Messaging between nodes is disabled. This is primarily used for testing.
-  * http - Messages are transmitted over HTTP.
   * gossip - Messages are transmitted over TCP. Cluster status and node state are kept in sync via internode gossip.
 * Flag: `cluster.type="gossip"`
 * Env: `PILOSA_CLUSTER_TYPE="gossip"`


### PR DESCRIPTION
## Overview
cluster type http is no longer valid - this removes it from documentation

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
