### PR TITLE
Add support for lists of gossip seeds for redundancy

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,10 +127,6 @@ type TLSConfig struct {
 type Config struct {
 	DataDir string `toml:"data-dir"`
 	Bind    string `toml:"bind"`
-	// GossipPort DEPRECATED
-	GossipPort string `toml:"gossip-port"`
-	// GossipSeed DEPRECATED
-	GossipSeed string `toml:"gossip-seed"`
 
 	// Limits the number of mutating commands that can be in a single request to
 	// the server. This includes SetBit, ClearBit, SetRowAttrs & SetColumnAttrs.
@@ -151,7 +147,7 @@ type Config struct {
 
 	Gossip struct {
 		Port                string   `toml:"port"`
-		Seed                string   `toml:"seed"`
+		Seeds               []string `toml:"seeds"`
 		Key                 string   `toml:"key"`
 		StreamTimeout       Duration `toml:"stream-timeout"`
 		SuspicionMult       int      `toml:"suspicion-mult"`
@@ -193,9 +189,6 @@ func NewConfig() *Config {
 	c.Cluster.LongQueryTime = Duration(time.Minute)
 
 	// Gossip config.
-	// c.Gossip.Port = ""
-	// c.Gossip.Seed = ""
-	// c.Gossip.Key = ""
 	c.Gossip.StreamTimeout = Duration(DefaultGossipStreamTimeout)
 	c.Gossip.SuspicionMult = DefaultGossipSuspicionMult
 	c.Gossip.PushPullInterval = Duration(DefaultGossipPushPullInterval)

--- a/config.go
+++ b/config.go
@@ -189,6 +189,9 @@ func NewConfig() *Config {
 	c.Cluster.LongQueryTime = Duration(time.Minute)
 
 	// Gossip config.
+	// c.Gossip.Port = ""
+	// c.Gossip.Seeds = []string{}
+	// c.Gossip.Key = ""
 	c.Gossip.StreamTimeout = Duration(DefaultGossipStreamTimeout)
 	c.Gossip.SuspicionMult = DefaultGossipSuspicionMult
 	c.Gossip.PushPullInterval = Duration(DefaultGossipPushPullInterval)

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -26,8 +26,6 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags := cmd.Flags()
 	flags.StringVarP(&srv.Config.DataDir, "data-dir", "d", srv.Config.DataDir, "Directory to store pilosa data files.")
 	flags.StringVarP(&srv.Config.Bind, "bind", "b", srv.Config.Bind, "Default URI on which pilosa should listen.")
-	flags.StringVarP(&srv.Config.GossipPort, "gossip-port", "", "", "(DEPRECATED) Port to which pilosa should bind for internal state sharing.")
-	flags.StringVarP(&srv.Config.GossipSeed, "gossip-seed", "", "", "(DEPRECATED) Host with which to seed the gossip membership.")
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
 
@@ -43,7 +41,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 
 	// Gossip
 	flags.StringVarP(&srv.Config.Gossip.Port, "gossip.port", "", srv.Config.Gossip.Port, "Port to which pilosa should bind for internal state sharing.")
-	flags.StringVarP(&srv.Config.Gossip.Seed, "gossip.seed", "", srv.Config.Gossip.Seed, "Host with which to seed the gossip membership.")
+	flags.StringSliceVarP(&srv.Config.Gossip.Seeds, "gossip.seeds", "", srv.Config.Gossip.Seeds, "Host with which to seed the gossip membership.")
 	flags.StringVarP(&srv.Config.Gossip.Key, "gossip.key", "", srv.Config.Gossip.Key, "The path to file of the encryption key for gossip. The contents of the file should be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.")
 	flags.DurationVarP((*time.Duration)(&srv.Config.Gossip.StreamTimeout), "gossip.stream-timeout", "", (time.Duration)(srv.Config.Gossip.StreamTimeout), "Timeout for establishing a stream connection with a remote node for a full state sync.")
 	flags.IntVarP(&srv.Config.Gossip.SuspicionMult, "gossip.suspicion-mult", "", srv.Config.Gossip.SuspicionMult, "Multiplier for determining the time an inaccessible node is considered suspect before declaring it dead.")

--- a/ctl/server_test.go
+++ b/ctl/server_test.go
@@ -28,9 +28,6 @@ func TestBuildServerFlags(t *testing.T) {
 	stdin, stdout, stderr := GetIO(buf)
 	Server := server.NewCommand(stdin, stdout, stderr)
 	BuildServerFlags(cm, Server)
-	if cm.Flags().Lookup("gossip-port").Name == "" {
-		t.Fatal("gossip-port flag is required")
-	}
 	if cm.Flags().Lookup("data-dir").Name == "" {
 		t.Fatal("data-dir flag is required")
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,16 +109,16 @@ Any flag that has a value that is a comma separated list on the command line bec
       port = 11101
     ```
 
-#### Gossip Seed
+#### Gossip Seeds
 
-* Description: When using the gossip [Cluster Type]({{< ref "#cluster-type" >}}), this specifies which internal host(s) should be used to initialize membership in the cluster. Typcially this can be the address of any available host in the cluster. You may enter multiple seeds by separating them with a comma. For example, when starting a three-node cluster made up of `node0`, `node1`, and `node2`, the `gossip-seed` for all three nodes can be configured to be the address of `node0`.
-* Flag: `--gossip.seed="localhost:11101"`
-* Env: `PILOSA_GOSSIP_SEED="localhost:11101"`
+* Description: This specifies which internal host(s) should be used to initialize membership in the cluster. Typcially this can be the address of any available host in the cluster. For example, when starting a three-node cluster made up of `node0`, `node1`, and `node2`, the `gossip.seeds` for all three nodes can be configured to be the address of `node0`. Multiple seeds should be comma-separated in the flag and env forms.
+* Flag: `--gossip.seeds="localhost:11101"`
+* Env: `PILOSA_GOSSIP_SEEDS="localhost:11101"`
 * Config:
 
     ```toml
     [gossip]
-      seed = "localhost:11101"
+      seeds = ["localhost:11101"]
     ```
 
 #### Gossip Key
@@ -134,7 +134,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 #### Cluster Hosts
 
-* Description: List of hosts in the cluster. Multiple hosts should be comma separated in the flag and env forms.
+* Description: List of hosts in the cluster. Multiple hosts should be comma-separated in the flag and env forms.
 * Flag: `--cluster.hosts="localhost:10101"`
 * Env: `PILOSA_CLUSTER_HOSTS="localhost:10101"`
 * Config:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,7 +111,7 @@ Any flag that has a value that is a comma separated list on the command line bec
 
 #### Gossip Seed
 
-* Description: When using the gossip [Cluster Type]({{< ref "#cluster-type" >}}), this specifies which internal host should be used to initialize membership in the cluster. Typcially this can be the address of any available host in the cluster. For example, when starting a three-node cluster made up of `node0`, `node1`, and `node2`, the `gossip-seed` for all three nodes can be configured to be the address of `node0`.
+* Description: When using the gossip [Cluster Type]({{< ref "#cluster-type" >}}), this specifies which internal host(s) should be used to initialize membership in the cluster. Typcially this can be the address of any available host in the cluster. You may enter multiple seeds by separating them with a comma. For example, when starting a three-node cluster made up of `node0`, `node1`, and `node2`, the `gossip-seed` for all three nodes can be configured to be the address of `node0`.
 * Flag: `--gossip.seed="localhost:11101"`
 * Env: `PILOSA_GOSSIP_SEED="localhost:11101"`
 * Config:

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -62,9 +62,9 @@ func (g *GossipMemberSet) Start(h pilosa.BroadcastHandler) error {
 	return nil
 }
 
-// Seed returns the gossipSeed determined by the config.
-func (g *GossipMemberSet) Seed() string {
-	return g.config.gossipSeed
+// Seeds returns the gossipSeeds determined by the config.
+func (g *GossipMemberSet) Seeds() []string {
+	return g.config.gossipSeeds
 }
 
 // Open implements the MemberSet interface to start network activity.
@@ -92,9 +92,8 @@ func (g *GossipMemberSet) Open(n *pilosa.Node) error {
 		RetransmitMult: 3,
 	}
 
-	parts := strings.Split(g.config.gossipSeed, ",")
-	var uris = make([]*pilosa.URI, len(parts))
-	for i, addr := range parts {
+	var uris = make([]*pilosa.URI, len(g.config.gossipSeeds))
+	for i, addr := range g.config.gossipSeeds {
 		uris[i], err = pilosa.NewURIFromAddress(addr)
 		if err != nil {
 			return fmt.Errorf("new uri from address: %s", err)
@@ -148,7 +147,7 @@ func (g *GossipMemberSet) logger() *log.Logger {
 ////////////////////////////////////////////////////////////////
 
 type gossipConfig struct {
-	gossipSeed       string
+	gossipSeeds      []string
 	memberlistConfig *memberlist.Config
 }
 
@@ -197,14 +196,14 @@ func NewGossipMemberSetWithTransport(name string, cfg *pilosa.Config, transport 
 
 	g.config = &gossipConfig{
 		memberlistConfig: conf,
-		gossipSeed:       cfg.Gossip.Seed,
+		gossipSeeds:      cfg.Gossip.Seeds,
 	}
 
 	g.statusHandler = server
 
-	// If no gossipSeed is provided, use local host:port.
-	if cfg.Gossip.Seed == "" {
-		g.config.gossipSeed = fmt.Sprintf("%s:%d", host, port)
+	// If no gossipSeeds is provided, use local host:port.
+	if len(cfg.Gossip.Seeds) == 0 {
+		g.config.gossipSeeds = []string{fmt.Sprintf("%s:%d", host, port)}
 	}
 
 	return g, nil

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -47,7 +47,7 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 
 	// get the host portion of addr to use for binding
 	m0.Config.Gossip.Port = "0"
-	m0.Config.Gossip.Seed = ""
+	m0.Config.Gossip.Seeds = []string{}
 
 	m0.Server.Cluster.Coordinator = m0.Server.URI
 	m0.Server.Cluster.Topology = &pilosa.Topology{NodeIDs: []string{m0.Server.NodeID, m1.Server.NodeID}}
@@ -75,7 +75,7 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 
 	// get the host portion of addr to use for binding
 	m1.Config.Gossip.Port = "0"
-	m1.Config.Gossip.Seed = gossipMemberSet0.Seed()
+	m1.Config.Gossip.Seeds = gossipMemberSet0.Seeds()
 
 	m1.Server.Cluster.Coordinator = m0.Server.URI
 	m1.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver()
@@ -222,7 +222,7 @@ func TestClusterResize_EmptyNodes(t *testing.T) {
 
 	gossipHost := "localhost"
 	gossipPort := 0
-	seed, coord, err := m0.RunWithTransport(gossipHost, gossipPort, "", pilosa.URI{})
+	seed, coord, err := m0.RunWithTransport(gossipHost, gossipPort, []string{}, pilosa.URI{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +231,7 @@ func TestClusterResize_EmptyNodes(t *testing.T) {
 	m1 := test.NewMainWithCluster()
 	defer m1.Close()
 
-	seed, coord, err = m1.RunWithTransport(gossipHost, gossipPort, seed, coord)
+	seed, coord, err = m1.RunWithTransport(gossipHost, gossipPort, []string{seed}, coord)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +250,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
+		seed, coord, err := m0.RunWithTransport("localhost", 0, []string{}, pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -261,7 +261,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, []string{seed}, coord)
 			if err != nil {
 				return err
 			}
@@ -284,7 +284,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
+		seed, coord, err := m0.RunWithTransport("localhost", 0, []string{}, pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -305,7 +305,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, []string{seed}, coord)
 			if err != nil {
 				return err
 			}
@@ -330,7 +330,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
+		seed, coord, err := m0.RunWithTransport("localhost", 0, []string{}, pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -360,7 +360,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, []string{seed}, coord)
 			if err != nil {
 				return err
 			}
@@ -385,7 +385,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
+		seed, coord, err := m0.RunWithTransport("localhost", 0, []string{}, pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -415,7 +415,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 
 		var eg errgroup.Group
 		eg.Go(func() error {
-			_, _, err = m1.RunWithTransport("localhost", 0, seed, coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, []string{seed}, coord)
 			if err != nil {
 				return err
 			}
@@ -443,7 +443,7 @@ func TestCluster_GossipMembership(t *testing.T) {
 		m0 := test.NewMainWithCluster()
 		defer m0.Close()
 
-		seed, coord, err := m0.RunWithTransport("localhost", 0, "", pilosa.URI{})
+		seed, coord, err := m0.RunWithTransport("localhost", 0, []string{}, pilosa.URI{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -455,7 +455,7 @@ func TestCluster_GossipMembership(t *testing.T) {
 		var eg errgroup.Group
 		eg.Go(func() error {
 			// Pass invalid seed as first in list
-			_, _, err = m1.RunWithTransport("localhost", 0, "http://localhost:8765,"+seed, coord)
+			_, _, err = m1.RunWithTransport("localhost", 0, []string{"http://localhost:8765", seed}, coord)
 			if err != nil {
 				return err
 			}
@@ -468,7 +468,7 @@ func TestCluster_GossipMembership(t *testing.T) {
 
 		eg.Go(func() error {
 			// Pass invalid seed as last in list
-			_, _, err = m2.RunWithTransport("localhost", 0, seed+",http://localhost:8765", coord)
+			_, _, err = m2.RunWithTransport("localhost", 0, []string{seed, "http://localhost:8765"}, coord)
 			if err != nil {
 				return err
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -237,11 +237,8 @@ func (m *Command) SetupNetworking() error {
 
 	// Set internal port (string).
 	gossipPortStr := pilosa.DefaultGossipPort
-	// Config.GossipPort is deprecated, so Config.Gossip.Port has priority
 	if m.Config.Gossip.Port != "" {
 		gossipPortStr = m.Config.Gossip.Port
-	} else if m.Config.GossipPort != "" {
-		gossipPortStr = m.Config.GossipPort
 	}
 
 	gossipPort, err := strconv.Atoi(gossipPortStr)


### PR DESCRIPTION
## Overview

This adds support for a comma-separated list of URIs in the `gossip.seed` configuration variable.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
