### PR TITLE
make sure gossipMemberSet.Logger is set during server setup

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -169,7 +169,9 @@ func WithLogger(logger *log.Logger) GossipMemberSetOption {
 
 // NewGossipMemberSet returns a new instance of GossipMemberSet based on options.
 func NewGossipMemberSet(name string, host string, cfg Config, ger *GossipEventReceiver, sh pilosa.StatusHandler, options ...GossipMemberSetOption) (*GossipMemberSet, error) {
-	g := &GossipMemberSet{}
+	g := &GossipMemberSet{
+		Logger: pilosa.NopLogger,
+	}
 
 	// options
 	for _, opt := range options {

--- a/server/server.go
+++ b/server/server.go
@@ -300,10 +300,19 @@ func (m *Command) SetupNetworking() error {
 
 	gossipEventReceiver := gossip.NewGossipEventReceiver(m.logger)
 	m.Server.Cluster.EventReceiver = gossipEventReceiver
-	gossipMemberSet, err := gossip.NewGossipMemberSet(m.Server.NodeID, m.Server.URI.Host(), m.Config.Gossip, gossipEventReceiver, m.Server, gossip.WithLogger(m.logger.Logger()), gossip.WithTransport(transport))
+	gossipMemberSet, err := gossip.NewGossipMemberSet(
+		m.Server.NodeID,
+		m.Server.URI.Host(),
+		m.Config.Gossip,
+		gossipEventReceiver,
+		m.Server,
+		gossip.WithLogger(m.logger.Logger()),
+		gossip.WithTransport(transport),
+	)
 	if err != nil {
 		return err
 	}
+	gossipMemberSet.Logger = m.logger
 	m.Server.Cluster.MemberSet = gossipMemberSet
 	m.Server.Broadcaster = m.Server
 	m.Server.BroadcastReceiver = gossipMemberSet


### PR DESCRIPTION
## Overview

`GossipMemberSet.Logger` wasn't being set and would occasionally panic during CI when it tried to log to a `nil` logger.


## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
