### PR TITLE
Clean up logger; make it honor --log-path flag.

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,7 +43,7 @@ func NewServeCmd(stdin io.Reader, stdout, stderr io.Writer) *cobra.Command {
 		Long: `pilosa server runs Pilosa.
 
 It will load existing data from the configured
-directory, and start listening client connections
+directory and start listening for client connections
 on the configured port.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logOutput, err := server.GetLogWriter(Server.Config.LogPath, stderr)

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/signal"
 	"runtime/pprof"
@@ -46,11 +45,11 @@ It will load existing data from the configured
 directory and start listening for client connections
 on the configured port.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logOutput, err := server.GetLogWriter(Server.Config.LogPath, stderr)
-			if err != nil {
-				return err
+			// Set up the logger.
+			if err := Server.SetupLogger(); err != nil {
+				return fmt.Errorf("error setting up the logger: %v", err)
 			}
-			logger := log.New(logOutput, "", log.LstdFlags)
+			logger := Server.Server.Logger
 			logger.Printf("Pilosa %s, build time %s\n", pilosa.Version, pilosa.BuildTime)
 
 			// Start CPU profiling.

--- a/config.go
+++ b/config.go
@@ -133,6 +133,7 @@ type Config struct {
 	MaxWritesPerRequest int `toml:"max-writes-per-request"`
 
 	LogPath string `toml:"log-path"`
+	Verbose bool   `toml:"verbose"`
 
 	// TLS
 	TLS TLSConfig
@@ -178,6 +179,7 @@ func NewConfig() *Config {
 		Bind:                ":" + DefaultPort,
 		MaxWritesPerRequest: DefaultMaxWritesPerRequest,
 		// LogPath: "",
+		// Verbose: false,
 		TLS: TLSConfig{},
 	}
 

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -28,7 +28,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.StringVarP(&srv.Config.Bind, "bind", "b", srv.Config.Bind, "Default URI on which pilosa should listen.")
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
-	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Verbose logging")
+	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Enable verbose logging")
 
 	// TLS
 	SetTLSConfig(flags, &srv.Config.TLS.CertificatePath, &srv.Config.TLS.CertificateKeyPath, &srv.Config.TLS.SkipVerify)

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -28,6 +28,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.StringVarP(&srv.Config.Bind, "bind", "b", srv.Config.Bind, "Default URI on which pilosa should listen.")
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
+	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Verbose logging")
 
 	// TLS
 	SetTLSConfig(flags, &srv.Config.TLS.CertificatePath, &srv.Config.TLS.CertificateKeyPath, &srv.Config.TLS.SkipVerify)

--- a/diagnostics_internal_test.go
+++ b/diagnostics_internal_test.go
@@ -16,7 +16,6 @@ package pilosa
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -31,7 +30,6 @@ func TestDiagnosticsClient(t *testing.T) {
 
 	// Create a new client.
 	d := NewDiagnosticsCollector(server.URL)
-	d.SetLogger(ioutil.Discard)
 
 	d.Set("gg", 10)
 	d.Set("ss", "ss")
@@ -146,7 +144,6 @@ func BenchmarkDiagnostics(b *testing.B) {
 
 	// Create a new client.
 	d := NewDiagnosticsCollector(server.URL)
-	d.SetLogger(ioutil.Discard)
 
 	prev := runtime.GOMAXPROCS(4)
 	defer runtime.GOMAXPROCS(prev)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -81,6 +81,17 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
     log-path = "/path/to/logfile"
     ```
 
+#### Verbose
+
+* Description: Enable verbose logging.
+* Flag: `--verbose`
+* Env: `PILOSA_VERBOSE`
+* Config:
+
+    ```toml
+    verbose = true
+    ```
+
 #### Max Writes Per Request
 
 * Description: Maximum number of mutating commands allowed per request. This includes SetBit, ClearBit, SetRowAttrs, SetColumnAttrs, and SetFieldValue.

--- a/fragment.go
+++ b/fragment.go
@@ -26,7 +26,6 @@ import (
 	"hash"
 	"io"
 	"io/ioutil"
-	"log"
 	"net/http"
 	"os"
 	"sort"
@@ -103,8 +102,8 @@ type Fragment struct {
 	// so that they can be mmapped and heap utilization can be kept low.
 	MaxOpN int
 
-	// Writer used for out-of-band log entries.
-	LogOutput io.Writer
+	// Logger used for out-of-band log entries.
+	Logger Logger
 
 	// Row attribute storage.
 	// This is set by the parent frame unless overridden for testing.
@@ -124,8 +123,8 @@ func NewFragment(path, index, frame, view string, slice uint64) *Fragment {
 		CacheType: DefaultCacheType,
 		CacheSize: DefaultCacheSize,
 
-		LogOutput: ioutil.Discard,
-		MaxOpN:    DefaultFragmentMaxOpN,
+		Logger: NopLogger,
+		MaxOpN: DefaultFragmentMaxOpN,
 
 		stats: NopStatsClient,
 	}
@@ -273,7 +272,7 @@ func (f *Fragment) openCache() error {
 	// Unmarshal cache data.
 	var pb internal.Cache
 	if err := proto.Unmarshal(buf, &pb); err != nil {
-		f.logger().Printf("error unmarshaling cache data, skipping: path=%s, err=%s", path, err)
+		f.Logger.Printf("error unmarshaling cache data, skipping: path=%s, err=%s", path, err)
 		return nil
 	}
 
@@ -298,13 +297,13 @@ func (f *Fragment) Close() error {
 func (f *Fragment) close() error {
 	// Flush cache if closing gracefully.
 	if err := f.flushCache(); err != nil {
-		f.logger().Printf("fragment: error flushing cache on close: err=%s, path=%s", err, f.path)
+		f.Logger.Printf("fragment: error flushing cache on close: err=%s, path=%s", err, f.path)
 		return err
 	}
 
 	// Close underlying storage.
 	if err := f.closeStorage(); err != nil {
-		f.logger().Printf("fragment: error closing storage: err=%s, path=%s", err, f.path)
+		f.Logger.Printf("fragment: error closing storage: err=%s, path=%s", err, f.path)
 		return err
 	}
 
@@ -342,9 +341,6 @@ func (f *Fragment) closeStorage() error {
 
 	return nil
 }
-
-// logger returns a logger instance for the fragment.nt.
-func (f *Fragment) logger() *log.Logger { return log.New(f.LogOutput, "", log.LstdFlags) }
 
 // Row returns a row by ID.
 func (f *Fragment) Row(rowID uint64) *Bitmap {
@@ -1385,18 +1381,17 @@ func (f *Fragment) Snapshot() error {
 	defer f.mu.Unlock()
 	return f.snapshot()
 }
-func track(start time.Time, message string, stats StatsClient, logger *log.Logger) {
+func track(start time.Time, message string, stats StatsClient, logger Logger) {
 	elapsed := time.Since(start)
 	logger.Printf("%s took %s", message, elapsed)
 	stats.Histogram("snapshot", elapsed.Seconds(), 1.0)
 }
 
 func (f *Fragment) snapshot() error {
-	logger := f.logger()
-	logger.Printf("fragment: snapshotting %s/%s/%s/%d", f.index, f.frame, f.view, f.slice)
+	f.Logger.Printf("fragment: snapshotting %s/%s/%s/%d", f.index, f.frame, f.view, f.slice)
 	completeMessage := fmt.Sprintf("fragment: snapshot complete %s/%s/%s/%d", f.index, f.frame, f.view, f.slice)
 	start := time.Now()
-	defer track(start, completeMessage, f.stats, logger)
+	defer track(start, completeMessage, f.stats, f.Logger)
 
 	// Create a temporary file to snapshot to.
 	snapshotPath := f.path + SnapshotExt

--- a/frame.go
+++ b/frame.go
@@ -17,7 +17,6 @@ package pilosa
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -65,7 +64,7 @@ type Frame struct {
 	rangeEnabled   bool
 	fields         []*Field
 
-	LogOutput io.Writer
+	Logger Logger
 }
 
 // NewFrame returns a new instance of frame.
@@ -95,7 +94,7 @@ func NewFrame(path, index, name string) (*Frame, error) {
 		rangeEnabled: DefaultRangeEnabled,
 		//fields
 
-		LogOutput: ioutil.Discard,
+		Logger: NopLogger,
 	}, nil
 }
 
@@ -624,7 +623,7 @@ func (f *Frame) createViewIfNotExistsBase(name string) (*View, bool, error) {
 func (f *Frame) newView(path, name string) *View {
 	view := NewView(path, f.index, f.name, name, f.cacheSize)
 	view.cacheType = f.cacheType
-	view.LogOutput = f.LogOutput
+	view.Logger = f.Logger
 	view.RowAttrStore = f.rowAttrStore
 	view.stats = f.Stats.WithTags(fmt.Sprintf("view:%s", name))
 	view.broadcaster = f.broadcaster

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -147,8 +147,10 @@ type gossipConfig struct {
 	memberlistConfig *memberlist.Config
 }
 
+// GossipMemberSetOption describes a functional option for GossipMemberSet.
 type GossipMemberSetOption func(*GossipMemberSet) error
 
+// WithTransport is a functional option for providing a transport to NewGossipMemberSet.
 func WithTransport(transport *Transport) func(*GossipMemberSet) error {
 	return func(g *GossipMemberSet) error {
 		g.transport = transport
@@ -156,6 +158,7 @@ func WithTransport(transport *Transport) func(*GossipMemberSet) error {
 	}
 }
 
+// WithLogger is a functional option for providing a logger to NewGossipMemberSet.
 func WithLogger(logger *log.Logger) func(*GossipMemberSet) error {
 	return func(g *GossipMemberSet) error {
 		g.logger = logger

--- a/handler_test.go
+++ b/handler_test.go
@@ -37,13 +37,13 @@ import (
 
 func TestHandlerPanics(t *testing.T) {
 	h := test.NewHandler()
-	buf := &bytes.Buffer{}
-	h.Handler.LogOutput = buf
+	bufLogger := test.NewBufferLogger()
+	h.Handler.Logger = bufLogger
 
 	w := httptest.NewRecorder()
 	// will panic since Handler has no Holder set up
 	h.ServeHTTP(w, test.MustNewHTTPRequest("GET", "/index/taxi", nil))
-	bufbytes, err := ioutil.ReadAll(buf)
+	bufbytes, err := bufLogger.ReadAll()
 	if err != nil {
 		t.Fatalf("reading all logoutput: %v", err)
 	}

--- a/index.go
+++ b/index.go
@@ -17,7 +17,6 @@ package pilosa
 import (
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -66,7 +65,7 @@ type Index struct {
 	broadcaster Broadcaster
 	Stats       StatsClient
 
-	LogOutput io.Writer
+	Logger Logger
 }
 
 // NewIndex returns a new instance of Index.
@@ -92,7 +91,7 @@ func NewIndex(path, name string) (*Index, error) {
 
 		broadcaster: NopBroadcaster,
 		Stats:       NopStatsClient,
-		LogOutput:   ioutil.Discard,
+		Logger:      NopLogger,
 	}, nil
 }
 
@@ -528,7 +527,7 @@ func (i *Index) newFrame(path, name string) (*Frame, error) {
 	if err != nil {
 		return nil, err
 	}
-	f.LogOutput = i.LogOutput
+	f.Logger = i.Logger
 	f.Stats = i.Stats.WithTags(fmt.Sprintf("frame:%s", name))
 	f.broadcaster = i.broadcaster
 	f.rowAttrStore = i.NewAttrStore(filepath.Join(f.path, ".data"))

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,69 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pilosa
+
+import (
+	"io/ioutil"
+	"log"
+)
+
+// Ensure nopLogger implements interface.
+var _ Logger = &nopLogger{}
+
+// Logger represents an interface for a shared logger.
+type Logger interface {
+	Printf(format string, v ...interface{})
+	Debugf(format string, v ...interface{})
+}
+
+func init() {
+	NopLogger = &nopLogger{
+		logger: log.New(ioutil.Discard, "", log.LstdFlags),
+	}
+}
+
+// NopLogger represents a Logger that doesn't do anything.
+var NopLogger Logger
+
+type nopLogger struct {
+	logger *log.Logger
+}
+
+// Printf is a no-op implementation of the Logger Printf method.
+func (n *nopLogger) Printf(format string, v ...interface{}) {}
+
+// Debugf is a no-op implementation of the Logger Debugf method.
+func (n *nopLogger) Debugf(format string, v ...interface{}) {}
+
+// StandardLogger is a basic implementation of pilosa.Logger based on log.Logger.
+type StandardLogger struct {
+	logger *log.Logger
+}
+
+func NewStandardLogger(logger *log.Logger) *StandardLogger {
+	return &StandardLogger{
+		logger: logger,
+	}
+}
+
+// Printf is a no-op implementation of the Logger Printf method.
+func (s *StandardLogger) Printf(format string, v ...interface{}) {
+	s.logger.Printf(format, v...)
+}
+
+// Debugf is a no-op implementation of the Logger Debugf method.
+func (s *StandardLogger) Debugf(format string, v ...interface{}) {
+	// TODO: implement this
+}

--- a/logger.go
+++ b/logger.go
@@ -14,10 +14,7 @@
 
 package pilosa
 
-import (
-	"io/ioutil"
-	"log"
-)
+import "log"
 
 // Ensure nopLogger implements interface.
 var _ Logger = &nopLogger{}
@@ -29,17 +26,13 @@ type Logger interface {
 }
 
 func init() {
-	NopLogger = &nopLogger{
-		logger: log.New(ioutil.Discard, "", log.LstdFlags),
-	}
+	NopLogger = &nopLogger{}
 }
 
 // NopLogger represents a Logger that doesn't do anything.
 var NopLogger Logger
 
-type nopLogger struct {
-	logger *log.Logger
-}
+type nopLogger struct{}
 
 // Printf is a no-op implementation of the Logger Printf method.
 func (n *nopLogger) Printf(format string, v ...interface{}) {}

--- a/logger.go
+++ b/logger.go
@@ -58,12 +58,28 @@ func NewStandardLogger(logger *log.Logger) *StandardLogger {
 	}
 }
 
-// Printf is a no-op implementation of the Logger Printf method.
 func (s *StandardLogger) Printf(format string, v ...interface{}) {
 	s.logger.Printf(format, v...)
 }
 
-// Debugf is a no-op implementation of the Logger Debugf method.
-func (s *StandardLogger) Debugf(format string, v ...interface{}) {
-	// TODO: implement this
+func (s *StandardLogger) Debugf(format string, v ...interface{}) {}
+
+// VerboseLogger is an implementation of pilosa.Logger which includes debug messages.
+type VerboseLogger struct {
+	logger *log.Logger
+}
+
+func NewVerboseLogger(logger *log.Logger) *VerboseLogger {
+	return &VerboseLogger{
+		logger: logger,
+	}
+}
+
+func (vb *VerboseLogger) Printf(format string, v ...interface{}) {
+	vb.logger.Printf(format, v...)
+}
+
+func (vb *VerboseLogger) Debugf(format string, v ...interface{}) {
+	vb.logger.Printf("VERBOSE...")
+	vb.logger.Printf(format, v...)
 }

--- a/server.go
+++ b/server.go
@@ -20,7 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -88,7 +88,7 @@ type Server struct {
 	MaxWritesPerRequest int
 
 	LogOutput io.Writer
-	logger    *log.Logger
+	Logger    Logger
 
 	defaultClient InternalClient
 }
@@ -115,9 +115,9 @@ func NewServer() *Server {
 		MetricInterval:      0,
 		DiagnosticInterval:  0,
 
-		LogOutput: os.Stderr,
+		LogOutput: ioutil.Discard,
+		Logger:    NopLogger,
 	}
-	s.logger = log.New(s.LogOutput, "", log.LstdFlags)
 
 	s.Handler.Holder = s.Holder
 	s.diagnostics.server = s
@@ -126,7 +126,7 @@ func NewServer() *Server {
 
 // Open opens and initializes the server.
 func (s *Server) Open() error {
-	s.Logger().Printf("open server")
+	s.Logger.Printf("open server")
 	// s.ln can be configured prior to Open() via s.OpenListener().
 	if s.ln == nil {
 		if err := s.OpenListener(); err != nil {
@@ -151,7 +151,6 @@ func (s *Server) Open() error {
 	// Peek at the holder to determine if there is data on disk.
 	// Don't actually load the data until after the Cluster
 	// management starts.
-	s.Holder.LogOutput = s.LogOutput
 	s.Holder.Peek()
 
 	// Create default HTTP client
@@ -175,7 +174,6 @@ func (s *Server) Open() error {
 	s.Handler.Node = node
 	s.Handler.Cluster = s.Cluster
 	s.Handler.Executor = e
-	s.Handler.LogOutput = s.LogOutput
 
 	s.Cluster.prefect = s.Handler
 
@@ -186,7 +184,7 @@ func (s *Server) Open() error {
 	go func() {
 		err := http.Serve(s.ln, s.Handler)
 		if err != nil {
-			s.Logger().Printf("HTTP handler terminated with error: %s\n", err)
+			s.Logger.Printf("HTTP handler terminated with error: %s\n", err)
 		}
 	}()
 
@@ -226,7 +224,7 @@ func (s *Server) Open() error {
 
 // OpenListener opens a listener for the Server.
 func (s *Server) OpenListener() error {
-	s.Logger().Printf("open server listener: %s", s.URI)
+	s.Logger.Printf("open server listener: %s", s.URI)
 	if s.ln != nil {
 		return fmt.Errorf("a listener already exists for server: %s", s.URI)
 	}
@@ -288,7 +286,7 @@ func (s *Server) LoadNodeID() string {
 	}
 	nodeID, err := s.Holder.loadNodeID()
 	if err != nil {
-		s.Logger().Printf("loading NodeID: %v", err)
+		s.Logger.Printf("loading NodeID: %v", err)
 		return s.NodeID
 	}
 	return nodeID
@@ -321,14 +319,11 @@ func GetHTTPClient(t *tls.Config) *http.Client {
 	return &http.Client{Transport: transport}
 }
 
-// Logger returns a logger that writes to LogOutput
-func (s *Server) Logger() *log.Logger { return s.logger }
-
 func (s *Server) monitorAntiEntropy() {
 	ticker := time.NewTicker(s.AntiEntropyInterval)
 	defer ticker.Stop()
 
-	s.Logger().Printf("holder sync monitor initializing (%s interval)", s.AntiEntropyInterval)
+	s.Logger.Printf("holder sync monitor initializing (%s interval)", s.AntiEntropyInterval)
 
 	for {
 		// Wait for tick or a close.
@@ -339,7 +334,7 @@ func (s *Server) monitorAntiEntropy() {
 			s.Holder.Stats.Count("AntiEntropy", 1, 1.0)
 		}
 		t := time.Now()
-		s.Logger().Printf("holder sync beginning")
+		s.Logger.Printf("holder sync beginning")
 
 		// Initialize syncer with local holder and remote client.
 		var syncer HolderSyncer
@@ -352,12 +347,12 @@ func (s *Server) monitorAntiEntropy() {
 
 		// Sync holders.
 		if err := syncer.SyncHolder(); err != nil {
-			s.Logger().Printf("holder sync error: err=%s", err)
+			s.Logger.Printf("holder sync error: err=%s", err)
 			continue
 		}
 
 		// Record successful sync in log.
-		s.Logger().Printf("holder sync complete")
+		s.Logger.Printf("holder sync complete")
 		dif := time.Since(t)
 		s.Holder.Stats.Histogram("AntiEntropyDuration", float64(dif), 1.0)
 	}
@@ -482,7 +477,7 @@ func (s *Server) ReceiveMessage(pb proto.Message) error {
 func (s *Server) SendSync(pb proto.Message) error {
 	var eg errgroup.Group
 	for _, node := range s.Cluster.Nodes {
-		s.Logger().Printf("SendSync to: %s", node.URI)
+		s.Logger.Printf("SendSync to: %s", node.URI)
 		// Don't forward the message to ourselves.
 		if s.URI == node.URI {
 			continue
@@ -504,7 +499,7 @@ func (s *Server) SendAsync(pb proto.Message) error {
 
 // SendTo represents an implementation of Broadcaster.
 func (s *Server) SendTo(to *Node, pb proto.Message) error {
-	s.Logger().Printf("SendTo: %s", to.URI)
+	s.Logger.Printf("SendTo: %s", to.URI)
 	ctx := context.WithValue(context.Background(), "uri", &to.URI)
 	return s.defaultClient.SendMessage(ctx, pb)
 }
@@ -554,7 +549,7 @@ func (s *Server) HandleRemoteStatus(pb proto.Message) error {
 
 		err := s.mergeRemoteStatus(pb.(*internal.NodeStatus))
 		if err != nil {
-			s.Logger().Printf("merge remote status: %s", err)
+			s.Logger.Printf("merge remote status: %s", err)
 		}
 	}()
 
@@ -579,7 +574,7 @@ func (s *Server) mergeRemoteStatus(ns *internal.NodeStatus) error {
 		// if we don't know about an index locally, log an error because
 		// indexes should be created and synced prior to slice creation
 		if localIndex == nil {
-			s.Logger().Printf("Local Index not found: %s", index)
+			s.Logger.Printf("Local Index not found: %s", index)
 			continue
 		}
 		if newMax > oldmaxslices[index] {
@@ -595,7 +590,7 @@ func (s *Server) mergeRemoteStatus(ns *internal.NodeStatus) error {
 		// if we don't know about an index locally, log an error because
 		// indexes should be created and synced prior to slice creation
 		if localIndex == nil {
-			s.Logger().Printf("Local Index not found: %s", index)
+			s.Logger.Printf("Local Index not found: %s", index)
 			continue
 		}
 		if newMaxInverse > oldMaxInverseSlices[index] {
@@ -611,13 +606,13 @@ func (s *Server) mergeRemoteStatus(ns *internal.NodeStatus) error {
 func (s *Server) monitorDiagnostics() {
 	// Do not send more than once a minute
 	if s.DiagnosticInterval < time.Minute {
-		s.Logger().Printf("diagnostics disabled")
+		s.Logger.Printf("diagnostics disabled")
 		return
 	} else {
-		s.Logger().Printf("Pilosa is currently configured to send small diagnostics reports to our team every %v. More information here: https://www.pilosa.com/docs/latest/administration/#diagnostics", s.DiagnosticInterval)
+		s.Logger.Printf("Pilosa is currently configured to send small diagnostics reports to our team every %v. More information here: https://www.pilosa.com/docs/latest/administration/#diagnostics", s.DiagnosticInterval)
 	}
 
-	s.diagnostics.SetLogger(s.LogOutput)
+	s.diagnostics.Logger = s.Logger
 	s.diagnostics.SetVersion(Version)
 	s.diagnostics.Set("Host", s.URI.host)
 	s.diagnostics.Set("Cluster", strings.Join(s.Cluster.NodeIDs(), ","))
@@ -639,7 +634,7 @@ func (s *Server) monitorDiagnostics() {
 		s.diagnostics.CheckVersion()
 		err = s.diagnostics.Flush()
 		if err != nil {
-			s.Logger().Printf("Diagnostics error: %s", err)
+			s.Logger.Printf("Diagnostics error: %s", err)
 		}
 	}
 
@@ -670,7 +665,7 @@ func (s *Server) monitorRuntime() {
 
 	defer s.GCNotifier.Close()
 
-	s.Logger().Printf("runtime stats initializing (%s interval)", s.MetricInterval)
+	s.Logger.Printf("runtime stats initializing (%s interval)", s.MetricInterval)
 
 	for {
 		// Wait for tick or a close.

--- a/server.go
+++ b/server.go
@@ -19,8 +19,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -87,8 +85,7 @@ type Server struct {
 	// Misc options.
 	MaxWritesPerRequest int
 
-	LogOutput io.Writer
-	Logger    Logger
+	Logger Logger
 
 	defaultClient InternalClient
 }
@@ -115,8 +112,7 @@ func NewServer() *Server {
 		MetricInterval:      0,
 		DiagnosticInterval:  0,
 
-		LogOutput: ioutil.Discard,
-		Logger:    NopLogger,
+		Logger: NopLogger,
 	}
 
 	s.Handler.Holder = s.Holder

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -54,7 +54,7 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 
 	m0.Server.Cluster.Coordinator = m0.Server.NodeID
 	m0.Server.Cluster.Topology = &pilosa.Topology{NodeIDs: []string{m0.Server.NodeID, m1.Server.NodeID}}
-	m0.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m0.Server.LogOutput)
+	m0.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m0.Server.Logger)
 	gossipMemberSet0, err := gossip.NewGossipMemberSet(m0.Server.URI.HostPort(), m0.Config, m0.Server)
 	if err != nil {
 		t.Fatal(err)
@@ -81,7 +81,7 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 	m1.Config.Gossip.Seeds = []string{gossipMemberSet0.GetBindAddr()}
 
 	m1.Server.Cluster.Coordinator = m0.Server.NodeID
-	m1.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m1.Server.LogOutput)
+	m1.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m1.Server.Logger)
 	gossipMemberSet1, err := gossip.NewGossipMemberSet(m1.Server.URI.HostPort(), m1.Config, m1.Server)
 	if err != nil {
 		t.Fatal(err)

--- a/server/server.go
+++ b/server/server.go
@@ -134,7 +134,6 @@ func (m *Command) SetupServer() error {
 	if err != nil {
 		return err
 	}
-	m.Server.LogOutput = lw
 	m.logger = log.New(lw, "", log.LstdFlags)
 	if m.Config.Verbose {
 		m.Server.Logger = pilosa.NewVerboseLogger(m.logger)
@@ -299,8 +298,8 @@ func GetLogWriter(path string, defaultWriter io.Writer) (io.Writer, error) {
 func (m *Command) Close() error {
 	var logErr error
 	serveErr := m.Server.Close()
-	logOutput := m.Server.LogOutput
-	if closer, ok := logOutput.(io.Closer); ok {
+	logger := m.Server.Logger
+	if closer, ok := logger.(io.Closer); ok {
 		logErr = closer.Close()
 	}
 	close(m.Done)

--- a/server/server.go
+++ b/server/server.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -71,6 +72,8 @@ type Command struct {
 	Started chan struct{}
 	// Done will be closed when Command.Close() is called
 	Done chan struct{}
+
+	logger *log.Logger
 }
 
 // NewCommand returns a new instance of Main.
@@ -115,7 +118,7 @@ func (m *Command) Run(args ...string) (err error) {
 		return fmt.Errorf("server.Open: %v", err)
 	}
 
-	m.Server.Logger().Printf("Listening as %s\n", m.Server.URI)
+	m.Server.Logger.Printf("Listening as %s\n", m.Server.URI)
 	return nil
 }
 
@@ -125,6 +128,18 @@ func (m *Command) SetupServer() error {
 	if err != nil {
 		return err
 	}
+
+	// Set up logger based on configuration.
+	lw, err := GetLogWriter(m.Config.LogPath, m.Stderr)
+	if err != nil {
+		return err
+	}
+	m.Server.LogOutput = lw
+	m.logger = log.New(lw, "", log.LstdFlags)
+	m.Server.Logger = pilosa.NewStandardLogger(m.logger)
+	m.Server.Handler.Logger = m.Server.Logger
+	m.Server.Holder.Logger = m.Server.Logger
+	m.Server.Holder.Stats.SetLogger(m.Server.Logger)
 
 	uri, err := pilosa.AddressWithDefaults(m.Config.Bind)
 
@@ -136,14 +151,9 @@ func (m *Command) SetupServer() error {
 	cluster := pilosa.NewCluster()
 	cluster.ReplicaN = m.Config.Cluster.ReplicaN
 	cluster.Holder = m.Server.Holder
+	cluster.Logger = m.Server.Logger
 
 	m.Server.Cluster = cluster
-
-	// Setup logging output.
-	m.Server.LogOutput, err = GetLogWriter(m.Config.LogPath, m.Stderr)
-	if err != nil {
-		return err
-	}
 
 	// Configure data directory (for Cluster .topology)
 	m.Server.Cluster.Path = m.Config.DataDir
@@ -152,7 +162,7 @@ func (m *Command) SetupServer() error {
 	m.Server.Holder.NewAttrStore = boltdb.NewAttrStore
 
 	// Configure holder.
-	m.Server.Logger().Printf("Using data from: %s\n", m.Config.DataDir)
+	m.Server.Logger.Printf("Using data from: %s\n", m.Config.DataDir)
 	m.Server.Holder.Path = m.Config.DataDir
 	m.Server.MetricInterval = time.Duration(m.Config.Metric.PollInterval)
 	if m.Config.Metric.Diagnostics {
@@ -164,8 +174,6 @@ func (m *Command) SetupServer() error {
 	if err != nil {
 		return err
 	}
-
-	m.Server.Holder.Stats.SetLogger(m.Server.LogOutput)
 
 	// Copy configuration flags.
 	m.Server.MaxWritesPerRequest = m.Config.MaxWritesPerRequest
@@ -246,7 +254,7 @@ func (m *Command) SetupNetworking() error {
 	if m.GossipTransport != nil {
 		transport = m.GossipTransport
 	} else {
-		transport, err = gossip.NewTransport(gossipHost, gossipPort)
+		transport, err = gossip.NewTransport(gossipHost, gossipPort, m.logger)
 		if err != nil {
 			return err
 		}
@@ -257,8 +265,8 @@ func (m *Command) SetupNetworking() error {
 		m.Server.Cluster.Coordinator = m.Server.NodeID
 	}
 
-	m.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m.Server.LogOutput)
-	gossipMemberSet, err := gossip.NewGossipMemberSetWithTransport(m.Server.NodeID, m.Config, transport, m.Server)
+	m.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m.Server.Logger)
+	gossipMemberSet, err := gossip.NewGossipMemberSet(m.Server.NodeID, m.Config, m.Server, gossip.WithLogger(m.logger), gossip.WithTransport(transport))
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -136,7 +136,11 @@ func (m *Command) SetupServer() error {
 	}
 	m.Server.LogOutput = lw
 	m.logger = log.New(lw, "", log.LstdFlags)
-	m.Server.Logger = pilosa.NewStandardLogger(m.logger)
+	if m.Config.Verbose {
+		m.Server.Logger = pilosa.NewVerboseLogger(m.logger)
+	} else {
+		m.Server.Logger = pilosa.NewStandardLogger(m.logger)
+	}
 	m.Server.Handler.Logger = m.Server.Logger
 	m.Server.Holder.Logger = m.Server.Logger
 	m.Server.Holder.Stats.SetLogger(m.Server.Logger)

--- a/stats.go
+++ b/stats.go
@@ -16,7 +16,6 @@ package pilosa
 
 import (
 	"expvar"
-	"io"
 	"sort"
 	"strings"
 	"sync"
@@ -57,7 +56,7 @@ type StatsClient interface {
 	Timing(name string, value time.Duration, rate float64)
 
 	// SetLogger Set the logger output type
-	SetLogger(logger io.Writer)
+	SetLogger(logger Logger)
 
 	// Starts the service
 	Open()
@@ -79,7 +78,7 @@ func (c *nopStatsClient) Gauge(name string, value float64, rate float64)        
 func (c *nopStatsClient) Histogram(name string, value float64, rate float64)                        {}
 func (c *nopStatsClient) Set(name string, value string, rate float64)                               {}
 func (c *nopStatsClient) Timing(name string, value time.Duration, rate float64)                     {}
-func (c *nopStatsClient) SetLogger(logger io.Writer)                                                {}
+func (c *nopStatsClient) SetLogger(logger Logger)                                                   {}
 func (c *nopStatsClient) Open()                                                                     {}
 func (c *nopStatsClient) Close() error                                                              { return nil }
 
@@ -154,7 +153,7 @@ func (c *ExpvarStatsClient) Timing(name string, value time.Duration, rate float6
 }
 
 // SetLogger has no logger.
-func (c *ExpvarStatsClient) SetLogger(logger io.Writer) {
+func (c *ExpvarStatsClient) SetLogger(logger Logger) {
 }
 
 // Open no-op.
@@ -226,7 +225,7 @@ func (a MultiStatsClient) Timing(name string, value time.Duration, rate float64)
 }
 
 // SetLogger Sets the StatsD logger output type.
-func (a MultiStatsClient) SetLogger(logger io.Writer) {
+func (a MultiStatsClient) SetLogger(logger Logger) {
 	for _, c := range a {
 		c.SetLogger(logger)
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -16,8 +16,6 @@ package pilosa_test
 
 import (
 	"context"
-	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -38,7 +36,6 @@ func TestMultiStatClient_Expvar(t *testing.T) {
 	ms[0] = c
 	hldr.Stats = ms
 
-	hldr.Stats.SetLogger(ioutil.Discard)
 	hldr.MustCreateFragmentIfNotExists("d", "f", pilosa.ViewStandard, 0).SetBit(0, 0)
 	hldr.MustCreateFragmentIfNotExists("d", "f", pilosa.ViewStandard, 0).SetBit(0, 1)
 	hldr.MustCreateFragmentIfNotExists("d", "f", pilosa.ViewStandard, 1).SetBit(0, SliceWidth)
@@ -357,6 +354,6 @@ func (c *MockStats) Gauge(name string, value float64, rate float64)        {}
 func (c *MockStats) Histogram(name string, value float64, rate float64)    {}
 func (c *MockStats) Set(name string, value string, rate float64)           {}
 func (c *MockStats) Timing(name string, value time.Duration, rate float64) {}
-func (c *MockStats) SetLogger(logger io.Writer)                            {}
+func (c *MockStats) SetLogger(logger pilosa.Logger)                        {}
 func (c *MockStats) Open()                                                 {}
 func (c *MockStats) Close() error                                          { return nil }

--- a/statsd/statsd.go
+++ b/statsd/statsd.go
@@ -15,9 +15,6 @@
 package statsd
 
 import (
-	"io"
-	"io/ioutil"
-	"log"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
@@ -40,9 +37,9 @@ var _ pilosa.StatsClient = &StatsClient{}
 
 // StatsClient represents a StatsD implementation of pilosa.StatsClient.
 type StatsClient struct {
-	client    *statsd.Client
-	tags      []string
-	logOutput io.Writer
+	client *statsd.Client
+	tags   []string
+	logger pilosa.Logger
 }
 
 // NewStatsClient returns a new instance of StatsClient.
@@ -53,8 +50,8 @@ func NewStatsClient(host string) (*StatsClient, error) {
 	}
 
 	return &StatsClient{
-		client:    c,
-		logOutput: ioutil.Discard,
+		client: c,
+		logger: pilosa.NopLogger,
 	}, nil
 }
 
@@ -74,16 +71,16 @@ func (c *StatsClient) Tags() []string {
 // WithTags returns a new client with additional tags appended.
 func (c *StatsClient) WithTags(tags ...string) pilosa.StatsClient {
 	return &StatsClient{
-		client:    c.client,
-		tags:      pilosa.UnionStringSlice(c.tags, tags),
-		logOutput: c.logOutput,
+		client: c.client,
+		tags:   pilosa.UnionStringSlice(c.tags, tags),
+		logger: c.logger,
 	}
 }
 
 // Count tracks the number of times something occurs per second.
 func (c *StatsClient) Count(name string, value int64, rate float64) {
 	if err := c.client.Count(Prefix+name, value, c.tags, rate); err != nil {
-		c.logger().Printf("statsd.StatsClient.Count error: %s", err)
+		c.logger.Printf("statsd.StatsClient.Count error: %s", err)
 	}
 }
 
@@ -91,44 +88,39 @@ func (c *StatsClient) Count(name string, value int64, rate float64) {
 func (c *StatsClient) CountWithCustomTags(name string, value int64, rate float64, t []string) {
 	tags := append(c.tags, t...)
 	if err := c.client.Count(Prefix+name, value, tags, rate); err != nil {
-		c.logger().Printf("statsd.StatsClient.Count error: %s", err)
+		c.logger.Printf("statsd.StatsClient.Count error: %s", err)
 	}
 }
 
 // Gauge sets the value of a metric.
 func (c *StatsClient) Gauge(name string, value float64, rate float64) {
 	if err := c.client.Gauge(Prefix+name, value, c.tags, rate); err != nil {
-		c.logger().Printf("statsd.StatsClient.Gauge error: %s", err)
+		c.logger.Printf("statsd.StatsClient.Gauge error: %s", err)
 	}
 }
 
 // Histogram tracks statistical distribution of a metric.
 func (c *StatsClient) Histogram(name string, value float64, rate float64) {
 	if err := c.client.Histogram(Prefix+name, value, c.tags, rate); err != nil {
-		c.logger().Printf("statsd.StatsClient.Histogram error: %s", err)
+		c.logger.Printf("statsd.StatsClient.Histogram error: %s", err)
 	}
 }
 
 // Set tracks number of unique elements.
 func (c *StatsClient) Set(name string, value string, rate float64) {
 	if err := c.client.Set(Prefix+name, value, c.tags, rate); err != nil {
-		c.logger().Printf("statsd.StatsClient.Set error: %s", err)
+		c.logger.Printf("statsd.StatsClient.Set error: %s", err)
 	}
 }
 
 // Timing tracks timing information for a metric.
 func (c *StatsClient) Timing(name string, value time.Duration, rate float64) {
 	if err := c.client.Timing(Prefix+name, value, c.tags, rate); err != nil {
-		c.logger().Printf("statsd.StatsClient.Timing error: %s", err)
+		c.logger.Printf("statsd.StatsClient.Timing error: %s", err)
 	}
 }
 
-// SetLogger has no logger
-func (c *StatsClient) SetLogger(logger io.Writer) {
-	c.logOutput = logger
-}
-
-// logger returns a logger that writes to LogOutput
-func (c *StatsClient) logger() *log.Logger {
-	return log.New(c.logOutput, "", log.LstdFlags)
+// SetLogger sets the logger for client.
+func (c *StatsClient) SetLogger(logger pilosa.Logger) {
+	c.logger = logger
 }

--- a/statsd/statsd_test.go
+++ b/statsd/statsd_test.go
@@ -15,7 +15,6 @@
 package statsd_test
 
 import (
-	"io/ioutil"
 	"reflect"
 	"testing"
 	"time"
@@ -31,7 +30,6 @@ func TestStatsClient_WithTags(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer c.Close()
-	c.SetLogger(ioutil.Discard)
 
 	// Create a new client with additional tags.
 	c1 := c.WithTags("foo", "bar")

--- a/test/handler.go
+++ b/test/handler.go
@@ -41,7 +41,6 @@ func NewHandler() *Handler {
 		Handler: pilosa.NewHandler(),
 	}
 	h.Handler.Executor = &h.Executor
-	h.Handler.LogOutput = ioutil.Discard
 
 	// Handler test messages can no-op.
 	h.Broadcaster = pilosa.NopBroadcaster

--- a/test/holder.go
+++ b/test/holder.go
@@ -15,7 +15,6 @@
 package test
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 
@@ -26,7 +25,6 @@ import (
 // Holder is a test wrapper for pilosa.Holder.
 type Holder struct {
 	*pilosa.Holder
-	LogOutput bytes.Buffer
 }
 
 // NewHolder returns a new instance of Holder with a temporary path.
@@ -38,7 +36,6 @@ func NewHolder() *Holder {
 
 	h := &Holder{Holder: pilosa.NewHolder()}
 	h.Path = path
-	h.Holder.LogOutput = &h.LogOutput
 	h.Holder.NewAttrStore = boltdb.NewAttrStore
 
 	return h
@@ -62,10 +59,10 @@ func (h *Holder) Close() error {
 // Reopen instantiates and opens a new holder.
 // Note that the holder must be Closed first.
 func (h *Holder) Reopen() error {
-	path, logOutput := h.Path, h.Holder.LogOutput
+	path, logger := h.Path, h.Holder.Logger
 	h.Holder = pilosa.NewHolder()
 	h.Holder.Path = path
-	h.Holder.LogOutput = logOutput
+	h.Holder.Logger = logger
 	h.Holder.NewAttrStore = boltdb.NewAttrStore
 	if err := h.Holder.Open(); err != nil {
 		return err

--- a/test/logger.go
+++ b/test/logger.go
@@ -1,0 +1,48 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+)
+
+// BufferLogger represents a test Logger that holds log messages
+// in a buffer for review.
+type BufferLogger struct {
+	buf *bytes.Buffer
+}
+
+// NewBufferLogger returns a new instance of BufferLogger.
+func NewBufferLogger() *BufferLogger {
+	return &BufferLogger{
+		buf: &bytes.Buffer{},
+	}
+}
+
+func (b *BufferLogger) Printf(format string, v ...interface{}) {
+	s := fmt.Sprintf(format, v...)
+	_, err := b.buf.WriteString(s)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (b *BufferLogger) Debugf(format string, v ...interface{}) {}
+
+func (b *BufferLogger) ReadAll() ([]byte, error) {
+	return ioutil.ReadAll(b.buf)
+}

--- a/test/logger.go
+++ b/test/logger.go
@@ -43,8 +43,6 @@ func (b *BufferLogger) Printf(format string, v ...interface{}) {
 
 func (b *BufferLogger) Debugf(format string, v ...interface{}) {}
 
-func (b *BufferLogger) Close() error { return nil }
-
 func (b *BufferLogger) ReadAll() ([]byte, error) {
 	return ioutil.ReadAll(b.buf)
 }

--- a/test/logger.go
+++ b/test/logger.go
@@ -43,6 +43,8 @@ func (b *BufferLogger) Printf(format string, v ...interface{}) {
 
 func (b *BufferLogger) Debugf(format string, v ...interface{}) {}
 
+func (b *BufferLogger) Close() error { return nil }
+
 func (b *BufferLogger) ReadAll() ([]byte, error) {
 	return ioutil.ReadAll(b.buf)
 }

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -181,7 +181,7 @@ func (m *Main) RunWithTransport(host string, bindPort int, joinSeeds []string) (
 	}
 
 	// Open gossip transport to use in SetupServer.
-	transport, err := gossip.NewTransport(host, bindPort)
+	transport, err := gossip.NewTransport(host, bindPort, nil)
 	if err != nil {
 		return seed, err
 	}


### PR DESCRIPTION
## Overview

This PR adds a `Logger` interface so all objects share the same logger.
It also adds functional options to `NewGossipMemberSet` to support supplying a `log.Logger` and/or a `Transport`.

Fixes #631 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
