### PR TITLE
Close HTTP handler gracefully (Fixes #1018) (v0.10)

### DIFF
--- a/server.go
+++ b/server.go
@@ -307,8 +307,13 @@ func (s *Server) Open() error {
 
 	// Serve HTTP.
 	go func() {
-		err := http.Serve(s.ln, s.handler)
-		if err != nil {
+		server := &http.Server{Handler: s.handler}
+		go func() {
+			<-s.closing
+			server.Close()
+		}()
+		err := server.Serve(s.ln)
+		if err != nil && err.Error() != "http: Server closed" {
 			s.logger.Printf("HTTP handler terminated with error: %s\n", err)
 		}
 	}()


### PR DESCRIPTION
An earlier version of this patch, #1019, was erroneously removed during a merge.

This is a duplicate of #1018 that applies to v0.10.