### PR TITLE
fix generate-config command, use single toml lib

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,6 @@
 
 
 [[projects]]
-  name = "github.com/BurntSushi/toml"
-  packages = ["."]
-  revision = "b26d9c308763d68093482582cea63d69be07a0f0"
-  version = "v0.3.0"
-
-[[projects]]
   branch = "master"
   name = "github.com/CAFxX/gcnotifier"
   packages = ["."]
@@ -212,13 +206,21 @@
 [[projects]]
   name = "github.com/shirou/gopsutil"
   packages = [
+    "cpu",
     "host",
     "internal/common",
     "mem",
+    "net",
     "process"
   ]
   revision = "bfe3c2e8f406bf352bc8df81f98c752224867349"
   version = "v2.17.11"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/shirou/w32"
+  packages = ["."]
+  revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
   branch = "master"
@@ -302,6 +304,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8f633d73d966ca439d2fdf3704a41d8ea59be8ed9a2cab0ab73de4b72c5772ba"
+  inputs-digest = "325d0fb217ec7f1509186ff947e184f6c8e65941f06000eb110180e65816b1a4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/ctl/generate_config_test.go
+++ b/ctl/generate_config_test.go
@@ -34,7 +34,7 @@ func TestGenerateConfigCommand_Run(t *testing.T) {
 	io.Copy(&buf, r)
 	if err != nil {
 		t.Fatalf("Config Run doesn't work: %s", err)
-	} else if !strings.Contains(buf.String(), "localhost:10101") {
+	} else if !strings.Contains(buf.String(), ":10101") {
 		t.Fatalf("Unexpected config: %s", buf.String())
 	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -61,7 +61,7 @@ type Config struct {
 	Handler struct {
 		// CORS Allowed Origins
 		AllowedOrigins []string `toml:"allowed-origins"`
-	}
+	} `toml:"handler"`
 
 	// TLS
 	TLS TLSConfig `toml:"tls"`

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"testing/quick"
 
-	"github.com/BurntSushi/toml"
+	"github.com/pelletier/go-toml"
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/server"
 	"github.com/pilosa/pilosa/test"
@@ -374,7 +374,7 @@ func GenerateSetCommands(n int, rand *rand.Rand) []SetCommand {
 // ParseConfig parses s into a Config.
 func ParseConfig(s string) (server.Config, error) {
 	var c server.Config
-	_, err := toml.Decode(s, &c)
+	err := toml.Unmarshal([]byte(s), &c)
 	return c, err
 }
 


### PR DESCRIPTION
## Overview
The generate-config command was printing a fixed string rather than calling
NewConfig() which is the canonical source for default config. I also noticed
that we were depending on two different toml libraries, and so collapsed that to
a single one. We have to use pelletier rather than BurntSushi because the viper
library that we use depends on pelletier.

There is no ticket for this specifically, but it removes the last vestiges of #1217, so Fixes #1217

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
