### PR TITLE
remove old GossipPort and GossipSeed config options

### DIFF
--- a/config.go
+++ b/config.go
@@ -127,10 +127,6 @@ type TLSConfig struct {
 type Config struct {
 	DataDir string `toml:"data-dir"`
 	Bind    string `toml:"bind"`
-	// GossipPort DEPRECATED
-	GossipPort string `toml:"gossip-port"`
-	// GossipSeed DEPRECATED
-	GossipSeed string `toml:"gossip-seed"`
 
 	// Limits the number of mutating commands that can be in a single request to
 	// the server. This includes SetBit, ClearBit, SetRowAttrs & SetColumnAttrs.

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -26,8 +26,6 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags := cmd.Flags()
 	flags.StringVarP(&srv.Config.DataDir, "data-dir", "d", srv.Config.DataDir, "Directory to store pilosa data files.")
 	flags.StringVarP(&srv.Config.Bind, "bind", "b", srv.Config.Bind, "Default URI on which pilosa should listen.")
-	flags.StringVarP(&srv.Config.GossipPort, "gossip-port", "", "", "(DEPRECATED) Port to which pilosa should bind for internal state sharing.")
-	flags.StringVarP(&srv.Config.GossipSeed, "gossip-seed", "", "", "(DEPRECATED) Host with which to seed the gossip membership.")
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
 
@@ -38,7 +36,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.BoolVarP(&srv.Config.Cluster.Disabled, "cluster.disabled", "", srv.Config.Cluster.Disabled, "Disabled multi-node cluster communication (used for testing)")
 	flags.StringVarP(&srv.Config.Cluster.Coordinator, "cluster.coordinator", "", "", "Host that will act as cluster coordinator during startup and resizing.")
 	flags.IntVarP(&srv.Config.Cluster.ReplicaN, "cluster.replicas", "", 1, "Number of hosts each piece of data should be stored on.")
-	flags.StringSliceVarP(&srv.Config.Cluster.Hosts, "cluster.hosts", "", []string{}, "Comma separated list of hosts in cluster.")
+	flags.StringSliceVarP(&srv.Config.Cluster.Hosts, "cluster.hosts", "", []string{}, "Comma separated list of hosts in cluster. Only used for testing.")
 	flags.DurationVarP((*time.Duration)(&srv.Config.Cluster.LongQueryTime), "cluster.long-query-time", "", time.Minute, "Duration that will trigger log and stat messages for slow queries.")
 
 	// Gossip

--- a/ctl/server_test.go
+++ b/ctl/server_test.go
@@ -28,9 +28,6 @@ func TestBuildServerFlags(t *testing.T) {
 	stdin, stdout, stderr := GetIO(buf)
 	Server := server.NewCommand(stdin, stdout, stderr)
 	BuildServerFlags(cm, Server)
-	if cm.Flags().Lookup("gossip-port").Name == "" {
-		t.Fatal("gossip-port flag is required")
-	}
 	if cm.Flags().Lookup("data-dir").Name == "" {
 		t.Fatal("data-dir flag is required")
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -240,8 +240,6 @@ func (m *Command) SetupNetworking() error {
 	// Config.GossipPort is deprecated, so Config.Gossip.Port has priority
 	if m.Config.Gossip.Port != "" {
 		gossipPortStr = m.Config.Gossip.Port
-	} else if m.Config.GossipPort != "" {
-		gossipPortStr = m.Config.GossipPort
 	}
 
 	gossipPort, err := strconv.Atoi(gossipPortStr)


### PR DESCRIPTION
## Overview

This PR removes the deprecated GossipPort (`--gossip-port`) and GossipSeed (`--gossip-seed`) config options. It also updates the `Cluster.Hosts` help text to clarify that it is only to be used for testing.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
