### PR TITLE
remove PATCH frame endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -925,23 +925,6 @@ func (api *API) ImportValue(ctx context.Context, req internal.ImportValueRequest
 	return err
 }
 
-// ModifyFrameTimeQuantum changes the time quantum on the given frame. TODO:
-// what happens if there is already data in the frame?
-func (api *API) ModifyFrameTimeQuantum(ctx context.Context, indexName string, frameName string, timeQuantum TimeQuantum) error {
-	if err := api.validate(apiModifyFrameTimeQuantum); err != nil {
-		return errors.Wrap(err, "validate api method")
-	}
-
-	// Retrieve index by name.
-	frame := api.Holder.Frame(indexName, frameName)
-	if frame == nil {
-		return ErrFrameNotFound
-	}
-
-	// Set default time quantum on index.
-	return frame.SetTimeQuantum(timeQuantum)
-}
-
 // MaxSlices returns the maximum slice number for each index in a map.
 func (api *API) MaxSlices(ctx context.Context) map[string]uint64 {
 	return api.Holder.MaxSlices()
@@ -1168,7 +1151,6 @@ const (
 	apiMarshalFragment
 	//apiMaxInverseSlices // not implemented
 	//apiMaxSlices // not implemented
-	apiModifyFrameTimeQuantum
 	apiQuery
 	apiRecalculateCaches
 	apiRemoveNode
@@ -1196,32 +1178,31 @@ var methodsResizing = map[apiMethod]struct{}{
 }
 
 var methodsNormal = map[apiMethod]struct{}{
-	apiCreateField:            struct{}{},
-	apiCreateFrame:            struct{}{},
-	apiCreateIndex:            struct{}{},
-	apiCreateInputDefinition:  struct{}{},
-	apiDeleteField:            struct{}{},
-	apiDeleteFrame:            struct{}{},
-	apiDeleteIndex:            struct{}{},
-	apiDeleteInputDefinition:  struct{}{},
-	apiDeleteView:             struct{}{},
-	apiExportCSV:              struct{}{},
-	apiFields:                 struct{}{},
-	apiFragmentBlockData:      struct{}{},
-	apiFragmentBlocks:         struct{}{},
-	apiFrameAttrDiff:          struct{}{},
-	apiImport:                 struct{}{},
-	apiImportValue:            struct{}{},
-	apiIndex:                  struct{}{},
-	apiIndexAttrDiff:          struct{}{},
-	apiInputDefinition:        struct{}{},
-	apiModifyFrameTimeQuantum: struct{}{},
-	apiQuery:                  struct{}{},
-	apiRecalculateCaches:      struct{}{},
-	apiRemoveNode:             struct{}{},
-	apiRestoreFrame:           struct{}{},
-	apiSliceNodes:             struct{}{},
-	apiUnmarshalFragment:      struct{}{},
-	apiViews:                  struct{}{},
-	apiWriteInput:             struct{}{},
+	apiCreateField:           struct{}{},
+	apiCreateFrame:           struct{}{},
+	apiCreateIndex:           struct{}{},
+	apiCreateInputDefinition: struct{}{},
+	apiDeleteField:           struct{}{},
+	apiDeleteFrame:           struct{}{},
+	apiDeleteIndex:           struct{}{},
+	apiDeleteInputDefinition: struct{}{},
+	apiDeleteView:            struct{}{},
+	apiExportCSV:             struct{}{},
+	apiFields:                struct{}{},
+	apiFragmentBlockData:     struct{}{},
+	apiFragmentBlocks:        struct{}{},
+	apiFrameAttrDiff:         struct{}{},
+	apiImport:                struct{}{},
+	apiImportValue:           struct{}{},
+	apiIndex:                 struct{}{},
+	apiIndexAttrDiff:         struct{}{},
+	apiInputDefinition:       struct{}{},
+	apiQuery:                 struct{}{},
+	apiRecalculateCaches:     struct{}{},
+	apiRemoveNode:            struct{}{},
+	apiRestoreFrame:          struct{}{},
+	apiSliceNodes:            struct{}{},
+	apiUnmarshalFragment:     struct{}{},
+	apiViews:                 struct{}{},
+	apiWriteInput:            struct{}{},
 }

--- a/apimethod_string.go
+++ b/apimethod_string.go
@@ -4,9 +4,9 @@ package pilosa
 
 import "fmt"
 
-const _apiMethod_name = "apiClusterMessageapiCreateFieldapiCreateFrameapiCreateIndexapiCreateInputDefinitionapiDeleteFieldapiDeleteFrameapiDeleteIndexapiDeleteInputDefinitionapiDeleteViewapiExportCSVapiFieldsapiFragmentBlockDataapiFragmentBlocksapiFrameAttrDiffapiImportapiImportValueapiIndexapiIndexAttrDiffapiInputDefinitionapiMarshalFragmentapiModifyFrameTimeQuantumapiQueryapiRecalculateCachesapiRemoveNodeapiResizeAbortapiRestoreFrameapiSetCoordinatorapiSliceNodesapiUnmarshalFragmentapiViewsapiWriteInput"
+const _apiMethod_name = "apiClusterMessageapiCreateFieldapiCreateFrameapiCreateIndexapiCreateInputDefinitionapiDeleteFieldapiDeleteFrameapiDeleteIndexapiDeleteInputDefinitionapiDeleteViewapiExportCSVapiFieldsapiFragmentBlockDataapiFragmentBlocksapiFrameAttrDiffapiImportapiImportValueapiIndexapiIndexAttrDiffapiInputDefinitionapiMarshalFragmentapiQueryapiRecalculateCachesapiRemoveNodeapiResizeAbortapiRestoreFrameapiSetCoordinatorapiSliceNodesapiUnmarshalFragmentapiViewsapiWriteInput"
 
-var _apiMethod_index = [...]uint16{0, 17, 31, 45, 59, 83, 97, 111, 125, 149, 162, 174, 183, 203, 220, 236, 245, 259, 267, 283, 301, 319, 344, 352, 372, 385, 399, 414, 431, 444, 464, 472, 485}
+var _apiMethod_index = [...]uint16{0, 17, 31, 45, 59, 83, 97, 111, 125, 149, 162, 174, 183, 203, 220, 236, 245, 259, 267, 283, 301, 319, 327, 347, 360, 374, 389, 406, 419, 439, 447, 460}
 
 func (i apiMethod) String() string {
 	if i < 0 || i >= apiMethod(len(_apiMethod_index)-1) {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -149,35 +149,6 @@ curl -XDELETE localhost:10101/index/user/frame/language
 {}
 ```
 
-### Change frame time quantum
-
-`PATCH /index/<index-name>/frame/<frame-name>/time-quantum`
-
-Changes the time quantum for the given frame. This endpoint should be called at most once right after creating a frame.
-
-The payload is in JSON with the format: `{"timeQuantum": "${TIME_QUANTUM}"}`. Valid time quantum values are:
-
-* (Empty string)
-* Y: year
-* M: month
-* D: day
-* H: hour
-* YM: year and month
-* MD: month and day
-* DH: day and hour
-* YMD: year, month and day
-* MDH: month, day and hour
-* YMDH: year, month, day and hour
-
-``` request
-curl localhost:10101/index/user/frame/language/time-quantum \
-     -X POST \
-     -d '{"timeQuantum": "YM"}'
-```
-``` response
-{}
-```
-
 ### Create Field
 
 `POST /index/<index-name>/frame/<frame-name>/field/<field-name>`

--- a/handler.go
+++ b/handler.go
@@ -157,7 +157,6 @@ func NewRouter(handler *Handler) *mux.Router {
 	router.HandleFunc("/index/{index}/frame/{frame}", handler.handleDeleteFrame).Methods("DELETE")
 	router.HandleFunc("/index/{index}/frame/{frame}/attr/diff", handler.handlePostFrameAttrDiff).Methods("POST")
 	router.HandleFunc("/index/{index}/frame/{frame}/restore", handler.handlePostFrameRestore).Methods("POST").Name("PostFrameRestore")
-	router.HandleFunc("/index/{index}/frame/{frame}/time-quantum", handler.handlePatchFrameTimeQuantum).Methods("PATCH")
 	router.HandleFunc("/index/{index}/frame/{frame}/field/{field}", handler.handlePostFrameField).Methods("POST")
 	router.HandleFunc("/index/{index}/frame/{frame}/fields", handler.handleGetFrameFields).Methods("GET")
 	router.HandleFunc("/index/{index}/frame/{frame}/field/{field}", handler.handleDeleteFrameField).Methods("DELETE")
@@ -595,46 +594,6 @@ func (h *Handler) handleDeleteFrame(w http.ResponseWriter, r *http.Request) {
 }
 
 type deleteFrameResponse struct{}
-
-// handlePatchFrameTimeQuantum handles PATCH /frame/time_quantum request.
-func (h *Handler) handlePatchFrameTimeQuantum(w http.ResponseWriter, r *http.Request) {
-	indexName := mux.Vars(r)["index"]
-	frameName := mux.Vars(r)["frame"]
-
-	// Decode request.
-	var req patchFrameTimeQuantumRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	// Validate quantum.
-	tq, err := ParseTimeQuantum(req.TimeQuantum)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
-	if err := h.API.ModifyFrameTimeQuantum(r.Context(), indexName, frameName, tq); err != nil {
-		if err == ErrFragmentNotFound {
-			http.Error(w, err.Error(), http.StatusNotFound)
-		} else {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-		return
-	}
-
-	// Encode response.
-	if err := json.NewEncoder(w).Encode(patchFrameTimeQuantumResponse{}); err != nil {
-		h.Logger.Printf("response encoding error: %s", err)
-	}
-}
-
-type patchFrameTimeQuantumRequest struct {
-	TimeQuantum string `json:"timeQuantum"`
-}
-
-type patchFrameTimeQuantumResponse struct{}
 
 // handlePostFrameField handles POST /frame/field request.
 func (h *Handler) handlePostFrameField(w http.ResponseWriter, r *http.Request) {

--- a/handler_test.go
+++ b/handler_test.go
@@ -748,30 +748,6 @@ func TestHandler_DeleteFrame(t *testing.T) {
 	}
 }
 
-// Ensure handler can set the frame time quantum.
-func TestHandler_SetFrameTimeQuantum(t *testing.T) {
-	hldr := test.MustOpenHolder()
-	defer hldr.Close()
-
-	// Create frame.
-	if _, err := hldr.MustCreateIndexIfNotExists("i0", pilosa.IndexOptions{}).CreateFrame("f1", pilosa.FrameOptions{}); err != nil {
-		t.Fatal(err)
-	}
-
-	h := test.NewHandler()
-	h.API.Holder = hldr.Holder
-	h.API.Cluster = test.NewCluster(1)
-	w := httptest.NewRecorder()
-	h.ServeHTTP(w, test.MustNewHTTPRequest("PATCH", "/index/i0/frame/f1/time-quantum", strings.NewReader(`{"timeQuantum":"ymdh"}`)))
-	if w.Code != http.StatusOK {
-		t.Fatalf("unexpected status code: %d", w.Code)
-	} else if body := w.Body.String(); body != `{}`+"\n" {
-		t.Fatalf("unexpected body: %s", body)
-	} else if q := hldr.Index("i0").Frame("f1").TimeQuantum(); q != pilosa.TimeQuantum("YMDH") {
-		t.Fatalf("unexpected time quantum: %s", q)
-	}
-}
-
 // Ensure the handler can return data in differing blocks for an index.
 func TestHandler_Index_AttrStore_Diff(t *testing.T) {
 	hldr := test.MustOpenHolder()


### PR DESCRIPTION
## Overview

Removed the PATCH frame endpoint, which supported the ability to modify the timeQuantum for an existing frame. For now, setting timeQuantum will be restricted to frame creation.

Fixes #1218 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
