### PR TITLE
make container struct description more accurate

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1002,12 +1002,16 @@ const ArrayMaxSize = 4096
 // RunMaxSize represents the maximum size of run length encoded containers.
 const RunMaxSize = 2048
 
-// container represents a container for uint32 integers.
+// container represents a container for uint16 integers.
 //
-// These are used for storing the low bits. Containers are separated into three
-// types depending on cardinality. For containers with less than 4,096 values,
-// an array or RLE container is used, depending on the contents. For containers
-// with more than 4,096 values, the values are encoded into bitmaps.
+// These are used for storing the low bits of numbers in larger sets of uint64.
+// The high bits are stored in a container's key which is tracked by a separate
+// data structure. Integers in a container can be encoded in one of three ways -
+// the encoding used is usually whichever is most compact, though any container
+// type should be able to encode any set of integers safely. For containers with
+// less than 4,096 values, an array is often used. Containers with long runs of
+// integers would use run length encoding, and more random data usually uses
+// bitmap encoding.
 type container struct {
 	mapped        bool         // mapped directly to a byte slice when true
 	containerType byte         // array, bitmap, or run


### PR DESCRIPTION
## Overview

I noticed this comment was pretty wrong a while ago, but finally fixing it. Note that I'm explicitly saying that an array container COULD have more than 4096 values, and all the code should still work, and more generally, any container type can represent any set of bits and all operations should still perform. This is consistent (I think) with our new testing strategy, so I think it's good to be explicit about it.

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
