### PR TITLE
Log time/version to startup log (Fixes #391)

### DIFF
--- a/holder.go
+++ b/holder.go
@@ -547,6 +547,28 @@ func (h *Holder) loadNodeID() (string, error) {
 	return nodeID, nil
 }
 
+// Log startup time and version to $DATA_DIR/.startup.log
+func (h *Holder) logStartup() error {
+	time, err := time.Now().MarshalText()
+	if err != nil {
+		return errors.Wrap(err, "creating timestamp")
+	}
+	logLine := fmt.Sprintf("%s\t%s\n", time, Version)
+
+	f, err := os.OpenFile(h.Path+"/.startup.log", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+	if err != nil {
+		return errors.Wrap(err, "opening startup log")
+	}
+
+	defer f.Close()
+
+	if _, err = f.WriteString(logLine); err != nil {
+		return errors.Wrap(err, "writing startup log")
+	}
+
+	return nil
+}
+
 // HolderSyncer is an active anti-entropy tool that compares the local holder
 // with a remote holder based on block checksums and resolves differences.
 type HolderSyncer struct {

--- a/server.go
+++ b/server.go
@@ -17,6 +17,7 @@ package pilosa
 import (
 	"context"
 	"fmt"
+	"log"
 	"net"
 	"net/http"
 	"os"
@@ -266,6 +267,12 @@ func (s *Server) Open() error {
 	// s.ln can be configured prior to Open() via s.OpenListener().
 	if s.ln == nil {
 		return errors.New("Must pass a listener option to NewServer")
+	}
+
+	// Log startup
+	err := s.Holder.logStartup()
+	if err != nil {
+		log.Println(errors.Wrap(err, "logging startup"))
 	}
 
 	// Get or create NodeID.


### PR DESCRIPTION
## Overview

This adds a log line to `$DATA_DIR/.startup.log` with the current time and pilosa version. We can use this for debugging in the future if need be.

Fixes #391 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
