### PR TITLE
API.URI was not being used. removed it.

### DIFF
--- a/api.go
+++ b/api.go
@@ -46,7 +46,6 @@ type API struct {
 	BroadcastHandler BroadcastHandler
 	StatusHandler    StatusHandler
 	Cluster          *Cluster
-	URI              URI
 	RemoteClient     *http.Client
 	Logger           Logger
 }
@@ -294,7 +293,7 @@ func (api *API) ExportCSV(ctx context.Context, indexName string, frameName strin
 
 	// Validate that this handler owns the slice.
 	if !api.Cluster.OwnsSlice(api.LocalID(), indexName, slice) {
-		api.Logger.Printf("host does not own slice %s-%s slice:%d", api.URI, indexName, slice)
+		api.Logger.Printf("node %s does not own slice %d of index %s", api.LocalID(), slice, indexName)
 		return ErrClusterDoesNotOwnSlice
 	}
 
@@ -957,7 +956,7 @@ func (api *API) LongQueryTime() time.Duration {
 func (api *API) indexFrame(indexName string, frameName string, slice uint64) (*Index, *Frame, error) {
 	// Validate that this handler owns the slice.
 	if !api.Cluster.OwnsSlice(api.LocalID(), indexName, slice) {
-		api.Logger.Printf("host does not own slice %s-%s slice:%d", api.URI, indexName, slice)
+		api.Logger.Printf("node %s does not own slice %d of index %s", api.LocalID(), slice, indexName)
 		return nil, nil, ErrClusterDoesNotOwnSlice
 	}
 

--- a/client_test.go
+++ b/client_test.go
@@ -37,7 +37,6 @@ func createCluster(c *pilosa.Cluster) ([]*test.Server, []*test.Holder) {
 	for i := 0; i < numNodes; i++ {
 		hldr[i] = test.MustOpenHolder()
 		server[i] = test.NewServer()
-		server[i].Handler.API.URI = server[i].HostURI()
 		server[i].Handler.API.Cluster = c
 		server[i].Handler.API.Cluster.Nodes[i].URI = server[i].HostURI()
 		server[i].Handler.API.Holder = hldr[i].Holder
@@ -218,7 +217,6 @@ func TestClient_Import(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -269,7 +267,6 @@ func TestClient_ImportInverseEnabled(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -318,7 +315,6 @@ func TestClient_ImportValue(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -386,7 +382,6 @@ func TestClient_BackupRestore(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -452,7 +447,6 @@ func TestClient_BackupInverseView(t *testing.T) {
 	s := test.NewServer()
 	defer s.Close()
 
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -489,7 +483,6 @@ func TestClient_BackupInvalidView(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -518,7 +511,6 @@ func TestClient_FragmentBlocks(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	s.Handler.API.URI = s.HostURI()
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder

--- a/ctl/backup_test.go
+++ b/ctl/backup_test.go
@@ -46,11 +46,7 @@ func TestBackupCommand_Run(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	uri, err := pilosa.NewURIFromAddress(s.Host())
-	if err != nil {
-		t.Fatal(err)
-	}
-	s.Handler.API.URI = *uri
+
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder

--- a/ctl/export_test.go
+++ b/ctl/export_test.go
@@ -59,11 +59,7 @@ func TestExportCommand_Run(t *testing.T) {
 	defer hldr.Close()
 	s := test.NewServer()
 	defer s.Close()
-	uri, err := pilosa.NewURIFromAddress(s.Host())
-	if err != nil {
-		t.Fatal(err)
-	}
-	s.Handler.API.URI = *uri
+
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -75,8 +71,7 @@ func TestExportCommand_Run(t *testing.T) {
 	cm.Index = "i"
 	cm.Frame = "f"
 	cm.View = pilosa.ViewStandard
-	err = cm.Run(context.Background())
-	if err != nil {
+	if err := cm.Run(context.Background()); err != nil {
 		t.Fatalf("Export Run doesn't work: %s", err)
 	}
 }

--- a/ctl/import_test.go
+++ b/ctl/import_test.go
@@ -65,11 +65,7 @@ func TestImportCommand_Run(t *testing.T) {
 	defer hldr.Close()
 	s := test.NewServer()
 	defer s.Close()
-	uri, err := pilosa.NewURIFromAddress(s.Host())
-	if err != nil {
-		t.Fatal(err)
-	}
-	s.Handler.API.URI = *uri
+
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder
@@ -103,12 +99,7 @@ func TestImportCommand_RunValue(t *testing.T) {
 	defer hldr.Close()
 	s := test.NewServer()
 	defer s.Close()
-	uri, err := pilosa.NewURIFromAddress(s.Host())
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	s.Handler.API.URI = *uri
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder

--- a/ctl/restore_test.go
+++ b/ctl/restore_test.go
@@ -48,11 +48,7 @@ func TestRestoreCommand_Run(t *testing.T) {
 
 	s := test.NewServer()
 	defer s.Close()
-	uri, err := pilosa.NewURIFromAddress(s.Host())
-	if err != nil {
-		t.Fatal(err)
-	}
-	s.Handler.API.URI = *uri
+
 	s.Handler.API.Cluster = test.NewCluster(1)
 	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
 	s.Handler.API.Holder = hldr.Holder

--- a/server.go
+++ b/server.go
@@ -300,7 +300,6 @@ func (s *Server) Open() error {
 	s.handler.API.Broadcaster = s.Broadcaster
 	s.handler.API.BroadcastHandler = s
 	s.handler.API.StatusHandler = s
-	s.handler.API.URI = s.URI
 	s.handler.API.Cluster = s.Cluster
 
 	// Initialize Holder.

--- a/test/handler.go
+++ b/test/handler.go
@@ -75,13 +75,6 @@ func NewServer() *Server {
 	}
 	s.Server = httptest.NewServer(s.Handler.Handler)
 
-	// Update handler to use hostname.
-	uri, err := pilosa.NewURIFromAddress(s.Host())
-	if err != nil {
-		panic(err)
-	}
-	s.Handler.API.URI = *uri
-
 	// Handler test messages can no-op.
 	s.Handler.API.Broadcaster = pilosa.NopBroadcaster
 	// Create a default cluster on the handler


### PR DESCRIPTION
## Overview

`API.URI` wasn't being used, so I removed it from the struct and from everywhere it was being set.


## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
