### PR TITLE
adjust cluster state tests so they aren't so dependent upon a sleep

### DIFF
--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -187,11 +187,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		time.Sleep(1 * time.Second)
-
-		if m0.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if m1.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -231,12 +229,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Give the cluster time to settle.
-		time.Sleep(1 * time.Second)
-
-		if m0.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if m1.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -286,12 +281,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Give the cluster time to settle.
-		time.Sleep(1 * time.Second)
-
-		if m0.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if m1.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -341,12 +333,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Give the cluster time to settle.
-		time.Sleep(1 * time.Second)
-
-		if m0.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if m1.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -395,14 +384,11 @@ func TestCluster_GossipMembership(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Give the cluster time to settle.
-		time.Sleep(1 * time.Second)
-
-		if m0.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if m1.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
-		} else if m2.Server.Cluster.State() != pilosa.ClusterStateNormal {
+		} else if !checkClusterState(m2.Server.Cluster, pilosa.ClusterStateNormal, 200) {
 			t.Fatalf("unexpected node2 cluster state: %s", m2.Server.Cluster.State())
 		}
 
@@ -496,4 +482,16 @@ func TestClusterResize_RemoveNode(t *testing.T) {
 			t.Fatalf("expected to contain '%s' but got '%s'", expBody, strings.TrimSpace(resp.Body))
 		}
 	})
+}
+
+// checkClusterState polls a given cluster for its state until it
+// receives a matching state. It polls up to n times before returning.
+func checkClusterState(c *pilosa.Cluster, state string, n int) bool {
+	for i := 0; i < n; i++ {
+		if c.State() == state {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
 }

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -187,9 +187,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -229,9 +229,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -281,9 +281,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -333,9 +333,9 @@ func TestClusterResize_AddNode(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
 		}
 	})
@@ -384,11 +384,11 @@ func TestCluster_GossipMembership(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		if !checkClusterState(m0.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node0 cluster state: %s", m0.Server.Cluster.State())
-		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		} else if !checkClusterState(m1.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node1 cluster state: %s", m1.Server.Cluster.State())
-		} else if !checkClusterState(m2.Server.Cluster, pilosa.ClusterStateNormal, 200) {
+		} else if !checkClusterState(m2.Server.Cluster, pilosa.ClusterStateNormal, 1000) {
 			t.Fatalf("unexpected node2 cluster state: %s", m2.Server.Cluster.State())
 		}
 


### PR DESCRIPTION
## Overview

Several cluster resize tests employed a `time.Sleep()` prior to checking cluster state in order to give the test cluster time to settle. This PR replaces that fixed sleep with a periodic poll using a smaller sleep time and a maximum number of attempts.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
