### PR TITLE
Refactor Diagnostics: Move to main package, remove gobreaker, add SystemInfo abstraction for gopsutil dependency injection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -206,12 +206,6 @@
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
-  name = "github.com/sony/gobreaker"
-  packages = ["."]
-  revision = "e9556a45379ef1da12e54847edb2fb3d7d566f36"
-  version = "0.3.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/spf13/afero"
   packages = [".","mem"]

--- a/broadcast.go
+++ b/broadcast.go
@@ -63,17 +63,17 @@ var NopBroadcaster Broadcaster
 
 type nopBroadcaster struct{}
 
-// SendSync A no-op implemenetation of Broadcaster SendSync method.
+// SendSync A no-op implementation of Broadcaster SendSync method.
 func (n *nopBroadcaster) SendSync(pb proto.Message) error {
 	return nil
 }
 
-// SendAsync A no-op implemenetation of Broadcaster SendAsync method.
+// SendAsync A no-op implementation of Broadcaster SendAsync method.
 func (n *nopBroadcaster) SendAsync(pb proto.Message) error {
 	return nil
 }
 
-// SendTo is a no-op implemenetation of Broadcaster SendTo method.
+// SendTo is a no-op implementation of Broadcaster SendTo method.
 func (c *nopBroadcaster) SendTo(to *Node, pb proto.Message) error {
 	return nil
 }
@@ -112,7 +112,7 @@ var NopGossiper Gossiper
 
 type nopGossiper struct{}
 
