### PR TITLE
move fragment_test into the pilosa package (internal)

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -221,3 +221,56 @@ func DecodeAttrs(v []byte) (map[string]interface{}, error) {
 	}
 	return decodeAttrs(pb.GetAttrs()), nil
 }
+
+func newMemAttrStore() AttrStore {
+	return &memAttrStore{
+		store: make(map[uint64]map[string]interface{}),
+	}
+}
+
+// memAttrStore represents an in-memory implementation of the AttrStore interface.
+type memAttrStore struct {
+	store map[uint64]map[string]interface{}
+}
+
+// Path is an in-memory implementation of AttrStore Path method.
+func (s *memAttrStore) Path() string { return "" }
+
+// Open is an in-memory implementation of AttrStore Open method.
+func (s *memAttrStore) Open() error {
+	return nil
+}
+
+// Close is an in-memory implementation of AttrStore Close method.
+func (s *memAttrStore) Close() error {
+	return nil
+}
+
+// Attrs returns a set of attributes by ID.
+func (s *memAttrStore) Attrs(id uint64) (m map[string]interface{}, err error) {
+	return s.store[id], nil
+}
+
+// SetAttrs sets attribute values for a given ID.
+func (s *memAttrStore) SetAttrs(id uint64, m map[string]interface{}) error {
+	s.store[id] = m
+	return nil
+}
+
+// SetBulkAttrs sets attribute values for a set of ids.
+func (s *memAttrStore) SetBulkAttrs(m map[uint64]map[string]interface{}) error {
+	for id, v := range m {
+		s.store[id] = v
+	}
+	return nil
+}
+
+// Blocks is an in-memory implementation of AttrStore Blocks method.
+func (s *memAttrStore) Blocks() ([]AttrBlock, error) {
+	return nil, nil
+}
+
+// BlockData is an in-memory implementation of AttrStore BlockData method.
+func (s *memAttrStore) BlockData(i uint64) (map[uint64]map[string]interface{}, error) {
+	return nil, nil
+}

--- a/index_internal_test.go
+++ b/index_internal_test.go
@@ -12,27 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package pilosa
 
 import (
-	"github.com/pilosa/pilosa"
+	"io/ioutil"
 )
 
-// SliceWidth is a helper reference to use when testing.
-const SliceWidth = pilosa.SliceWidth
-
-// Fragment is a test wrapper for pilosa.Fragment.
-type Fragment struct {
-	*pilosa.Fragment
-	RowAttrStore pilosa.AttrStore
+// mustOpenIndex returns a new, opened index at a temporary path. Panic on error.
+func mustOpenIndex() *Index {
+	path, err := ioutil.TempDir("", "pilosa-index-")
+	if err != nil {
+		panic(err)
+	}
+	index, err := NewIndex(path, "i")
+	if err != nil {
+		panic(err)
+	}
+	if err := index.Open(); err != nil {
+		panic(err)
+	}
+	return index
 }
 
-// MustSetBits sets columns on a row. Panic on error.
-// This function does not accept a timestamp or quantum.
-func (f *Fragment) MustSetBits(rowID uint64, columnIDs ...uint64) {
-	for _, columnID := range columnIDs {
-		if _, err := f.SetBit(rowID, columnID); err != nil {
-			panic(err)
-		}
+// reopen closes the index and reopens it.
+func (i *Index) reopen() error {
+	if err := i.Close(); err != nil {
+		return err
 	}
+	if err := i.Open(); err != nil {
+		return err
+	}
+	return nil
 }

--- a/index_test.go
+++ b/index_test.go
@@ -23,6 +23,9 @@ import (
 	"github.com/pilosa/pilosa/test"
 )
 
+// SliceWidth is a helper reference to use when testing.
+const SliceWidth = pilosa.SliceWidth
+
 // Ensure index can open and retrieve a field.
 func TestIndex_CreateFieldIfNotExists(t *testing.T) {
 	index := test.MustOpenIndex()


### PR DESCRIPTION
## Overview

In preparation for #1352, this PR moves fragment tests into the `pilosa` package.
It also adds an in-memory implementation of `AttrStore`.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
