### PR TITLE
make sure that slices is treated as inverseSlices on inverse calls

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 	"testing/quick"
+	"time"
 
 	"github.com/BurntSushi/toml"
 	"github.com/pilosa/pilosa"
@@ -231,6 +232,49 @@ func TestMain_SetColumnAttrs(t *testing.T) {
 		t.Fatal(err)
 	} else if res != `{"results":[{"attrs":{},"bits":[100,101]}],"columnAttrs":[{"id":100,"attrs":{"foo":"bar"}}]}`+"\n" {
 		t.Fatalf("unexpected result(reopen): %s", res)
+	}
+}
+
+// Ensure inverse slices get handled correctly in a multi-node query.
+func TestMain_InverseSlices(t *testing.T) {
+	mains := test.MustRunMainWithCluster(t, 2)
+
+	m0 := mains[0]
+	m1 := mains[1]
+
+	// Make sure to use node0 in the cluster.
+	var m *test.Main
+	if m0.Server.NodeID < m1.Server.NodeID {
+		m = m0
+	} else {
+		m = m1
+	}
+
+	// Create frames.
+	client := m.Client()
+	if err := client.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
+		t.Fatal("create index:", err)
+	}
+	if err := client.CreateFrame(context.Background(), "i", "f", pilosa.FrameOptions{InverseEnabled: true}); err != nil {
+		t.Fatal("create frame:", err)
+	}
+
+	// Write data on cluster.
+	if _, err := m.Query("i", "", fmt.Sprintf(`
+		SetBit(col=1, frame="f", row=1000)
+		SetBit(col=1, frame="f", row=2000)
+		SetBit(col=1, frame="f", row=%d)
+	`, 1*pilosa.SliceWidth)); err != nil {
+		t.Fatal("setting bits:", err)
+	}
+
+	time.Sleep(1 * time.Second)
+
+	// Query the cluster.
+	if res, err := m.Query("i", "", `Bitmap(col=1, frame="f")`); err != nil {
+		t.Fatal("another bitmap query:", err)
+	} else if res != fmt.Sprintf(`{"results":[{"attrs":{},"bits":[1000,2000,%d]}]}`, 1*pilosa.SliceWidth)+"\n" {
+		t.Fatalf("unexpected result: %s", res)
 	}
 }
 


### PR DESCRIPTION
## Overview

When `slices` were sent to a remote node in the case of an inverse query, it actually represented `inverseSlices`. This PR makes sure that the remote node uses that value correctly.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
