### PR TITLE
remove holder.Peek, combine with HasData, move server logic

### DIFF
--- a/holder_test.go
+++ b/holder_test.go
@@ -283,26 +283,24 @@ func TestHolder_HasData(t *testing.T) {
 		h := test.MustOpenHolder()
 		defer h.Close()
 
-		if h.HasData() {
-			t.Fatal("expected HasData to return false")
+		if ok, err := h.HasData(); ok || err != nil {
+			t.Fatal("expected HasData to return false, no err, but", ok, err)
 		}
 
 		if _, err := h.CreateIndex("test", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
 		}
 
-		if !h.HasData() {
-			t.Fatal("expected HasData to return true")
+		if ok, err := h.HasData(); !ok || err != nil {
+			t.Fatal("expected HasData to return true, but ", ok, err)
 		}
 	})
 
 	t.Run("Peek", func(t *testing.T) {
 		h := test.NewHolder()
 
-		if hasData := h.Peek(); hasData != false {
-			t.Fatal("expected Peek to return false")
-		} else if h.HasData() {
-			t.Fatal("expected HasData to return false")
+		if ok, err := h.HasData(); ok || err != nil {
+			t.Fatal("expected HasData to return false, no err, but", ok, err)
 		}
 
 		// Create an index directory to indicate data exists.
@@ -310,24 +308,19 @@ func TestHolder_HasData(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if hasData := h.Peek(); hasData != true {
-			t.Fatal("expected Peek to return true")
-		} else if !h.HasData() {
-			t.Fatal("expected HasData to return true")
+		if ok, err := h.HasData(); !ok || err != nil {
+			t.Fatal("expected HasData to return true, no err, but", ok, err)
 		}
 	})
 
 	t.Run("Peek at missing directory", func(t *testing.T) {
 		h := test.NewHolder()
 
-		// Ensure that hasData is false when trying to peek into
-		// a directory that doesn't exist.
+		// Ensure that hasData is false when dir doesn't exist.
 		h.Path = "bad-path"
 
-		if hasData := h.Peek(); hasData != false {
-			t.Fatal("expected Peek to return false")
-		} else if h.HasData() {
-			t.Fatal("expected HasData to return false")
+		if ok, err := h.HasData(); ok || err != nil {
+			t.Fatal("expected HasData to return false, no err, but", ok, err)
 		}
 	})
 }

--- a/server/server.go
+++ b/server/server.go
@@ -305,6 +305,7 @@ func (m *Command) SetupNetworking() error {
 	// Set Coordinator.
 	if m.Config.Cluster.Coordinator || len(m.Config.Gossip.Seeds) == 0 {
 		m.Server.Cluster.Coordinator = m.Server.NodeID
+		m.Server.Cluster.Node.IsCoordinator = true
 	}
 
 	gossipEventReceiver := gossip.NewGossipEventReceiver(m.logger)


### PR DESCRIPTION
Server initializing happens more in NewServer than Open now - expecting to
continue this trend. goal was to remove remoteClient from Server (since it has a
defaultClient) as well, but we'll have to refactor the client usage in fragment
and frame first.


Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
