### PR TITLE
Make sure ~ is expanded in NewServer; BroadcastReceiver uses temp path

### DIFF
--- a/broadcast_test.go
+++ b/broadcast_test.go
@@ -56,9 +56,14 @@ func testMessageMarshal(t *testing.T, m proto.Message) {
 
 // Ensure that BroadcastReceiver can register a BroadcastHandler.
 func TestBroadcast_BroadcastReceiver(t *testing.T) {
+	path, err := ioutil.TempDir("", "pilosa-")
+	if err != nil {
+		panic(err)
+	}
 	com := server.NewCommand(bytes.NewBuffer([]byte{}), ioutil.Discard, ioutil.Discard)
 	com.Config.Bind = "localhost:0"
-	err := com.SetupServer() // this test shouldn't need to import pilosa/server just to set up the Server, but it really shouldn't need to setup the Server at all. The Server should not be the implementation of Broadcast* TODO
+	com.Config.DataDir = path
+	err = com.SetupServer() // this test shouldn't need to import pilosa/server just to set up the Server, but it really shouldn't need to setup the Server at all. The Server should not be the implementation of Broadcast* TODO
 	if err != nil {
 		t.Fatalf("setting up server: %v", err)
 	}

--- a/server.go
+++ b/server.go
@@ -77,6 +77,7 @@ type Server struct {
 	maxWritesPerRequest int
 
 	defaultClient InternalClient
+	dataDir       string
 }
 
 // ServerOption is a functional option type for pilosa.Server
@@ -98,8 +99,7 @@ func OptServerReplicaN(n int) ServerOption {
 
 func OptServerDataDir(dir string) ServerOption {
 	return func(s *Server) error {
-		s.Cluster.Path = dir
-		s.Holder.Path = dir
+		s.dataDir = dir
 		return nil
 	}
 }
@@ -231,21 +231,16 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		}
 	}
 
-	path, err := expandDirName(s.Holder.Path)
+	path, err := expandDirName(s.dataDir)
 	if err != nil {
 		return nil, err
 	}
-	s.Holder.Path = path
 
+	s.Holder.Path = path
 	s.Holder.Logger = s.logger
 	s.Holder.Stats.SetLogger(s.logger)
 
-	path, err = expandDirName(s.Cluster.Path)
-	if err != nil {
-		return nil, err
-	}
 	s.Cluster.Path = path
-
 	s.Cluster.Logger = s.logger
 	s.Cluster.Holder = s.Holder
 

--- a/server/server.go
+++ b/server/server.go
@@ -28,9 +28,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
-	"strings"
 	"syscall"
 	"time"
 
@@ -93,14 +91,6 @@ func NewCommand(stdin io.Reader, stdout, stderr io.Writer) *Command {
 // Start starts the pilosa server - it returns once the server is running.
 func (m *Command) Start() (err error) {
 	defer close(m.Started)
-	prefix := "~" + string(filepath.Separator)
-	if strings.HasPrefix(m.Config.DataDir, prefix) {
-		HomeDir := os.Getenv("HOME")
-		if HomeDir == "" {
-			return errors.New("data directory not specified and no home dir available")
-		}
-		m.Config.DataDir = filepath.Join(HomeDir, strings.TrimPrefix(m.Config.DataDir, prefix))
-	}
 
 	// SetupServer
 	err = m.SetupServer()


### PR DESCRIPTION
## Overview

[Describe what this pull request addresses.]

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
