### PR TITLE
change Makefile to test for equality on ENTERPRISE=1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ BRANCH_ID := $(BRANCH)-$(GOOS)-$(GOARCH)
 BUILD_TIME := $(shell date -u +%FT%T%z)
 LDFLAGS="-X github.com/pilosa/pilosa.Version=$(VERSION) -X github.com/pilosa/pilosa.BuildTime=$(BUILD_TIME) -X github.com/pilosa/pilosa.Enterprise=$(ENTERPRISE)"
 GO_VERSION=latest
-ENTERPRISE_TAG := $(if $(ENTERPRISE),-tags=enterprise)
+ifeq ($(ENTERPRISE),1)
+ENTERPRISE_TAG := -tags=enterprise
+endif
 
 # Run tests and compile Pilosa
 default: test build


### PR DESCRIPTION
## Overview

The Makefile was just testing for existence of `ENTERPRISE`, but `version.go` was testing for `pilosa.Enterprise=1`, so if you ran `ENTERPRISE=0 make install` then the build would include enterprise build tags, but the version would not specify enterprise.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
