### PR TITLE
prevent excessive sendSyce (createView) messages.

### DIFF
--- a/server.go
+++ b/server.go
@@ -424,7 +424,7 @@ func (s *Server) ReceiveMessage(pb proto.Message) error {
 		if f == nil {
 			return fmt.Errorf("Local Frame not found: %s", obj.Frame)
 		}
-		_, err := f.CreateViewIfNotExistsBase(obj.View)
+		_, _, err := f.createViewIfNotExistsBase(obj.View)
 		if err != nil {
 			return err
 		}

--- a/view.go
+++ b/view.go
@@ -99,6 +99,12 @@ func (v *View) Path() string { return v.path }
 
 // Open opens and initializes the view.
 func (v *View) Open() error {
+
+	// Never keep a cache for field views.
+	if strings.HasPrefix(v.name, ViewFieldPrefix) {
+		v.cacheType = CacheTypeNone
+	}
+
 	if err := func() error {
 		// Ensure the view's path exists.
 		if err := os.MkdirAll(v.path, 0777); err != nil {


### PR DESCRIPTION
## Overview

This PR fixes an issue where a broadcast message (`CreateViewMessage`) was being sent on any schema check. Now, if a view is not created during the check, then no message is sent.

This also moves the logic with disables caching on BSI field into the `view.Open()` method so that it's considered on startup.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
