### PR TITLE
WIP: prevent cluster resize and anti-entropy from running at the same time

### DIFF
--- a/holder_test.go
+++ b/holder_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/pilosa/pilosa"
@@ -448,11 +449,12 @@ func TestHolderSyncer_SyncHolder(t *testing.T) {
 
 	// Set up syncer.
 	syncer := pilosa.HolderSyncer{
-		Holder:       hldr0.Holder,
-		Node:         cluster.Nodes[0],
-		Cluster:      cluster,
-		RemoteClient: pilosa.GetHTTPClient(nil),
-		Stats:        pilosa.NopStatsClient,
+		Holder:        hldr0.Holder,
+		Node:          cluster.Nodes[0],
+		Cluster:       cluster,
+		RemoteClient:  pilosa.GetHTTPClient(nil),
+		Stats:         pilosa.NopStatsClient,
+		ActivityMutex: new(sync.Mutex),
 	}
 
 	if err := syncer.SyncHolder(); err != nil {

--- a/server.go
+++ b/server.go
@@ -87,6 +87,10 @@ type Server struct {
 	Logger Logger
 
 	defaultClient InternalClient
+
+	// ActivityMutex ensures mutual exclusion on cluster resize
+	// and anti-entropy events.
+	ActivityMutex *sync.Mutex
 }
 
 // NewServer returns a new instance of Server.
@@ -112,6 +116,8 @@ func NewServer() *Server {
 		DiagnosticInterval:  0,
 
 		Logger: NopLogger,
+
+		ActivityMutex: new(sync.Mutex),
 	}
 
 	s.Handler.API = NewAPI()
@@ -339,6 +345,7 @@ func (s *Server) monitorAntiEntropy() {
 		syncer.Closing = s.closing
 		syncer.RemoteClient = s.RemoteClient
 		syncer.Stats = s.Holder.Stats.WithTags("HolderSyncer")
+		syncer.ActivityMutex = s.ActivityMutex
 
 		// Sync holders.
 		if err := syncer.SyncHolder(); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -170,6 +170,7 @@ func (m *Command) SetupServer() error {
 	cluster.ReplicaN = m.Config.Cluster.ReplicaN
 	cluster.Holder = m.Server.Holder
 	cluster.Logger = m.Server.Logger
+	cluster.ActivityMutex = m.Server.ActivityMutex
 
 	m.Server.Cluster = cluster
 


### PR DESCRIPTION
## Overview

It is important that anti-entropy is not running when a resize event begins (and vise versa). This PR creates a mutex shared by `HolderSyncer` and `Cluster` to ensure that those two activities do not happen concurrently.

Ideally the resize job could stop a currently running anti-entropy job by writing to the `->closing` channel in `HolderSyncer`. This would potentially prevent delays in resize (as resize must wait for AE to fully complete).

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