-// SendAsync A no-op implemenetation of Gossiper SendAsync method.
+// SendAsync A no-op implementation of Gossiper SendAsync method.
 func (n *nopGossiper) SendAsync(pb proto.Message) error {
 	return nil
 }

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -91,13 +91,8 @@ func (d *DiagnosticsCollector) Flush() error {
 	if err != nil {
 		return err
 	}
+	// Intentionally ignoring response body, as user does not need to be notified of error.
 	defer resp.Body.Close()
-
-	// TODO verify response
-	_, err = ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -38,7 +38,7 @@ type versionResponse struct {
 	Message string `json:"message"`
 }
 
-// DiagnosticsCollector represents a collector/sender of diagnostics data
+// DiagnosticsCollector represents a collector/sender of diagnostics data.
 type DiagnosticsCollector struct {
 	mu          sync.Mutex
 	host        string
@@ -57,9 +57,8 @@ type DiagnosticsCollector struct {
 	server *Server
 }
 
-// New returns a pointer to a new DiagnosticsCollector Client given an addr in the format "hostname:port".
+// NewDiagnosticsCollector returns a new DiagnosticsCollector given an addr in the format "hostname:port".
 func NewDiagnosticsCollector(host string) *DiagnosticsCollector {
-
 	return &DiagnosticsCollector{
 		host:       host,
 		VersionURL: defaultVersionCheckURL,
@@ -118,7 +117,7 @@ func (d *DiagnosticsCollector) CheckVersion() error {
 		return fmt.Errorf("json decode: %s", err)
 	}
 
-	// Same a version as last test
+	// If version has not changed since the last check, return
 	if rsp.Version == d.lastVersion {
 		return nil
 	}
@@ -133,8 +132,8 @@ func (d *DiagnosticsCollector) CheckVersion() error {
 
 // compareVersion check version strings.
 func (d *DiagnosticsCollector) compareVersion(value string) error {
-	currentVersion := VersionSegments(value)
-	localVersion := VersionSegments(d.version)
+	currentVersion := versionSegments(value)
+	localVersion := versionSegments(d.version)
 
 	if localVersion[0] < currentVersion[0] { //Major
 		return fmt.Errorf("Warning: You are running Pilosa %s. A newer version (%s) is available: https://github.com/pilosa/pilosa/releases", d.version, value)
@@ -249,8 +248,8 @@ func (d *DiagnosticsCollector) EnrichWithSchemaProperties() {
 	d.Set("TimeQuantumEnabled", timeQuantumEnabled)
 }
 
-// VersionSegments returns the numeric segments of the version as a slice of ints.
-func VersionSegments(segments string) []int {
+// versionSegments returns the numeric segments of the version as a slice of ints.
+func versionSegments(segments string) []int {
 	segments = strings.Trim(segments, "v")
 	segments = strings.Split(segments, "-")[0]
 	s := strings.Split(segments, ".")
@@ -261,7 +260,7 @@ func VersionSegments(segments string) []int {
 	return segmentSlice
 }
 
-// SystemInfo collects information about the host OS
+// SystemInfo collects information about the host OS.
 type SystemInfo interface {
 	Uptime() (uint64, error)
 	Platform() (string, error)
@@ -273,51 +272,51 @@ type SystemInfo interface {
 	MemUsed() (uint64, error)
 }
 
-// NewNopSystemInfo creates a no-op implementation of SystemInfo
+// NewNopSystemInfo creates a no-op implementation of SystemInfo.
 func NewNopSystemInfo() *NopSystemInfo {
 	return &NopSystemInfo{}
 }
 
-// NopSystemInfo is a no-op implementation of SystemInfo
+// NopSystemInfo is a no-op implementation of SystemInfo.
 type NopSystemInfo struct {
 }
 
-// Uptime is a no-op implementation of SystemInfo.Uptime
+// Uptime is a no-op implementation of SystemInfo.Uptime.
 func (n *NopSystemInfo) Uptime() (uint64, error) {
 	return 0, nil
 }
 
-// Platform is a no-op implementation of SystemInfo.Platform
+// Platform is a no-op implementation of SystemInfo.Platform.
 func (n *NopSystemInfo) Platform() (string, error) {
 	return "", nil
 }
 
-// Family is a no-op implementation of SystemInfo.Family
+// Family is a no-op implementation of SystemInfo.Family.
 func (n *NopSystemInfo) Family() (string, error) {
 	return "", nil
 }
 
-// OSVersion is a no-op implementation of SystemInfo.OSVersion
+// OSVersion is a no-op implementation of SystemInfo.OSVersion.
 func (n *NopSystemInfo) OSVersion() (string, error) {
 	return "", nil
 }
 
-// KernelVersion is a no-op implementation of SystemInfo.KernelVersion
+// KernelVersion is a no-op implementation of SystemInfo.KernelVersion.
 func (n *NopSystemInfo) KernelVersion() (string, error) {
 	return "", nil
 }
 
-// MemFree is a no-op implementation of SystemInfo.MemFree
+// MemFree is a no-op implementation of SystemInfo.MemFree.
 func (n *NopSystemInfo) MemFree() (uint64, error) {
 	return 0, nil
 }
 
-// MemTotal is a no-op implementation of SystemInfo.MemTotal
+// MemTotal is a no-op implementation of SystemInfo.MemTotal.
 func (n *NopSystemInfo) MemTotal() (uint64, error) {
 	return 0, nil
 }
 
-// MemUsed is a no-op implementation of SystemInfo.MemUsed
+// MemUsed is a no-op implementation of SystemInfo.MemUsed.
 func (n *NopSystemInfo) MemUsed() (uint64, error) {
 	return 0, nil
 }

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -148,6 +148,13 @@ func (d *DiagnosticsCollector) encode() ([]byte, error) {
 
 // Set adds a key value metric.
 func (d *DiagnosticsCollector) Set(name string, value interface{}) {
+	switch v := value.(type) {
+	case string:
+		if v == "" {
+			// Do not set empty string
+			return
+		}
+	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.metrics[name] = value

--- a/diagnostics_internal_test.go
+++ b/diagnostics_internal_test.go
@@ -69,7 +69,7 @@ func TestDiagnosticsClient(t *testing.T) {
 
 func TestDiagnosticsVersion_Parse(t *testing.T) {
 	version := "0.1.1"
-	vs := VersionSegments(version)
+	vs := versionSegments(version)
 
 	output := []int{0, 1, 1}
 	if !reflect.DeepEqual(vs, output) {

--- a/diagnostics_test.go
+++ b/diagnostics_test.go
@@ -32,7 +32,6 @@ func TestDiagnosticsClient(t *testing.T) {
 	// Create a new client.
 	d := NewDiagnosticsCollector(server.URL)
 	d.SetLogger(ioutil.Discard)
-	d.Open()
 
 	d.Set("gg", 10)
 	d.Set("ss", "ss")
@@ -80,7 +79,6 @@ func TestDiagnosticsVersion_Parse(t *testing.T) {
 
 func TestDiagnosticsVersion_Compare(t *testing.T) {
 	d := NewDiagnosticsCollector("localhost:10101")
-	d.Open()
 
 	version := "v0.1.1"
 	d.SetVersion(version)

--- a/diagnostics_test.go
+++ b/diagnostics_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package diagnostics_test
+package pilosa
 
 import (
 	"encoding/json"
@@ -23,25 +23,21 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-
-	"github.com/pilosa/pilosa/diagnostics"
 )
 
 func TestDiagnosticsClient(t *testing.T) {
 	// Mock server.
 	server := httptest.NewServer(nil)
-	defer server.Close()
 
 	// Create a new client.
-	d := diagnostics.New(server.URL)
+	d := NewDiagnosticsCollector(server.URL)
 	d.SetLogger(ioutil.Discard)
 	d.Open()
-	defer d.Close()
 
 	d.Set("gg", 10)
 	d.Set("ss", "ss")
 
-	data, err := d.Encode()
+	data, err := d.encode()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +54,7 @@ func TestDiagnosticsClient(t *testing.T) {
 
 	// Test the metrics after a flush.
 	d.Flush()
-	data, err = d.Encode()
+	data, err = d.encode()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +70,7 @@ func TestDiagnosticsClient(t *testing.T) {
 
 func TestDiagnosticsVersion_Parse(t *testing.T) {
 	version := "0.1.1"
-	vs := diagnostics.VersionSegments(version)
+	vs := VersionSegments(version)
 
 	output := []int{0, 1, 1}
 	if !reflect.DeepEqual(vs, output) {
@@ -83,35 +79,34 @@ func TestDiagnosticsVersion_Parse(t *testing.T) {
 }
 
 func TestDiagnosticsVersion_Compare(t *testing.T) {
-	d := diagnostics.New("localhost:10101")
+	d := NewDiagnosticsCollector("localhost:10101")
 	d.Open()
-	defer d.Close()
 
 	version := "v0.1.1"
 	d.SetVersion(version)
 
-	err := d.CompareVersion("v1.7.0")
+	err := d.compareVersion("v1.7.0")
 	if !strings.Contains(err.Error(), "A newer version") {
 		t.Fatalf("Expected a newer version is available, actual error: %s", err)
 	}
-	err = d.CompareVersion("1.7.0")
+	err = d.compareVersion("1.7.0")
 	if !strings.Contains(err.Error(), "A newer version") {
 		t.Fatalf("Expected a newer version is available, actual error: %s", err)
 	}
-	err = d.CompareVersion("0.7.0")
+	err = d.compareVersion("0.7.0")
 	if !strings.Contains(err.Error(), "The latest Minor release is") {
 		t.Fatalf("Expected Minor Version Missmatch, actual error: %s", err)
 	}
-	err = d.CompareVersion("0.1.2")
+	err = d.compareVersion("0.1.2")
 	if !strings.Contains(err.Error(), "There is a new patch release of Pilosa") {
 		t.Fatalf("Expected Patch Version Missmatch, actual error: %s", err)
 	}
-	err = d.CompareVersion("0.1.1")
+	err = d.compareVersion("0.1.1")
 	if err != nil {
 		t.Fatalf("Versions should match")
 	}
 	d.SetVersion("v1.7.0")
-	err = d.CompareVersion("0.7.2")
+	err = d.compareVersion("0.7.2")
 	if err != nil {
 		t.Fatalf("Local version is greater")
 	}
@@ -125,21 +120,15 @@ func TestDiagnosticsVersion_Check(t *testing.T) {
 			Version: "1.1.1",
 		})
 	}))
-	defer server.Close()
 
 	// Create a new client.
-	d := diagnostics.New("localhost:10101")
-	defer d.Close()
+	d := NewDiagnosticsCollector("localhost:10101")
 
 	version := "0.1.1"
 	d.SetVersion(version)
 	d.VersionURL = server.URL
 
 	d.CheckVersion()
-}
-
-type versionResponse struct {
-	Version string `json:"version"`
 }
 
 func compareJSON(a, b []byte) (bool, error) {
@@ -156,12 +145,10 @@ func compareJSON(a, b []byte) (bool, error) {
 func BenchmarkDiagnostics(b *testing.B) {
 	// Mock server.
 	server := httptest.NewServer(nil)
-	defer server.Close()
 
 	// Create a new client.
-	d := diagnostics.New(server.URL)
+	d := NewDiagnosticsCollector(server.URL)
 	d.SetLogger(ioutil.Discard)
-	defer d.Close()
 
 	prev := runtime.GOMAXPROCS(4)
 	defer runtime.GOMAXPROCS(prev)

--- a/gc.go
+++ b/gc.go
@@ -29,10 +29,10 @@ var NopGCNotifier GCNotifier
 
 type nopGCNotifier struct{}
 
-// Close is a no-op implemenetation of GCNotifier Close method.
+// Close is a no-op implementation of GCNotifier Close method.
 func (n *nopGCNotifier) Close() {}
 
-// AfterGC is a no-op implemenetation of GCNotifier AfterGC method.
+// AfterGC is a no-op implementation of GCNotifier AfterGC method.
 func (c *nopGCNotifier) AfterGC() <-chan struct{} {
 	return nil
 }

--- a/gc.go
+++ b/gc.go
@@ -14,6 +14,9 @@
 
 package pilosa
 
+// Ensure nopGCNotifier implements interface.
+var _ GCNotifier = &nopGCNotifier{}
+
 // GCNotifier represents an interface for garbage collection notificationss.
 type GCNotifier interface {
 	Close()

--- a/gopsutil/systeminfo.go
+++ b/gopsutil/systeminfo.go
@@ -1,0 +1,116 @@
+package gopsutil
+
+import (
+	"github.com/pilosa/pilosa"
+	"github.com/shirou/gopsutil/host"
+	"github.com/shirou/gopsutil/mem"
+)
+
+var _ pilosa.SystemInfo = NewSystemInfo()
+
+// SystemInfo is an implementation of pilosa.SystemInfo that uses gopsutil to collect information about the host OS
+type SystemInfo struct {
+	hostInfo  *host.InfoStat
+	memInfo   *mem.VirtualMemoryStat
+	platform  string
+	family    string
+	osVersion string
+}
+
+// Uptime returns the system uptime in seconds
+func (s *SystemInfo) Uptime() (uptime uint64, err error) {
+	if s.hostInfo == nil {
+		s.hostInfo, err = host.Info()
+		if err != nil {
+			return 0, err
+		}
+	}
+	return s.hostInfo.Uptime, nil
+}
+
+// Uptime returns the system platform
+func (s *SystemInfo) Platform() (string, error) {
+	err := s.collectPlatformInfo()
+	if err != nil {
+		return "", err
+	}
+	return s.platform, nil
+}
+
+// Family returns the system family
+func (s *SystemInfo) Family() (string, error) {
+	err := s.collectPlatformInfo()
+	if err != nil {
+		return "", err
+	}
+	return s.family, err
+}
+
+// OSVersion returns the OS Version
+func (s *SystemInfo) OSVersion() (string, error) {
+	err := s.collectPlatformInfo()
+	if err != nil {
+		return "", err
+	}
+	return s.osVersion, err
+}
+
+// collectPlatformInfo fetches and caches system platform information
+func (s *SystemInfo) collectPlatformInfo() error {
+	var err error
+	if s.platform == "" {
+		s.platform, s.family, s.osVersion, err = host.PlatformInformation()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// collectMemoryInfo fetches and caches memory stats
+func (s *SystemInfo) collectMemoryInfo() (err error) {
+	if s.memInfo == nil {
+		s.memInfo, err = mem.VirtualMemory()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MemFree returns the amount of free memory in bytes
+func (s *SystemInfo) MemFree() (uint64, error) {
+	err := s.collectMemoryInfo()
+	if err != nil {
+		return 0, err
+	}
+	return s.memInfo.Free, err
+}
+
+// MemFree returns the amount of total memory in bytes
+func (s *SystemInfo) MemTotal() (uint64, error) {
+	err := s.collectMemoryInfo()
+	if err != nil {
+		return 0, err
+	}
+	return s.memInfo.Total, err
+}
+
+// MemFree returns the amount of used memory in bytes
+func (s *SystemInfo) MemUsed() (uint64, error) {
+	err := s.collectMemoryInfo()
+	if err != nil {
+		return 0, err
+	}
+	return s.memInfo.Used, err
+}
+
+// KernelVersion returns the kernel version as a string
+func (s *SystemInfo) KernelVersion() (string, error) {
+	return host.KernelVersion()
+}
+
+// NewSystemInfo is a constructor for the gopsutil implementation of SystemInfo
+func NewSystemInfo() *SystemInfo {
+	return &SystemInfo{}
+}

--- a/gopsutil/systeminfo.go
+++ b/gopsutil/systeminfo.go
@@ -8,14 +8,14 @@ import (
 
 var _ pilosa.SystemInfo = NewSystemInfo()
 
-// SystemInfo is an implementation of pilosa.SystemInfo that uses gopsutil to collect information about the host OS
+// SystemInfo is an implementation of pilosa.SystemInfo that uses gopsutil to collect information about the host OS.
 type SystemInfo struct {
 	platform  string
 	family    string
 	osVersion string
 }
 
-// Uptime returns the system uptime in seconds
+// Uptime returns the system uptime in seconds.
 func (s *SystemInfo) Uptime() (uptime uint64, err error) {
 	hostInfo, err := host.Info()
 	if err != nil {
@@ -24,7 +24,7 @@ func (s *SystemInfo) Uptime() (uptime uint64, err error) {
 	return hostInfo.Uptime, nil
 }
 
-// collectPlatformInfo fetches and caches system platform information
+// collectPlatformInfo fetches and caches system platform information.
 func (s *SystemInfo) collectPlatformInfo() error {
 	var err error
 	if s.platform == "" {
@@ -36,7 +36,7 @@ func (s *SystemInfo) collectPlatformInfo() error {
 	return nil
 }
 
-// Uptime returns the system platform
+// Platform returns the system platform.
 func (s *SystemInfo) Platform() (string, error) {
 	err := s.collectPlatformInfo()
 	if err != nil {
@@ -45,7 +45,7 @@ func (s *SystemInfo) Platform() (string, error) {
 	return s.platform, nil
 }
 
-// Family returns the system family
+// Family returns the system family.
 func (s *SystemInfo) Family() (string, error) {
 	err := s.collectPlatformInfo()
 	if err != nil {
@@ -54,7 +54,7 @@ func (s *SystemInfo) Family() (string, error) {
 	return s.family, err
 }
 
-// OSVersion returns the OS Version
+// OSVersion returns the OS Version.
 func (s *SystemInfo) OSVersion() (string, error) {
 	err := s.collectPlatformInfo()
 	if err != nil {
@@ -63,7 +63,7 @@ func (s *SystemInfo) OSVersion() (string, error) {
 	return s.osVersion, err
 }
 
-// MemFree returns the amount of free memory in bytes
+// MemFree returns the amount of free memory in bytes.
 func (s *SystemInfo) MemFree() (uint64, error) {
 	memInfo, err := mem.VirtualMemory()
 	if err != nil {
@@ -72,7 +72,7 @@ func (s *SystemInfo) MemFree() (uint64, error) {
 	return memInfo.Free, err
 }
 
-// MemFree returns the amount of total memory in bytes
+// MemTotal returns the amount of total memory in bytes.
 func (s *SystemInfo) MemTotal() (uint64, error) {
 	memInfo, err := mem.VirtualMemory()
 	if err != nil {
@@ -81,7 +81,7 @@ func (s *SystemInfo) MemTotal() (uint64, error) {
 	return memInfo.Total, err
 }
 
-// MemFree returns the amount of used memory in bytes
+// MemUsed returns the amount of used memory in bytes.
 func (s *SystemInfo) MemUsed() (uint64, error) {
 	memInfo, err := mem.VirtualMemory()
 	if err != nil {
@@ -90,12 +90,12 @@ func (s *SystemInfo) MemUsed() (uint64, error) {
 	return memInfo.Used, err
 }
 
-// KernelVersion returns the kernel version as a string
+// KernelVersion returns the kernel version as a string.
 func (s *SystemInfo) KernelVersion() (string, error) {
 	return host.KernelVersion()
 }
 
-// NewSystemInfo is a constructor for the gopsutil implementation of SystemInfo
+// NewSystemInfo is a constructor for the gopsutil implementation of SystemInfo.
 func NewSystemInfo() *SystemInfo {
 	return &SystemInfo{}
 }

--- a/gopsutil/systeminfo_test.go
+++ b/gopsutil/systeminfo_test.go
@@ -2,7 +2,6 @@ package gopsutil_test
 
 import (
 	"log"
-	"runtime"
 	"testing"
 
 	"github.com/pilosa/pilosa"
@@ -27,8 +26,8 @@ func TestSystemInfo(t *testing.T) {
 	}
 
 	platform, err := systemInfo.Platform()
-	if err != nil || platform != runtime.GOOS {
-		t.Fatalf("Platform must be %s. (platform: %v, error: %v)", platform, runtime.GOOS, err)
+	if err != nil {
+		t.Fatalf("Error getting platform. (platform: %v, error: %v)", platform, err)
 	}
 
 	family, err := systemInfo.Family()

--- a/gopsutil/systeminfo_test.go
+++ b/gopsutil/systeminfo_test.go
@@ -28,7 +28,7 @@ func TestSystemInfo(t *testing.T) {
 
 	platform, err := systemInfo.Platform()
 	if err != nil || platform != runtime.GOOS {
-		t.Fatalf("Platform must be %s. (error: %v)", runtime.GOOS, err)
+		t.Fatalf("Platform must be %s. (platform: %v, error: %v)", platform, runtime.GOOS, err)
 	}
 
 	family, err := systemInfo.Family()

--- a/gopsutil/systeminfo_test.go
+++ b/gopsutil/systeminfo_test.go
@@ -1,0 +1,64 @@
+package gopsutil_test
+
+import (
+	"log"
+	"runtime"
+	"testing"
+
+	"github.com/pilosa/pilosa"
+	"github.com/pilosa/pilosa/gopsutil"
+)
+
+func TestSystemInfo(t *testing.T) {
+	var systemInfo pilosa.SystemInfo = gopsutil.NewSystemInfo()
+
+	//	Uptime()(uint64, error)
+	//	Platform()(string, error)
+	//	Family()(string, error)
+	//	OSVersion()(string, error)
+	//	KernelVersion()(string, error)
+	//	MemFree()(uint64, error)
+	//	MemTotal()(uint64, error)
+	//	MemUsed()(uint64, error)
+	//
+	uptime, err := systemInfo.Uptime()
+	if err != nil || uptime == 0 {
+		t.Fatalf("Error collecting uptime (error: %v)", err)
+	}
+
+	platform, err := systemInfo.Platform()
+	if err != nil || platform != runtime.GOOS {
+		t.Fatalf("Platform must be %s. (error: %v)", runtime.GOOS, err)
+	}
+
+	family, err := systemInfo.Family()
+	if err != nil {
+		t.Fatalf("Error getting OS family. (family: %v, error: %v)", family, err)
+	}
+
+	osversion, err := systemInfo.OSVersion()
+	if err != nil {
+		t.Fatalf("Error getting OS version. (osversion: %v, error: %v)", osversion, err)
+	}
+
+	kernelversion, err := systemInfo.KernelVersion()
+	if err != nil {
+		t.Fatalf("Error getting kernel version. (kernelversion: %v, error: %v)", kernelversion, err)
+	}
+
+	memfree, err := systemInfo.MemFree()
+	if err != nil {
+		t.Fatalf("Error getting memfree. (memfree: %v, error: %v)", memfree, err)
+	}
+
+	memused, err := systemInfo.MemUsed()
+	if err != nil {
+		t.Fatalf("Error getting memused. (memused: %v, error: %v)", memused, err)
+	}
+
+	memtotal, err := systemInfo.MemTotal()
+	log.Println(memtotal)
+	if err != nil {
+		t.Fatalf("Error getting memtotal. (memtotal: %v, error: %v)", memtotal, err)
+	}
+}

--- a/server.go
+++ b/server.go
@@ -610,7 +610,7 @@ func (s *Server) monitorDiagnostics() {
 		s.Logger().Printf("diagnostics disabled")
 		return
 	} else {
-		s.Logger().Printf("Pilosa is currently configured to send small diagnostics reports to our team every hour. More information here: https://www.pilosa.com/docs/latest/administration/#diagnostics")
+		s.Logger().Printf("Pilosa is currently configured to send small diagnostics reports to our team every %v. More information here: https://www.pilosa.com/docs/latest/administration/#diagnostics", s.DiagnosticInterval)
 	}
 
 	s.diagnostics.SetLogger(s.LogOutput)

--- a/server.go
+++ b/server.go
@@ -70,6 +70,7 @@ type Server struct {
 	URI         URI
 	Cluster     *Cluster
 	diagnostics *DiagnosticsCollector
+	SystemInfo  SystemInfo
 
 	GCNotifier GCNotifier
 
@@ -100,6 +101,7 @@ func NewServer() *Server {
 		Broadcaster:       NopBroadcaster,
 		BroadcastReceiver: NopBroadcastReceiver,
 		diagnostics:       NewDiagnosticsCollector(DefaultDiagnosticServer),
+		SystemInfo:        NewNopSystemInfo(),
 
 		Network: "tcp",
 
@@ -114,6 +116,7 @@ func NewServer() *Server {
 	s.logger = log.New(s.LogOutput, "", log.LstdFlags)
 
 	s.Handler.Holder = s.Holder
+	s.diagnostics.server = s
 	return s
 }
 
@@ -627,7 +630,7 @@ func (s *Server) monitorDiagnostics() {
 		}
 		s.diagnostics.Set("GoRoutines", runtime.NumGoroutine())
 		s.diagnostics.EnrichWithMemoryInfo()
-		s.diagnostics.EnrichWithSchemaProperties(s.Holder)
+		s.diagnostics.EnrichWithSchemaProperties()
 		s.diagnostics.CheckVersion()
 		s.diagnostics.Flush()
 	}

--- a/server.go
+++ b/server.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/pilosa/pilosa/diagnostics"
 	"github.com/pilosa/pilosa/internal"
 
 	"golang.org/x/sync/errgroup"
@@ -70,7 +69,7 @@ type Server struct {
 	NodeID      string
 	URI         URI
 	Cluster     *Cluster
-	diagnostics *diagnostics.Diagnostics
+	diagnostics *DiagnosticsCollector
 
 	GCNotifier GCNotifier
 
@@ -100,7 +99,7 @@ func NewServer() *Server {
 		Handler:           NewHandler(),
 		Broadcaster:       NopBroadcaster,
 		BroadcastReceiver: NopBroadcastReceiver,
-		diagnostics:       diagnostics.New(DefaultDiagnosticServer),
+		diagnostics:       NewDiagnosticsCollector(DefaultDiagnosticServer),
 
 		Network: "tcp",
 
@@ -622,13 +621,13 @@ func (s *Server) monitorDiagnostics() {
 
 	// Flush the diagnostics metrics at startup, then on each tick interval
 	flush := func() {
-		enrichDiagnosticsWithSchemaProperties(s.diagnostics, s.Holder)
 		openFiles, err := CountOpenFiles()
 		if err == nil {
 			s.diagnostics.Set("OpenFiles", openFiles)
 		}
 		s.diagnostics.Set("GoRoutines", runtime.NumGoroutine())
 		s.diagnostics.EnrichWithMemoryInfo()
+		s.diagnostics.EnrichWithSchemaProperties(s.Holder)
 		s.diagnostics.CheckVersion()
 		s.diagnostics.Flush()
 	}
@@ -724,40 +723,4 @@ type StatusHandler interface {
 	LocalStatus() (proto.Message, error)
 	ClusterStatus() (proto.Message, error)
 	HandleRemoteStatus(proto.Message) error
-}
-
-type diagnosticsFrameProperties struct {
-	BSIFieldCount      int
-	TimeQuantumEnabled bool
-}
-
-func enrichDiagnosticsWithSchemaProperties(d *diagnostics.Diagnostics, holder *Holder) {
-	// NOTE: this function is not in the diagnostics package, since circular imports are not allowed.
-	var numSlices uint64
-	numFrames := 0
-	numIndexes := 0
-	bsiFieldCount := 0
-	timeQuantumEnabled := false
-
-	for _, index := range holder.Indexes() {
-		numSlices += index.MaxSlice() + 1
-		numIndexes += 1
-		for _, frame := range index.Frames() {
-			numFrames += 1
-			if frame.rangeEnabled {
-				if fields, err := frame.GetFields(); err == nil {
-					bsiFieldCount += len(fields)
-				}
-			}
-			if frame.TimeQuantum() != "" {
-				timeQuantumEnabled = true
-			}
-		}
-	}
-
-	d.Set("NumIndexes", numIndexes)
-	d.Set("NumFrames", numFrames)
-	d.Set("NumSlices", numSlices)
-	d.Set("BSIFieldCount", bsiFieldCount)
-	d.Set("TimeQuantumEnabled", timeQuantumEnabled)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/gcnotify"
+	"github.com/pilosa/pilosa/gopsutil"
 	"github.com/pilosa/pilosa/gossip"
 	"github.com/pilosa/pilosa/statsd"
 )
@@ -152,6 +153,7 @@ func (m *Command) SetupServer() error {
 	if m.Config.Metric.Diagnostics {
 		m.Server.DiagnosticInterval = time.Duration(DefaultDiagnosticsInterval)
 	}
+	m.Server.SystemInfo = gopsutil.NewSystemInfo()
 	m.Server.GCNotifier = gcnotify.NewActiveGCNotifier()
 	m.Server.Holder.Stats, err = NewStatsClient(m.Config.Metric.Service, m.Config.Metric.Host)
 	if err != nil {


### PR DESCRIPTION
## Overview

This is an alternative to #1161 that, instead of creating a Diagnostics interface to move the gopsutil dependency out of `package pilosa`, it creates a `SystemInfo` interface with a `gopsutil` implementation. This also removes the `gobreaker` dependency and cleans up a few related things.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
