### PR TITLE
fix nil client bug in monitorAntiEntropy (and test)

### DIFF
--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -57,6 +57,7 @@ func testMessageMarshal(t *testing.T, m proto.Message) {
 // Ensure that BroadcastReceiver can register a BroadcastHandler.
 func TestBroadcast_BroadcastReceiver(t *testing.T) {
 	com := server.NewCommand(bytes.NewBuffer([]byte{}), ioutil.Discard, ioutil.Discard)
+	com.Config.Bind = "localhost:0"
 	err := com.SetupServer() // this test shouldn't need to import pilosa/server just to set up the Server, but it really shouldn't need to setup the Server at all. The Server should not be the implementation of Broadcast* TODO
 	if err != nil {
 		t.Fatalf("setting up server: %v", err)

--- a/server.go
+++ b/server.go
@@ -163,6 +163,7 @@ func OptServerGCNotifier(gcn GCNotifier) ServerOption {
 func OptServerRemoteClient(c *http.Client) ServerOption {
 	return func(s *Server) error {
 		s.executor = NewExecutor(c)
+		s.remoteClient = c
 		s.defaultClient = NewInternalHTTPClientFromURI(nil, c)
 		s.Cluster.RemoteClient = c
 		return nil

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,35 @@
+package pilosa_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pilosa/pilosa"
+	"github.com/pilosa/pilosa/test"
+)
+
+// TestMonitorAntiEntropy is a regression test which which caught a bug where
+// pilosa.Server was not having its remoteClient field set by an option and so
+// it was using a nil client in monitorAntiEntropy.
+func TestMonitorAntiEntropy(t *testing.T) {
+	cluster := test.MustRunMainWithCluster(t, 3, test.OptAntiEntropyInterval(time.Millisecond*1))
+	client := cluster[1].Client()
+	err := client.CreateIndex(context.Background(), "balh", pilosa.IndexOptions{})
+	if err != nil {
+		t.Fatalf("creating index: %v", err)
+	}
+	err = client.CreateFrame(context.Background(), "balh", "fralh", pilosa.FrameOptions{})
+	if err != nil {
+		t.Fatalf("creating frame: %v", err)
+	}
+
+	time.Sleep(time.Millisecond * 2)
+	for _, m := range cluster {
+		err := m.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+}


### PR DESCRIPTION
also fix bug where broadcast_test tried to listen on localhost:10101

## Overview

This was broken by some recent refactoring - I noticed it while trying to import a bunch of genome data into a Pilosa cluster. It was not caught by any of our current integration type tests because they use a 10 minute anti entropy interval by default.

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
