### PR TITLE
replace "Pilosa starting..." log line

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -159,6 +159,8 @@ func (m *Command) SetupServer() error {
 		return errors.Wrap(err, "setting up logger")
 	}
 
+	m.logger.Printf("Pilosa %s, build time %s\n", pilosa.Version, pilosa.BuildTime)
+
 	handler := pilosa.NewHandler()
 	handler.Logger = m.logger
 	handler.FileSystem = &statik.FileSystem{}


### PR DESCRIPTION
## Overview

The log line that looks like:
```
Pilosa v0.9.0-83-gc55209a, build time 2018-05-15T17:16:36+0000
```
was inadvertently removed during a previous refactor of the command code.
This PR replaces that log line.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
