### PR TITLE
renamed pilosa.Bitmap to Row

### DIFF
--- a/api.go
+++ b/api.go
@@ -114,7 +114,7 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 		// Consolidate all column ids across all calls.
 		var columnIDs []uint64
 		for _, result := range results {
-			bm, ok := result.(*Bitmap)
+			bm, ok := result.(*Row)
 			if !ok {
 				continue
 			}

--- a/bitmap_test.go
+++ b/bitmap_test.go
@@ -25,8 +25,8 @@ import (
 // Ensure a bitmap can be merged
 func TestBitmap_Merge(t *testing.T) {
 	tests := []struct {
-		bm1 *pilosa.Bitmap
-		bm2 *pilosa.Bitmap
+		bm1 *pilosa.Row
+		bm2 *pilosa.Row
 		exp uint64
 	}{
 		{

--- a/cache.go
+++ b/cache.go
@@ -463,8 +463,8 @@ func (p uint64Slice) merge(other []uint64) []uint64 {
 
 // BitmapCache provides an interface for caching full bitmaps.
 type BitmapCache interface {
-	Fetch(id uint64) (*Bitmap, bool)
-	Add(id uint64, b *Bitmap)
+	Fetch(id uint64) (*Row, bool)
+	Add(id uint64, b *Row)
 }
 
 // SimpleCache implements BitmapCache
@@ -473,17 +473,17 @@ type BitmapCache interface {
 // A read-heavy use case would cause the cache to get bigger, potentially causing the
 // node to run out of memory.
 type SimpleCache struct {
-	cache map[uint64]*Bitmap
+	cache map[uint64]*Row
 }
 
 // Fetch retrieves the bitmap at the id in the cache.
-func (s *SimpleCache) Fetch(id uint64) (*Bitmap, bool) {
+func (s *SimpleCache) Fetch(id uint64) (*Row, bool) {
 	m, ok := s.cache[id]
 	return m, ok
 }
 
 // Add adds the bitmap to the cache, keyed on the id.
-func (s *SimpleCache) Add(id uint64, b *Bitmap) {
+func (s *SimpleCache) Add(id uint64, b *Row) {
 	s.cache[id] = b
 }
 

--- a/executor_test.go
+++ b/executor_test.go
@@ -54,27 +54,27 @@ func TestExecutor_Execute_Bitmap(t *testing.T) {
 
 		if res, err := e.Execute(context.Background(), "i", test.MustParse(`Bitmap(row=10, frame=f)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{3, SliceWidth + 1}) {
+		} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{3, SliceWidth + 1}) {
 			t.Fatalf("unexpected bits: %+v", bits)
-		} else if attrs := res[0].(*pilosa.Bitmap).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar", "baz": int64(123)}) {
+		} else if attrs := res[0].(*pilosa.Row).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar", "baz": int64(123)}) {
 			t.Fatalf("unexpected attrs: %s", spew.Sdump(attrs))
 		}
 
 		// Inhibit bits.
 		if res, err := e.Execute(context.Background(), "i", test.MustParse(`Bitmap(row=10, frame=f)`), nil, &pilosa.ExecOptions{ExcludeBits: true}); err != nil {
 			t.Fatal(err)
-		} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{}) {
+		} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{}) {
 			t.Fatalf("unexpected bits: %+v", bits)
-		} else if attrs := res[0].(*pilosa.Bitmap).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar", "baz": int64(123)}) {
+		} else if attrs := res[0].(*pilosa.Row).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar", "baz": int64(123)}) {
 			t.Fatalf("unexpected attrs: %s", spew.Sdump(attrs))
 		}
 
 		// Inhibit attributes.
 		if res, err := e.Execute(context.Background(), "i", test.MustParse(`Bitmap(row=10, frame=f)`), nil, &pilosa.ExecOptions{ExcludeAttrs: true}); err != nil {
 			t.Fatal(err)
-		} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{3, SliceWidth + 1}) {
+		} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{3, SliceWidth + 1}) {
 			t.Fatalf("unexpected bits: %+v", bits)
-		} else if attrs := res[0].(*pilosa.Bitmap).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{}) {
+		} else if attrs := res[0].(*pilosa.Row).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{}) {
 			t.Fatalf("unexpected attrs: %s", spew.Sdump(attrs))
 		}
 	})
@@ -103,9 +103,9 @@ func TestExecutor_Execute_Bitmap(t *testing.T) {
 
 		if res, err := e.Execute(context.Background(), "i", test.MustParse(fmt.Sprintf(`Bitmap(col=%d, frame=f)`, SliceWidth+1)), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{10, 20}) {
+		} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{10, 20}) {
 			t.Fatalf("unexpected bits: %+v", bits)
-		} else if attrs := res[0].(*pilosa.Bitmap).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar", "baz": int64(123)}) {
+		} else if attrs := res[0].(*pilosa.Row).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar", "baz": int64(123)}) {
 			t.Fatalf("unexpected attrs: %s", spew.Sdump(attrs))
 		}
 	})
@@ -124,7 +124,7 @@ func TestExecutor_Execute_Difference(t *testing.T) {
 	e := test.NewExecutor(hldr.Holder, test.NewCluster(1))
 	if res, err := e.Execute(context.Background(), "i", test.MustParse(`Difference(Bitmap(row=10), Bitmap(row=11))`), nil, nil); err != nil {
 		t.Fatal(err)
-	} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{1, 3}) {
+	} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{1, 3}) {
 		t.Fatalf("unexpected bits: %+v", bits)
 	}
 }
@@ -156,7 +156,7 @@ func TestExecutor_Execute_Intersect(t *testing.T) {
 	e := test.NewExecutor(hldr.Holder, test.NewCluster(1))
 	if res, err := e.Execute(context.Background(), "i", test.MustParse(`Intersect(Bitmap(row=10), Bitmap(row=11))`), nil, nil); err != nil {
 		t.Fatal(err)
-	} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{1, SliceWidth + 2}) {
+	} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{1, SliceWidth + 2}) {
 		t.Fatalf("unexpected bits: %+v", bits)
 	}
 }
@@ -186,7 +186,7 @@ func TestExecutor_Execute_Union(t *testing.T) {
 	e := test.NewExecutor(hldr.Holder, test.NewCluster(1))
 	if res, err := e.Execute(context.Background(), "i", test.MustParse(`Union(Bitmap(row=10), Bitmap(row=11))`), nil, nil); err != nil {
 		t.Fatal(err)
-	} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{0, 2, SliceWidth + 1, SliceWidth + 2}) {
+	} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{0, 2, SliceWidth + 1, SliceWidth + 2}) {
 		t.Fatalf("unexpected bits: %+v", bits)
 	}
 }
@@ -200,7 +200,7 @@ func TestExecutor_Execute_Empty_Union(t *testing.T) {
 	e := test.NewExecutor(hldr.Holder, test.NewCluster(1))
 	if res, err := e.Execute(context.Background(), "i", test.MustParse(`Union()`), nil, nil); err != nil {
 		t.Fatal(err)
-	} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{}) {
+	} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{}) {
 		t.Fatalf("unexpected bits: %+v", bits)
 	}
 }
@@ -219,7 +219,7 @@ func TestExecutor_Execute_Xor(t *testing.T) {
 	e := test.NewExecutor(hldr.Holder, test.NewCluster(1))
 	if res, err := e.Execute(context.Background(), "i", test.MustParse(`Xor(Bitmap(row=10), Bitmap(row=11))`), nil, nil); err != nil {
 		t.Fatal(err)
-	} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{0, 2, SliceWidth + 1}) {
+	} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{0, 2, SliceWidth + 1}) {
 		t.Fatalf("unexpected bits: %+v", bits)
 	}
 }
@@ -784,7 +784,7 @@ func TestExecutor_Execute_Range(t *testing.T) {
 	t.Run("Standard", func(t *testing.T) {
 		if res, err := e.Execute(context.Background(), "i", test.MustParse(`Range(row=1, frame=f, start="1999-12-31T00:00", end="2002-01-01T03:00")`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{2, 3, 4, 5, 6, 7}) {
+		} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{2, 3, 4, 5, 6, 7}) {
 			t.Fatalf("unexpected bits: %+v", bits)
 		}
 	})
@@ -793,7 +793,7 @@ func TestExecutor_Execute_Range(t *testing.T) {
 		e := test.NewExecutor(hldr.Holder, test.NewCluster(1))
 		if res, err := e.Execute(context.Background(), "i", test.MustParse(`Range(col=2, frame=f, start="1999-01-01T00:00", end="2003-01-01T00:00")`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{1, 10}) {
+		} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{1, 10}) {
 			t.Fatalf("unexpected bits: %+v", bits)
 		}
 	})
@@ -854,7 +854,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("EQ", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo == 20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{50, (5 * SliceWidth) + 100}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{50, (5 * SliceWidth) + 100}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -863,28 +863,28 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 		// NEQ null
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo != null)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 		// NEQ <int>
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo != 20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{SliceWidth, SliceWidth + 1, SliceWidth + 2}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{SliceWidth, SliceWidth + 1, SliceWidth + 2}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 		// NEQ -<int>
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo != -20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Row).Bits()) {
 			//t.Fatalf("unexpected result: %s", spew.Sdump(result))
-			t.Fatalf("unexpected result: %v", result[0].(*pilosa.Bitmap).Bits())
+			t.Fatalf("unexpected result: %v", result[0].(*pilosa.Row).Bits())
 		}
 	})
 
 	t.Run("LT", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo < 20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{SliceWidth + 2}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{SliceWidth + 2}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -892,7 +892,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("LTE", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo <= 20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{50, SliceWidth + 2, (5 * SliceWidth) + 100}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{50, SliceWidth + 2, (5 * SliceWidth) + 100}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -900,7 +900,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("GT", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo > 20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{SliceWidth, SliceWidth + 1}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{SliceWidth, SliceWidth + 1}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -908,7 +908,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("GTE", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo >= 20)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{50, SliceWidth, SliceWidth + 1, (5 * SliceWidth) + 100}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{50, SliceWidth, SliceWidth + 1, (5 * SliceWidth) + 100}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -916,7 +916,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("BETWEEN", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo >< [1, 1000])`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -925,7 +925,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("FieldNotNull", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=other, foo >< [0, 1000])`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{0}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -933,7 +933,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("BelowMin", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo == 0)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -941,7 +941,7 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("AboveMax", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=f, foo == 200)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{}, result[0].(*pilosa.Bitmap).Bits()) {
+		} else if !reflect.DeepEqual([]uint64{}, result[0].(*pilosa.Row).Bits()) {
 			t.Fatalf("unexpected result: %s", spew.Sdump(result))
 		}
 	})
@@ -949,16 +949,16 @@ func TestExecutor_Execute_FieldRange(t *testing.T) {
 	t.Run("LTAboveMax", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=edge, foo < 200)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{0, 1}, result[0].(*pilosa.Bitmap).Bits()) {
-			t.Fatalf("unexpected result: %s", spew.Sdump(result[0].(*pilosa.Bitmap).Bits()))
+		} else if !reflect.DeepEqual([]uint64{0, 1}, result[0].(*pilosa.Row).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result[0].(*pilosa.Row).Bits()))
 		}
 	})
 
 	t.Run("GTBelowMin", func(t *testing.T) {
 		if result, err := e.Execute(context.Background(), "i", test.MustParse(`Range(frame=edge, foo > -200)`), nil, nil); err != nil {
 			t.Fatal(err)
-		} else if !reflect.DeepEqual([]uint64{0, 1}, result[0].(*pilosa.Bitmap).Bits()) {
-			t.Fatalf("unexpected result: %s", spew.Sdump(result[0].(*pilosa.Bitmap).Bits()))
+		} else if !reflect.DeepEqual([]uint64{0, 1}, result[0].(*pilosa.Row).Bits()) {
+			t.Fatalf("unexpected result: %s", spew.Sdump(result[0].(*pilosa.Row).Bits()))
 		}
 	})
 
@@ -1018,7 +1018,7 @@ func TestExecutor_Execute_Remote_Bitmap(t *testing.T) {
 	e := test.NewExecutor(hldr.Holder, c)
 	if res, err := e.Execute(context.Background(), "i", test.MustParse(`Bitmap(row=10, frame=f)`), nil, nil); err != nil {
 		t.Fatal(err)
-	} else if bits := res[0].(*pilosa.Bitmap).Bits(); !reflect.DeepEqual(bits, []uint64{1, 2, 2*SliceWidth + 4}) {
+	} else if bits := res[0].(*pilosa.Row).Bits(); !reflect.DeepEqual(bits, []uint64{1, 2, 2*SliceWidth + 4}) {
 		t.Fatalf("unexpected bits: %+v", bits)
 	}
 }

--- a/fragment_test.go
+++ b/fragment_test.go
@@ -284,7 +284,7 @@ func TestFragment_FieldMinMax(t *testing.T) {
 
 	t.Run("Min", func(t *testing.T) {
 		tests := []struct {
-			filter *pilosa.Bitmap
+			filter *pilosa.Row
 			exp    uint64
 			cnt    uint64
 		}{
@@ -308,7 +308,7 @@ func TestFragment_FieldMinMax(t *testing.T) {
 
 	t.Run("Max", func(t *testing.T) {
 		tests := []struct {
-			filter *pilosa.Bitmap
+			filter *pilosa.Row
 			exp    uint64
 			cnt    uint64
 		}{

--- a/frame.go
+++ b/frame.go
@@ -719,7 +719,7 @@ func (f *Frame) SetFieldValue(columnID uint64, name string, value int64) (change
 
 // FieldSum returns the sum and count for a field.
 // An optional filtering bitmap can be provided.
-func (f *Frame) FieldSum(filter *Bitmap, name string) (sum, count int64, err error) {
+func (f *Frame) FieldSum(filter *Row, name string) (sum, count int64, err error) {
 	field := f.Field(name)
 	if field == nil {
 		return 0, 0, ErrFieldNotFound
@@ -739,7 +739,7 @@ func (f *Frame) FieldSum(filter *Bitmap, name string) (sum, count int64, err err
 
 // FieldMin returns the min for a field.
 // An optional filtering bitmap can be provided.
-func (f *Frame) FieldMin(filter *Bitmap, name string) (min, count int64, err error) {
+func (f *Frame) FieldMin(filter *Row, name string) (min, count int64, err error) {
 	field := f.Field(name)
 	if field == nil {
 		return 0, 0, ErrFieldNotFound
@@ -759,7 +759,7 @@ func (f *Frame) FieldMin(filter *Bitmap, name string) (min, count int64, err err
 
 // FieldMax returns the max for a field.
 // An optional filtering bitmap can be provided.
-func (f *Frame) FieldMax(filter *Bitmap, name string) (max, count int64, err error) {
+func (f *Frame) FieldMax(filter *Row, name string) (max, count int64, err error) {
 	field := f.Field(name)
 	if field == nil {
 		return 0, 0, ErrFieldNotFound
@@ -777,7 +777,7 @@ func (f *Frame) FieldMax(filter *Bitmap, name string) (max, count int64, err err
 	return int64(vmax) + field.Min, int64(vcount), nil
 }
 
-func (f *Frame) FieldRange(name string, op pql.Token, predicate int64) (*Bitmap, error) {
+func (f *Frame) FieldRange(name string, op pql.Token, predicate int64) (*Row, error) {
 	// Retrieve and validate field.
 	field := f.Field(name)
 	if field == nil {
@@ -800,7 +800,7 @@ func (f *Frame) FieldRange(name string, op pql.Token, predicate int64) (*Bitmap,
 	return view.FieldRange(op, field.BitDepth(), baseValue)
 }
 
-func (f *Frame) FieldRangeBetween(name string, predicateMin, predicateMax int64) (*Bitmap, error) {
+func (f *Frame) FieldRangeBetween(name string, predicateMin, predicateMax int64) (*Row, error) {
 	// Retrieve and validate field.
 	field := f.Field(name)
 	if field == nil {

--- a/handler.go
+++ b/handler.go
@@ -1243,7 +1243,7 @@ func encodeQueryResponse(resp *QueryResponse) *internal.QueryResponse {
 		pb.Results[i] = &internal.QueryResult{}
 
 		switch result := resp.Results[i].(type) {
-		case *Bitmap:
+		case *Row:
 			pb.Results[i].Type = QueryResultTypeBitmap
 			pb.Results[i].Bitmap = encodeBitmap(result)
 		case []Pair:

--- a/view.go
+++ b/view.go
@@ -346,7 +346,7 @@ func (v *View) SetFieldValue(columnID uint64, bitDepth uint, value uint64) (chan
 }
 
 // FieldSum returns the sum & count of a field.
-func (v *View) FieldSum(filter *Bitmap, bitDepth uint) (sum, count uint64, err error) {
+func (v *View) FieldSum(filter *Row, bitDepth uint) (sum, count uint64, err error) {
 	for _, f := range v.Fragments() {
 		fsum, fcount, err := f.FieldSum(filter, bitDepth)
 		if err != nil {
@@ -359,7 +359,7 @@ func (v *View) FieldSum(filter *Bitmap, bitDepth uint) (sum, count uint64, err e
 }
 
 // FieldMin returns the min and count of a field.
-func (v *View) FieldMin(filter *Bitmap, bitDepth uint) (min, count uint64, err error) {
+func (v *View) FieldMin(filter *Row, bitDepth uint) (min, count uint64, err error) {
 	var minHasValue bool
 	for _, f := range v.Fragments() {
 		fmin, fcount, err := f.FieldMin(filter, bitDepth)
@@ -387,7 +387,7 @@ func (v *View) FieldMin(filter *Bitmap, bitDepth uint) (min, count uint64, err e
 }
 
 // FieldMax returns the max and count of a field.
-func (v *View) FieldMax(filter *Bitmap, bitDepth uint) (max, count uint64, err error) {
+func (v *View) FieldMax(filter *Row, bitDepth uint) (max, count uint64, err error) {
 	for _, f := range v.Fragments() {
 		fmax, fcount, err := f.FieldMax(filter, bitDepth)
 		if err != nil {
@@ -402,7 +402,7 @@ func (v *View) FieldMax(filter *Bitmap, bitDepth uint) (max, count uint64, err e
 }
 
 // FieldRange returns bitmaps with a field value encoding matching the predicate.
-func (v *View) FieldRange(op pql.Token, bitDepth uint, predicate uint64) (*Bitmap, error) {
+func (v *View) FieldRange(op pql.Token, bitDepth uint, predicate uint64) (*Row, error) {
 	bm := NewBitmap()
 	for _, frag := range v.Fragments() {
 		other, err := frag.FieldRange(op, bitDepth, predicate)
@@ -416,7 +416,7 @@ func (v *View) FieldRange(op pql.Token, bitDepth uint, predicate uint64) (*Bitma
 
 // FieldRangeBetween returns bitmaps with a field value encoding matching any
 // value between predicateMin and predicateMax.
-func (v *View) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Bitmap, error) {
+func (v *View) FieldRangeBetween(bitDepth uint, predicateMin, predicateMax uint64) (*Row, error) {
 	bm := NewBitmap()
 	for _, frag := range v.Fragments() {
 		other, err := frag.FieldRangeBetween(bitDepth, predicateMin, predicateMax)


### PR DESCRIPTION
## Overview

Renamed roaring .Bitmap to Row to simplify language and resolve ambiguity with roaring.Bitmap
Fixes #1144

## Pull request checklist

- [x ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

