### PR TITLE
remove field flag from pilosa import command

### DIFF
--- a/cmd/import.go
+++ b/cmd/import.go
@@ -55,7 +55,6 @@ omitted. If it is present then its format should be YYYY-MM-DDTHH:MM.
 	flags.StringVarP(&Importer.Host, "host", "", "localhost:10101", "host:port of Pilosa.")
 	flags.StringVarP(&Importer.Index, "index", "i", "", "Pilosa index to import into.")
 	flags.StringVarP(&Importer.Frame, "frame", "f", "", "Frame to import into.")
-	flags.StringVarP(&Importer.Field, "field", "", "", "Field to import into.")
 	flags.BoolVar(&Importer.StringKeys, "string-keys", false, "Treat payload as string keys.")
 	flags.IntVarP(&Importer.BufferSize, "buffer-size", "s", 10000000, "Number of bits to buffer/sort before importing.")
 	flags.BoolVarP(&Importer.Sort, "sort", "", false, "Enables sorting before import.")

--- a/ctl/import_test.go
+++ b/ctl/import_test.go
@@ -82,9 +82,7 @@ func TestImportCommand_Run(t *testing.T) {
 	}
 }
 
-// TODO: revisit this test once Frame is renamed Field
-// Ensure that the ImportValue path runs (note: we have specified a value
-// for cm.Field.)
+// Ensure that the ImportValue path runs.
 func TestImportCommand_RunValue(t *testing.T) {
 
 	buf := bytes.Buffer{}
@@ -112,7 +110,6 @@ func TestImportCommand_RunValue(t *testing.T) {
 
 	cm.Index = "i"
 	cm.Frame = "f"
-	cm.Field = "f"
 	cm.Paths = []string{file.Name()}
 	err = cm.Run(ctx)
 	if err != nil {
@@ -122,10 +119,19 @@ func TestImportCommand_RunValue(t *testing.T) {
 
 func TestImportCommand_InvalidFile(t *testing.T) {
 
+	hldr := test.MustOpenHolder()
+	defer hldr.Close()
+	s := test.NewServer()
+	defer s.Close()
+
+	s.Handler.API.Cluster = test.NewCluster(1)
+	s.Handler.API.Cluster.Nodes[0].URI = s.HostURI()
+	s.Handler.API.Holder = hldr.Holder
+
 	buf := bytes.Buffer{}
 	stdin, stdout, stderr := GetIO(buf)
 	cm := NewImportCommand(stdin, stdout, stderr)
-	cm.Host = "anyhost"
+	cm.Host = s.Host()
 	cm.Index = "i"
 	cm.Frame = "f"
 	file, err := ioutil.TempFile("", "import.csv")


### PR DESCRIPTION
## Overview

This PR removes the `field` flag from the `pilosa import` command. Instead of relying on the flag to determine how to handle the import data, the importer now requests the schema from the pilosa server in order to determine `frameType`.

Fixes #1353 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
