### PR TITLE
roaring: speed-up intersectionCountArrayBitmap

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1907,13 +1907,14 @@ func intersectionCountBitmapRun(a, b *container) (n int) {
 }
 
 func intersectionCountArrayBitmap(a, b *container) (n int) {
+	ln := len(b.bitmap)
 	for _, val := range a.array {
-		i := val >> 6
-		if i >= uint16(len(b.bitmap)) {
+		i := int(val >> 6)
+		if i >= ln {
 			break
 		}
 		off := val % 64
-		n += int((b.bitmap[i] & (1 << off)) >> off)
+		n += int(b.bitmap[i]>>off) & 1
 	}
 	return n
 }


### PR DESCRIPTION
While looking at benchmarks as a possible go compiler benchmarks,
I've tried some optimizations by hand:
Move len(b.bitmap) load out of the loop.
Remove some type conversions.
Use (x >> off) & 1  to get offs bit, instead of  x & (1 << of)f >> off.

This produces nice speed-up and passes go test roaring.

name                                    old time/op  new time/op  delta
Bitmap_IntersectionCount_ArrayRun-6     2.06µs ± 0%  1.57µs ± 0%  -24.04%  (p=0.000 n=10+9)
Bitmap_IntersectionCount_BitmapRun-6    2.24µs ± 0%  2.24µs ± 0%     ~     (p=0.913 n=10+9)
Bitmap_IntersectionCount_ArrayBitmap-6  2.06µs ± 0%  1.56µs ± 1%  -24.05%  (p=0.000 n=9+10)