### PR TITLE
Default gossip seed should be empty instead of local bind address

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -61,12 +61,11 @@ func (g *GossipMemberSet) Start(h pilosa.BroadcastHandler) error {
 	return nil
 }
 
-// Seeds returns the gossipSeeds determined by the config.
-func (g *GossipMemberSet) Seeds() []string {
-	if len(g.config.gossipSeeds) == 0 {
-		return []string{fmt.Sprintf("%s:%d", g.config.memberlistConfig.BindAddr, g.config.memberlistConfig.BindPort)}
-	}
-	return g.config.gossipSeeds
+// GetBindAddr returns the gossip bind address based on config and auto bind port.
+// This method is currently only used in a test scenario where a second node needs
+// the auto-bind address of the first node to use as its gossip seed.
+func (g *GossipMemberSet) GetBindAddr() string {
+	return fmt.Sprintf("%s:%d", g.config.memberlistConfig.BindAddr, g.config.memberlistConfig.BindPort)
 }
 
 // Open implements the MemberSet interface to start network activity.

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -63,6 +63,9 @@ func (g *GossipMemberSet) Start(h pilosa.BroadcastHandler) error {
 
 // Seeds returns the gossipSeeds determined by the config.
 func (g *GossipMemberSet) Seeds() []string {
+	if len(g.config.gossipSeeds) == 0 {
+		return []string{fmt.Sprintf("%s:%d", g.config.memberlistConfig.BindAddr, g.config.memberlistConfig.BindPort)}
+	}
 	return g.config.gossipSeeds
 }
 
@@ -201,11 +204,6 @@ func NewGossipMemberSetWithTransport(name string, cfg *pilosa.Config, transport 
 	}
 
 	g.statusHandler = server
-
-	// If no gossipSeeds is provided, use local host:port.
-	if len(cfg.Gossip.Seeds) == 0 {
-		g.config.gossipSeeds = []string{fmt.Sprintf("%s:%d", host, port)}
-	}
 
 	return g, nil
 }

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -78,7 +78,7 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 
 	// get the host portion of addr to use for binding
 	m1.Config.Gossip.Port = "0"
-	m1.Config.Gossip.Seeds = gossipMemberSet0.Seeds()
+	m1.Config.Gossip.Seeds = []string{gossipMemberSet0.GetBindAddr()}
 
 	m1.Server.Cluster.Coordinator = m0.Server.NodeID
 	m1.Server.Cluster.EventReceiver = gossip.NewGossipEventReceiver(m1.Server.LogOutput)


### PR DESCRIPTION
## Overview

There is no need to set the gossip seed to the local node's bind address (e.g. in the case of a one-node cluster). This PR removes that default, and moves the logic to the `Seeds()` method which is actually only used for testing.

Fixes #1172 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
