### PR TITLE
Added /info endpoint. Fixes #1232

### DIFF
--- a/api.go
+++ b/api.go
@@ -1121,6 +1121,17 @@ func (api *API) Version() string {
 	return strings.TrimPrefix(Version, "v")
 }
 
+// Info returns information about this server instance
+func (api *API) Info() ServerInfo {
+	return ServerInfo{
+		SliceWidth: SliceWidth,
+	}
+}
+
+type ServerInfo struct {
+	SliceWidth uint64 `json:"sliceWidth"`
+}
+
 type apiMethod int
 
 // API validation constants.

--- a/handler.go
+++ b/handler.go
@@ -126,6 +126,7 @@ func NewRouter(handler *Handler) *mux.Router {
 	router.HandleFunc("/schema", handler.handleGetSchema).Methods("GET")
 	router.HandleFunc("/slices/max", handler.handleGetSlicesMax).Methods("GET") // TODO: deprecate, but it's being used by the client (for backups)
 	router.HandleFunc("/status", handler.handleGetStatus).Methods("GET")
+	router.HandleFunc("/info", handler.handleGetInfo).Methods("GET")
 	router.HandleFunc("/version", handler.handleGetVersion).Methods("GET")
 
 	router.HandleFunc("/cluster/resize/abort", handler.handlePostClusterResizeAbort).Methods("POST")
@@ -249,6 +250,13 @@ func (h *Handler) handleGetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := json.NewEncoder(w).Encode(status); err != nil {
 		h.Logger.Printf("write status response error: %s", err)
+	}
+}
+
+func (h *Handler) handleGetInfo(w http.ResponseWriter, r *http.Request) {
+	info := h.API.Info()
+	if err := json.NewEncoder(w).Encode(info); err != nil {
+		h.Logger.Printf("write info response error: %s", err)
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -150,6 +151,20 @@ func TestHandler_Status(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("unexpected status code: %d", w.Code)
 	} else if body := w.Body.String(); body != `{"state":"NORMAL","nodes":[{"id":"node0","uri":{"scheme":"http","host":"host0"},"isCoordinator":false}]}`+"\n" {
+		t.Fatalf("unexpected body: %s", body)
+	}
+}
+
+func TestHandler_Info(t *testing.T) {
+	s := test.NewServer()
+	defer s.Close()
+	h := test.NewHandler()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, test.MustNewHTTPRequest("GET", "/info", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("unexpected status code: %d", w.Code)
+	} else if body := w.Body.String(); body != fmt.Sprintf("{\"sliceWidth\":%d}\n", SliceWidth) {
 		t.Fatalf("unexpected body: %s", body)
 	}
 }


### PR DESCRIPTION
## Overview

Adds `/info` endpoint which returns the slice width. We can also return other compile time server properties from this endpoint, such as `/version`.

Fixes #1232 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
