### PR TITLE
split FieldOptions into multiple FieldTypeOptions (Set, Int, Time)

### DIFF
--- a/api.go
+++ b/api.go
@@ -216,7 +216,7 @@ func (api *API) DeleteIndex(ctx context.Context, indexName string) error {
 }
 
 // CreateField makes the named field in the named index with the given options.
-func (api *API) CreateField(ctx context.Context, indexName string, fieldName string, options FieldOptions) (*Field, error) {
+func (api *API) CreateField(ctx context.Context, indexName string, fieldName string, options FieldTypeOptions) (*Field, error) {
 	if err := api.validate(apiCreateField); err != nil {
 		return nil, errors.Wrap(err, "validating api method")
 	}
@@ -238,7 +238,7 @@ func (api *API) CreateField(ctx context.Context, indexName string, fieldName str
 		&internal.CreateFieldMessage{
 			Index: indexName,
 			Field: fieldName,
-			Meta:  options.Encode(),
+			Meta:  encodeOptions(options),
 		})
 	if err != nil {
 		api.Logger.Printf("problem sending CreateField message: %s", err)

--- a/client.go
+++ b/client.go
@@ -41,10 +41,10 @@ type InternalClient interface {
 	Import(ctx context.Context, index, field string, slice uint64, bits []Bit) error
 	ImportK(ctx context.Context, index, field string, bits []Bit) error
 	EnsureIndex(ctx context.Context, name string, options IndexOptions) error
-	EnsureField(ctx context.Context, indexName string, fieldName string, options FieldOptions) error
+	EnsureField(ctx context.Context, indexName string, fieldName string, options FieldTypeOptions) error
 	ImportValue(ctx context.Context, index, field string, slice uint64, vals []FieldValue) error
 	ExportCSV(ctx context.Context, index, field string, slice uint64, w io.Writer) error
-	CreateField(ctx context.Context, index, field string, opt FieldOptions) error
+	CreateField(ctx context.Context, index, field string, opt FieldTypeOptions) error
 	FragmentBlocks(ctx context.Context, uri *URI, index, field string, slice uint64) ([]FragmentBlock, error)
 	BlockData(ctx context.Context, uri *URI, index, field string, slice uint64, block int) ([]uint64, []uint64, error)
 	ColumnAttrDiff(ctx context.Context, uri *URI, index string, blks []AttrBlock) (map[uint64]map[string]interface{}, error)
@@ -108,7 +108,7 @@ func (n *NopInternalClient) ImportK(ctx context.Context, index, field string, bi
 func (n *NopInternalClient) EnsureIndex(ctx context.Context, name string, options IndexOptions) error {
 	return nil
 }
-func (n *NopInternalClient) EnsureField(ctx context.Context, indexName string, fieldName string, options FieldOptions) error {
+func (n *NopInternalClient) EnsureField(ctx context.Context, indexName string, fieldName string, options FieldTypeOptions) error {
 	return nil
 }
 func (n *NopInternalClient) ImportValue(ctx context.Context, index, field string, slice uint64, vals []FieldValue) error {
@@ -117,7 +117,7 @@ func (n *NopInternalClient) ImportValue(ctx context.Context, index, field string
 func (n *NopInternalClient) ExportCSV(ctx context.Context, index, field string, slice uint64, w io.Writer) error {
 	return nil
 }
-func (n *NopInternalClient) CreateField(ctx context.Context, index, field string, opt FieldOptions) error {
+func (n *NopInternalClient) CreateField(ctx context.Context, index, field string, opt FieldTypeOptions) error {
 	return nil
 }
 func (n *NopInternalClient) FragmentBlocks(ctx context.Context, uri *URI, index, field string, slice uint64) ([]FragmentBlock, error) {

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -149,7 +149,7 @@ func TestFragSources(t *testing.T) {
 	c5.addNodeBasicSorted(node3)
 
 	idx := newIndexWithTempPath("i")
-	field, err := idx.CreateFieldIfNotExists("f", FieldOptions{})
+	field, err := idx.CreateFieldIfNotExists("f", FieldTypeOptionsSet{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -696,7 +696,7 @@ func TestCluster_ResizeStates(t *testing.T) {
 		}
 
 		// Add Bit Data to node0.
-		if err := tc.CreateField("i", "f", FieldOptions{}); err != nil {
+		if err := tc.CreateField("i", "f", FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 		tc.SetBit("i", "f", "standard", 1, 101, nil)

--- a/ctl/import.go
+++ b/ctl/import.go
@@ -113,7 +113,7 @@ func (cmd *ImportCommand) Run(ctx context.Context) error {
 		if index.Name == cmd.Index {
 			for _, field := range index.Fields {
 				if field.Name == cmd.Field {
-					fieldType = field.Options.Type
+					fieldType = field.Options.Type()
 				}
 			}
 		}
@@ -135,7 +135,7 @@ func (cmd *ImportCommand) ensureSchema(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("Error Creating Index: %s", err)
 	}
-	err = cmd.Client.EnsureField(ctx, cmd.Index, cmd.Field, cmd.FieldOptions)
+	err = cmd.Client.EnsureField(ctx, cmd.Index, cmd.Field, cmd.FieldOptions.Typed())
 	if err != nil {
 		return fmt.Errorf("Error Creating Field: %s", err)
 	}

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -227,10 +227,10 @@ func (d *DiagnosticsCollector) EnrichWithSchemaProperties() {
 		numIndexes += 1
 		for _, field := range index.Fields() {
 			numFields += 1
-			if field.Type() == FieldTypeInt {
+			switch field.Type() {
+			case FieldTypeInt:
 				bsiFieldCount += 1
-			}
-			if field.TimeQuantum() != "" {
+			case FieldTypeTime:
 				timeQuantumEnabled = true
 			}
 		}

--- a/executor.go
+++ b/executor.go
@@ -715,6 +715,12 @@ func (e *Executor) executeRangeSlice(ctx context.Context, index string, c *pql.C
 		return nil, ErrFieldNotFound
 	}
 
+	// Type-assert field options.
+	fo, ok := f.options.(FieldTypeOptionsTime)
+	if !ok {
+		return nil, errors.New("Range() requires a time field")
+	}
+
 	// Read row & column id.
 	rowID, rowOK, err := c.UintArg(rowLabel)
 	if err != nil {
@@ -744,8 +750,8 @@ func (e *Executor) executeRangeSlice(ctx context.Context, index string, c *pql.C
 		return nil, errors.New("cannot parse Range() end time")
 	}
 
-	// If no quantum exists then return an empty bitmap.
-	q := f.TimeQuantum()
+	// If no quantum exists then return an empty row.
+	q := fo.TimeQuantum
 	if q == "" {
 		return &Row{}, nil
 	}

--- a/executor_test.go
+++ b/executor_test.go
@@ -33,7 +33,7 @@ func TestExecutor_Execute_Bitmap(t *testing.T) {
 		hldr := test.MustOpenHolder()
 		defer hldr.Close()
 		index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-		f, err := index.CreateField("f", pilosa.FieldOptions{})
+		f, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +83,7 @@ func TestExecutor_Execute_Bitmap(t *testing.T) {
 		hldr := test.MustOpenHolder()
 		defer hldr.Close()
 		index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-		if _, err := index.CreateField("f", pilosa.FieldOptions{}); err != nil {
+		if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -273,13 +273,12 @@ func TestExecutor_Execute_SetValue(t *testing.T) {
 
 		// Create felds.
 		index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-		if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeInt,
-			Min:  0,
-			Max:  50,
+		if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsInt{
+			Min: 0,
+			Max: 50,
 		}); err != nil {
 			t.Fatal(err)
-		} else if _, err := index.CreateFieldIfNotExists("xxx", pilosa.FieldOptions{}); err != nil {
+		} else if _, err := index.CreateFieldIfNotExists("xxx", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -313,10 +312,9 @@ func TestExecutor_Execute_SetValue(t *testing.T) {
 		hldr := test.MustOpenHolder()
 		defer hldr.Close()
 		index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-		if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeInt,
-			Min:  0,
-			Max:  100,
+		if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsInt{
+			Min: 0,
+			Max: 100,
 		}); err != nil {
 			t.Fatal(err)
 		}
@@ -351,9 +349,9 @@ func TestExecutor_Execute_SetRowAttrs(t *testing.T) {
 
 	// Create fields.
 	index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-	if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{}); err != nil {
+	if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := index.CreateFieldIfNotExists("xxx", pilosa.FieldOptions{}); err != nil {
+	} else if _, err := index.CreateFieldIfNotExists("xxx", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -390,9 +388,9 @@ func TestExecutor_Execute_TopN(t *testing.T) {
 	// Set columns for rows 0, 10, & 20 across two slices.
 	if idx, err := hldr.CreateIndex("i", pilosa.IndexOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := idx.CreateField("f", pilosa.FieldOptions{}); err != nil {
+	} else if _, err := idx.CreateField("f", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := idx.CreateField("other", pilosa.FieldOptions{}); err != nil {
+	} else if _, err := idx.CreateField("other", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	} else if _, err := e.Execute(context.Background(), "i", test.MustParse(`
 		SetBit(field=f, row=0, col=0)
@@ -574,14 +572,13 @@ func TestExecutor_Execute_MinMax(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("x", pilosa.FieldOptions{}); err != nil {
+	if _, err := idx.CreateField("x", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("f", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  -10,
-		Max:  100,
+	if _, err := idx.CreateField("f", pilosa.FieldTypeOptionsInt{
+		Min: -10,
+		Max: 100,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -669,30 +666,27 @@ func TestExecutor_Execute_Sum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("x", pilosa.FieldOptions{}); err != nil {
+	if _, err := idx.CreateField("x", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("foo", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  10,
-		Max:  100,
+	if _, err := idx.CreateField("foo", pilosa.FieldTypeOptionsInt{
+		Min: 10,
+		Max: 100,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("bar", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  0,
-		Max:  100000,
+	if _, err := idx.CreateField("bar", pilosa.FieldTypeOptionsInt{
+		Min: 0,
+		Max: 100000,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("other", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  0,
-		Max:  1000,
+	if _, err := idx.CreateField("other", pilosa.FieldTypeOptionsInt{
+		Min: 0,
+		Max: 1000,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -739,8 +733,7 @@ func TestExecutor_Execute_BSIGroupRange(t *testing.T) {
 	index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
 
 	// Create field.
-	if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{
-		Type:        pilosa.FieldTypeTime,
+	if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsTime{
 		TimeQuantum: pilosa.TimeQuantum("YMDH"),
 	}); err != nil {
 		t.Fatal(err)
@@ -782,38 +775,34 @@ func TestExecutor_Execute_Range(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("f", pilosa.FieldOptions{}); err != nil {
+	if _, err := idx.CreateField("f", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("foo", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  10,
-		Max:  100,
+	if _, err := idx.CreateField("foo", pilosa.FieldTypeOptionsInt{
+		Min: 10,
+		Max: 100,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("bar", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  0,
-		Max:  100000,
+	if _, err := idx.CreateField("bar", pilosa.FieldTypeOptionsInt{
+		Min: 0,
+		Max: 100000,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("other", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  0,
-		Max:  1000,
+	if _, err := idx.CreateField("other", pilosa.FieldTypeOptionsInt{
+		Min: 0,
+		Max: 1000,
 	}); err != nil {
 		t.Fatal(err)
 	}
 
-	if _, err := idx.CreateField("edge", pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  -100,
-		Max:  100,
+	if _, err := idx.CreateField("edge", pilosa.FieldTypeOptionsInt{
+		Min: -100,
+		Max: 100,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -1070,7 +1059,7 @@ func TestExecutor_Execute_Remote_SetBit(t *testing.T) {
 	s.Handler.API.Holder = hldr.Holder
 
 	// Create field.
-	if _, err := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{}).CreateField("f", pilosa.FieldOptions{}); err != nil {
+	if _, err := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{}).CreateField("f", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1122,9 +1111,7 @@ func TestExecutor_Execute_Remote_SetBit_With_Timestamp(t *testing.T) {
 	s.Handler.API.Holder = hldr.Holder
 
 	// Create field.
-	if f, err := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{}).CreateField("f", pilosa.FieldOptions{}); err != nil {
-		t.Fatal(err)
-	} else if err := f.SetTimeQuantum("Y"); err != nil {
+	if _, err := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{}).CreateField("f", pilosa.FieldTypeOptionsTime{TimeQuantum: "Y"}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1225,7 +1212,7 @@ func TestExectutor_SetColumnAttrs_ExcludeField(t *testing.T) {
 	hldr := test.MustOpenHolder()
 	defer hldr.Close()
 	index := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-	index.CreateField("f", pilosa.FieldOptions{})
+	index.CreateField("f", pilosa.FieldTypeOptionsSet{})
 	targetAttrs := map[string]interface{}{
 		"foo": "bar",
 	}

--- a/field_test.go
+++ b/field_test.go
@@ -50,23 +50,21 @@ func TestField_CreateViewIfNotExists(t *testing.T) {
 
 // Ensure field can set its time quantum.
 func TestField_SetTimeQuantum(t *testing.T) {
-	fo := pilosa.FieldOptions{
-		Type: "time",
-	}
-	f := test.MustOpenField(pilosa.OptFieldFieldOptions(fo))
+	f := test.MustOpenField(pilosa.OptFieldTime("YMDH"))
 	defer f.Close()
 
-	// Set & retrieve time quantum.
-	if err := f.SetTimeQuantum(pilosa.TimeQuantum("YMDH")); err != nil {
-		t.Fatal(err)
-	} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YMDH") {
+	// Retrieve time quantum.
+	fo := f.Options().(pilosa.FieldTypeOptionsTime)
+	if q := fo.TimeQuantum; q != pilosa.TimeQuantum("YMDH") {
 		t.Fatalf("unexpected quantum: %s", q)
 	}
 
 	// Reload field and verify that it is persisted.
 	if err := f.Reopen(); err != nil {
 		t.Fatal(err)
-	} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YMDH") {
+	}
+	fp := f.Options().(pilosa.FieldTypeOptionsTime)
+	if q := fp.TimeQuantum; q != pilosa.TimeQuantum("YMDH") {
 		t.Fatalf("unexpected quantum (reopen): %s", q)
 	}
 }
@@ -77,10 +75,9 @@ func TestField_SetValue(t *testing.T) {
 		idx := test.MustOpenIndex()
 		defer idx.Close()
 
-		f, err := idx.CreateField("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeInt,
-			Min:  0,
-			Max:  30,
+		f, err := idx.CreateField("f", pilosa.FieldTypeOptionsInt{
+			Min: 0,
+			Max: 30,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -114,10 +111,9 @@ func TestField_SetValue(t *testing.T) {
 		idx := test.MustOpenIndex()
 		defer idx.Close()
 
-		f, err := idx.CreateField("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeInt,
-			Min:  0,
-			Max:  30,
+		f, err := idx.CreateField("f", pilosa.FieldTypeOptionsInt{
+			Min: 0,
+			Max: 30,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -151,9 +147,7 @@ func TestField_SetValue(t *testing.T) {
 		idx := test.MustOpenIndex()
 		defer idx.Close()
 
-		f, err := idx.CreateField("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeSet,
-		})
+		f, err := idx.CreateField("f", pilosa.FieldTypeOptionsSet{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -168,10 +162,9 @@ func TestField_SetValue(t *testing.T) {
 		idx := test.MustOpenIndex()
 		defer idx.Close()
 
-		f, err := idx.CreateField("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeInt,
-			Min:  20,
-			Max:  30,
+		f, err := idx.CreateField("f", pilosa.FieldTypeOptionsInt{
+			Min: 20,
+			Max: 30,
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -187,10 +180,9 @@ func TestField_SetValue(t *testing.T) {
 		idx := test.MustOpenIndex()
 		defer idx.Close()
 
-		f, err := idx.CreateField("f", pilosa.FieldOptions{
-			Type: pilosa.FieldTypeInt,
-			Min:  20,
-			Max:  30,
+		f, err := idx.CreateField("f", pilosa.FieldTypeOptionsInt{
+			Min: 20,
+			Max: 30,
 		})
 		if err != nil {
 			t.Fatal(err)

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -750,7 +750,7 @@ func TestFragment_TopN_CacheSize(t *testing.T) {
 	defer index.Close()
 
 	// Create field.
-	field, err := index.CreateFieldIfNotExists("f", FieldOptions{CacheType: CacheTypeRanked, CacheSize: cacheSize})
+	field, err := index.CreateFieldIfNotExists("f", FieldTypeOptionsSet{CacheType: CacheTypeRanked, CacheSize: cacheSize})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -916,7 +916,7 @@ func TestFragment_RankCache_Persistence(t *testing.T) {
 	defer index.Close()
 
 	// Create field.
-	field, err := index.CreateFieldIfNotExists("f", FieldOptions{CacheType: CacheTypeRanked})
+	field, err := index.CreateFieldIfNotExists("f", FieldTypeOptionsSet{CacheType: CacheTypeRanked})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/holder.go
+++ b/holder.go
@@ -239,8 +239,11 @@ func (h *Holder) ApplySchema(schema *internal.Schema) error {
 		}
 		// Create fields that don't exist.
 		for _, f := range index.Fields {
-			opt := decodeFieldOptions(f.Meta)
-			field, err := idx.CreateFieldIfNotExists(f.Name, *opt)
+			opt, err := decodeOptions(*f.Meta)
+			if err != nil {
+				return errors.Wrap(err, "decoding options")
+			}
+			field, err := idx.CreateFieldIfNotExists(f.Name, opt)
 			if err != nil {
 				return errors.Wrap(err, "creating field")
 			}

--- a/holder_test.go
+++ b/holder_test.go
@@ -100,7 +100,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if _, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if _, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if err := h.Holder.Close(); err != nil {
 			t.Fatal(err)
@@ -119,14 +119,13 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if _, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if _, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if err := h.Holder.Close(); err != nil {
 			t.Fatal(err)
 		} else if err := os.Truncate(filepath.Join(h.Path, "foo", "bar", ".meta"), 2); err != nil {
 			t.Fatal(err)
 		}
-
 		if err := h.Reopen(); err == nil || !strings.Contains(err.Error(), "open index: name=foo, err=opening fields: open field: name=bar, err=loading meta: unmarshaling: unexpected EOF") {
 			t.Fatalf("unexpected error: %s", err)
 		}
@@ -137,7 +136,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if _, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if _, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if err := h.Holder.Close(); err != nil {
 			t.Fatal(err)
@@ -159,7 +158,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if field, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if _, err := field.CreateViewIfNotExists(pilosa.ViewStandard); err != nil {
 			t.Fatal(err)
@@ -183,7 +182,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if field, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if _, err := field.CreateViewIfNotExists(pilosa.ViewStandard); err != nil {
 			t.Fatal(err)
@@ -208,7 +207,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if field, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if _, err := field.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 			t.Fatal(err)
@@ -229,7 +228,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if field, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if _, err := field.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 			t.Fatal(err)
@@ -253,7 +252,7 @@ func TestHolder_Open(t *testing.T) {
 
 		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
 			t.Fatal(err)
-		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
+		} else if field, err := idx.CreateField("bar", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		} else if view, err := field.CreateViewIfNotExists(pilosa.ViewStandard); err != nil {
 			t.Fatal(err)

--- a/http/client.go
+++ b/http/client.go
@@ -331,7 +331,7 @@ func (c *InternalClient) EnsureIndex(ctx context.Context, name string, options p
 	return err
 }
 
-func (c *InternalClient) EnsureField(ctx context.Context, indexName string, fieldName string, options pilosa.FieldOptions) error {
+func (c *InternalClient) EnsureField(ctx context.Context, indexName string, fieldName string, options pilosa.FieldTypeOptions) error {
 	err := c.CreateField(ctx, indexName, fieldName, options)
 	if err == nil || err == pilosa.ErrFieldExists {
 		return nil
@@ -617,7 +617,7 @@ func (c *InternalClient) backupSliceNode(ctx context.Context, index, field strin
 }
 
 // CreateField creates a new field on the server.
-func (c *InternalClient) CreateField(ctx context.Context, index, field string, opt pilosa.FieldOptions) error {
+func (c *InternalClient) CreateField(ctx context.Context, index, field string, opt pilosa.FieldTypeOptions) error {
 	if index == "" {
 		return pilosa.ErrIndexRequired
 	}

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -256,10 +256,9 @@ func TestClient_ImportValue(t *testing.T) {
 
 	fldName := "f"
 
-	fo := pilosa.FieldOptions{
-		Type: pilosa.FieldTypeInt,
-		Min:  -100,
-		Max:  100,
+	fo := pilosa.FieldTypeOptionsInt{
+		Min: -100,
+		Max: 100,
 	}
 
 	// Load bitmap into cache to ensure cache gets updated.

--- a/http/handler_internal_test.go
+++ b/http/handler_internal_test.go
@@ -64,13 +64,13 @@ func TestPostFieldRequestUnmarshalJSON(t *testing.T) {
 		expected postFieldRequest
 		err      string
 	}{
-		{json: `{"options": {}}`, expected: postFieldRequest{Options: pilosa.FieldOptions{}}},
-		{json: `{"options": 4}`, err: "options is not map[string]interface{}"},
-		{json: `{"option": {}}`, err: "Unknown key: option:map[]"},
-		{json: `{"options": {"badKey": "test"}}`, err: "Unknown key: badKey:test"},
-		{json: `{"options": {"inverseEnabled": true}}`, err: "Unknown key: inverseEnabled:true"},
-		{json: `{"options": {"cacheType": "type"}}`, expected: postFieldRequest{Options: pilosa.FieldOptions{CacheType: "type"}}},
-		{json: `{"options": {"inverse": true, "cacheType": "type"}}`, err: "Unknown key: inverse:true"},
+		{json: `{"options": {}}`, expected: postFieldRequest{Options: pilosa.FieldTypeOptionsSet{}}},
+		{json: `{"options": 4}`, err: "unmarshaling options"},
+		{json: `{"option": {}}`, err: "unknown keys: option"},
+		{json: `{"options": {"badKey": "test"}}`, err: "unmarshaling options: unknown key: badKey"},
+		{json: `{"options": {"inverseEnabled": true}}`, err: "unmarshaling options: unknown key: inverseEnabled"},
+		{json: `{"options": {"cacheType": "type"}}`, expected: postFieldRequest{Options: pilosa.FieldTypeOptionsSet{CacheType: "type"}}},
+		{json: `{"options": {"inverse": true, "cacheType": "type"}}`, err: "unmarshaling options: unknown key: inverse"},
 	}
 	for _, test := range tests {
 		actual := &postFieldRequest{}

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -83,17 +83,17 @@ func TestHandler_Schema(t *testing.T) {
 	i0 := hldr.MustCreateIndexIfNotExists("i0", pilosa.IndexOptions{})
 	i1 := hldr.MustCreateIndexIfNotExists("i1", pilosa.IndexOptions{})
 
-	if f, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldOptions{}); err != nil {
+	if f, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if f, err := i1.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
+	if f, err := i1.CreateFieldIfNotExists("f0", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := i0.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
+	if _, err := i0.CreateFieldIfNotExists("f0", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -120,17 +120,17 @@ func TestHandler_Status(t *testing.T) {
 	i0 := hldr.MustCreateIndexIfNotExists("i0", pilosa.IndexOptions{})
 	i1 := hldr.MustCreateIndexIfNotExists("i1", pilosa.IndexOptions{})
 
-	if f, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldOptions{}); err != nil {
+	if f, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if f, err := i1.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
+	if f, err := i1.CreateFieldIfNotExists("f0", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := i0.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
+	if _, err := i0.CreateFieldIfNotExists("f0", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -699,7 +699,7 @@ func TestHandler_DeleteField(t *testing.T) {
 	hldr := test.MustOpenHolder()
 	defer hldr.Close()
 	i0 := hldr.MustCreateIndexIfNotExists("i0", pilosa.IndexOptions{})
-	if _, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldOptions{}); err != nil {
+	if _, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -777,7 +777,7 @@ func TestHandler_Field_AttrStore_Diff(t *testing.T) {
 
 	// Set attributes on the index.
 	idx := hldr.MustCreateIndexIfNotExists("i", pilosa.IndexOptions{})
-	f, err := idx.CreateFieldIfNotExists("meta", pilosa.FieldOptions{})
+	f, err := idx.CreateFieldIfNotExists("meta", pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/index.go
+++ b/index.go
@@ -268,7 +268,7 @@ func (i *Index) RecalculateCaches() {
 }
 
 // CreateField creates a field.
-func (i *Index) CreateField(name string, opt FieldOptions) (*Field, error) {
+func (i *Index) CreateField(name string, opt FieldTypeOptions) (*Field, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -280,7 +280,7 @@ func (i *Index) CreateField(name string, opt FieldOptions) (*Field, error) {
 }
 
 // CreateFieldIfNotExists creates a field with the given options if it doesn't exist.
-func (i *Index) CreateFieldIfNotExists(name string, opt FieldOptions) (*Field, error) {
+func (i *Index) CreateFieldIfNotExists(name string, opt FieldTypeOptions) (*Field, error) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
@@ -292,16 +292,16 @@ func (i *Index) CreateFieldIfNotExists(name string, opt FieldOptions) (*Field, e
 	return i.createField(name, opt)
 }
 
-func (i *Index) createField(name string, opt FieldOptions) (*Field, error) {
+func (i *Index) createField(name string, opt FieldTypeOptions) (*Field, error) {
 	if name == "" {
 		return nil, errors.New("field name required")
-	} else if opt.CacheType != "" && !isValidCacheType(opt.CacheType) {
-		return nil, ErrInvalidCacheType
 	}
 
 	// Validate options.
-	if err := opt.Validate(); err != nil {
-		return nil, errors.Wrap(err, "validating options")
+	if opt != nil {
+		if err := opt.Validate(); err != nil {
+			return nil, errors.Wrap(err, "validating options")
+		}
 	}
 
 	// Initialize field.
@@ -321,6 +321,7 @@ func (i *Index) createField(name string, opt FieldOptions) (*Field, error) {
 		return nil, errors.Wrap(err, "applying options")
 	}
 
+	// Save meta data.
 	if err := f.saveMeta(); err != nil {
 		f.Close()
 		return nil, errors.Wrap(err, "saving meta")

--- a/index_test.go
+++ b/index_test.go
@@ -32,7 +32,7 @@ func TestIndex_CreateFieldIfNotExists(t *testing.T) {
 	defer index.Close()
 
 	// Create field.
-	f, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{})
+	f, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		t.Fatal(err)
 	} else if f == nil {
@@ -40,7 +40,7 @@ func TestIndex_CreateFieldIfNotExists(t *testing.T) {
 	}
 
 	// Retrieve existing field.
-	other, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{})
+	other, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		t.Fatal(err)
 	} else if f.Field != other.Field {
@@ -60,13 +60,14 @@ func TestIndex_CreateField(t *testing.T) {
 			defer index.Close()
 
 			// Create field with explicit quantum.
-			f, err := index.CreateField("f", pilosa.FieldOptions{
-				Type:        pilosa.FieldTypeTime,
+			f, err := index.CreateField("f", pilosa.FieldTypeOptionsTime{
 				TimeQuantum: pilosa.TimeQuantum("YMDH"),
 			})
 			if err != nil {
 				t.Fatal(err)
-			} else if q := f.TimeQuantum(); q != pilosa.TimeQuantum("YMDH") {
+			}
+			fo := f.Options().(pilosa.FieldTypeOptionsTime)
+			if q := fo.TimeQuantum; q != pilosa.TimeQuantum("YMDH") {
 				t.Fatalf("unexpected field time quantum: %s", q)
 			}
 		})
@@ -79,10 +80,9 @@ func TestIndex_CreateField(t *testing.T) {
 			defer index.Close()
 
 			// Create field with schema and verify it exists.
-			if f, err := index.CreateField("f", pilosa.FieldOptions{
-				Type: pilosa.FieldTypeInt,
-				Min:  10,
-				Max:  20,
+			if f, err := index.CreateField("f", pilosa.FieldTypeOptionsInt{
+				Min: 10,
+				Max: 20,
 			}); err != nil {
 				t.Fatal(err)
 			} else if !reflect.DeepEqual(f.Type(), pilosa.FieldTypeInt) {
@@ -104,7 +104,7 @@ func TestIndex_CreateField(t *testing.T) {
 				index := test.MustOpenIndex()
 				defer index.Close()
 
-				if _, err := index.CreateField("f", pilosa.FieldOptions{
+				if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{
 					CacheType: pilosa.CacheTypeRanked,
 				}); err != nil {
 					t.Fatal(err)
@@ -114,7 +114,7 @@ func TestIndex_CreateField(t *testing.T) {
 			t.Run("BSIFieldsWithCacheTypeNone", func(t *testing.T) {
 				index := test.MustOpenIndex()
 				defer index.Close()
-				if _, err := index.CreateField("f", pilosa.FieldOptions{
+				if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{
 					CacheType: pilosa.CacheTypeNone,
 					CacheSize: uint32(5),
 				}); err != nil {
@@ -126,7 +126,7 @@ func TestIndex_CreateField(t *testing.T) {
 				index := test.MustOpenIndex()
 				defer index.Close()
 
-				if _, err := index.CreateField("f", pilosa.FieldOptions{
+				if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{
 					Fields: []*pilosa.Field{
 						{Name: "field0", Type: pilosa.FieldTypeInt},
 					},
@@ -139,7 +139,7 @@ func TestIndex_CreateField(t *testing.T) {
 				index := test.MustOpenIndex()
 				defer index.Close()
 
-				if _, err := index.CreateField("f", pilosa.FieldOptions{
+				if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{
 					Fields: []*pilosa.Field{
 						{Name: "", Type: pilosa.FieldTypeInt},
 					},
@@ -152,7 +152,7 @@ func TestIndex_CreateField(t *testing.T) {
 				index := test.MustOpenIndex()
 				defer index.Close()
 
-				if _, err := index.CreateField("f", pilosa.FieldOptions{
+				if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{
 					Fields: []*pilosa.Field{
 						{Name: "field0", Type: "bad_type"},
 					},
@@ -165,7 +165,7 @@ func TestIndex_CreateField(t *testing.T) {
 				index := test.MustOpenIndex()
 				defer index.Close()
 
-				if _, err := index.CreateField("f", pilosa.FieldOptions{
+				if _, err := index.CreateField("f", pilosa.FieldTypeOptionsSet{
 					Fields: []*pilosa.Field{
 						{Name: "field0", Type: pilosa.FieldTypeInt, Min: 100, Max: 50},
 					},
@@ -183,7 +183,7 @@ func TestIndex_DeleteField(t *testing.T) {
 	defer index.Close()
 
 	// Create field.
-	if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldOptions{}); err != nil {
+	if _, err := index.CreateFieldIfNotExists("f", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/server.go
+++ b/server.go
@@ -442,8 +442,11 @@ func (s *Server) ReceiveMessage(pb proto.Message) error {
 		if idx == nil {
 			return fmt.Errorf("Local Index not found: %s", obj.Index)
 		}
-		opt := decodeFieldOptions(obj.Meta)
-		_, err := idx.CreateField(obj.Field, *opt)
+		opt, err := decodeOptions(*obj.Meta)
+		if err != nil {
+			return err
+		}
+		_, err = idx.CreateField(obj.Field, opt)
 		if err != nil {
 			return err
 		}

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -54,7 +54,7 @@ func TestMain_SendReceiveMessage(t *testing.T) {
 	// Create indexes and fields on one node.
 	if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 		t.Fatal(err)
-	} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldOptions{}); err != nil {
+	} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -209,7 +209,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		// Create indexes and fields on one node.
 		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 			t.Fatal(err)
-		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldOptions{}); err != nil {
+		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -253,7 +253,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		// Create indexes and fields on one node.
 		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 			t.Fatal(err)
-		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldOptions{}); err != nil {
+		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -305,7 +305,7 @@ func TestClusterResize_AddNode(t *testing.T) {
 		// Create indexes and fields on one node.
 		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 			t.Fatal(err)
-		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldOptions{}); err != nil {
+		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -458,7 +458,7 @@ func TestClusterResize_RemoveNode(t *testing.T) {
 		// Create indexes and fields on one node.
 		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 			t.Fatal(err)
-		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldOptions{}); err != nil {
+		} else if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldTypeOptionsSet{}); err != nil {
 			t.Fatal(err)
 		}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -54,7 +54,7 @@ func TestMain_Set_Quick(t *testing.T) {
 			if err := client.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 				t.Fatal(err)
 			}
-			if err := client.CreateField(context.Background(), "i", cmd.Field, pilosa.FieldOptions{}); err != nil && err != pilosa.ErrFieldExists {
+			if err := client.CreateField(context.Background(), "i", cmd.Field, pilosa.FieldTypeOptionsSet{}); err != nil && err != pilosa.ErrFieldExists {
 				t.Fatal(err)
 			}
 			if _, err := m.Query("i", "", fmt.Sprintf(`SetBit(row=%d, field=%q, col=%d)`, cmd.ID, cmd.Field, cmd.ColumnID)); err != nil {
@@ -123,11 +123,11 @@ func TestMain_SetRowAttrs(t *testing.T) {
 	client := m.Client()
 	if err := client.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 		t.Fatal(err)
-	} else if err := client.CreateField(context.Background(), "i", "x", pilosa.FieldOptions{}); err != nil {
+	} else if err := client.CreateField(context.Background(), "i", "x", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
-	} else if err := client.CreateField(context.Background(), "i", "z", pilosa.FieldOptions{}); err != nil {
+	} else if err := client.CreateField(context.Background(), "i", "z", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
-	} else if err := client.CreateField(context.Background(), "i", "neg", pilosa.FieldOptions{}); err != nil {
+	} else if err := client.CreateField(context.Background(), "i", "neg", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -200,7 +200,7 @@ func TestMain_SetColumnAttrs(t *testing.T) {
 	client := m.Client()
 	if err := client.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 		t.Fatal(err)
-	} else if err := client.CreateField(context.Background(), "i", "x", pilosa.FieldOptions{}); err != nil {
+	} else if err := client.CreateField(context.Background(), "i", "x", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -271,7 +271,7 @@ func TestMain_RecalculateHashes(t *testing.T) {
 	if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
 		t.Fatal("create index:", err)
 	}
-	if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldOptions{CacheType: "ranked"}); err != nil {
+	if err := client0.CreateField(context.Background(), "i", "f", pilosa.FieldTypeOptionsSet{CacheType: "ranked"}); err != nil {
 		t.Fatal("create field:", err)
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -33,7 +33,7 @@ func TestMonitorAntiEntropy(t *testing.T) {
 	if err != nil {
 		t.Fatalf("creating index: %v", err)
 	}
-	err = client.CreateField(context.Background(), "balh", "fralh", pilosa.FieldOptions{})
+	err = client.CreateField(context.Background(), "balh", "fralh", pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		t.Fatalf("creating field: %v", err)
 	}

--- a/stats_test.go
+++ b/stats_test.go
@@ -298,7 +298,7 @@ func TestStatsCount_DeleteField(t *testing.T) {
 	called := false
 	// Create index.
 	indx, _ := hldr.CreateIndexIfNotExists("i", pilosa.IndexOptions{})
-	if _, err := indx.CreateFieldIfNotExists("test", pilosa.FieldOptions{}); err != nil {
+	if _, err := indx.CreateFieldIfNotExists("test", pilosa.FieldTypeOptionsSet{}); err != nil {
 		t.Fatal(err)
 	}
 	s.Handler.API.Holder.Stats = &MockStats{

--- a/test/frame.go
+++ b/test/frame.go
@@ -17,7 +17,6 @@ package test
 import (
 	"io/ioutil"
 	"os"
-	"testing"
 	"time"
 
 	"github.com/pilosa/pilosa"
@@ -82,25 +81,4 @@ func (f *Field) MustSetBit(view string, rowID, columnID uint64, t *time.Time) (c
 		panic(err)
 	}
 	return changed
-}
-
-// Ensure field can set its cache
-func TestField_SetCacheSize(t *testing.T) {
-	f := MustOpenField()
-	defer f.Close()
-	cacheSize := uint32(100)
-
-	// Set & retrieve field cache size.
-	if err := f.SetCacheSize(cacheSize); err != nil {
-		t.Fatal(err)
-	} else if q := f.CacheSize(); q != cacheSize {
-		t.Fatalf("unexpected field cache size: %d", q)
-	}
-
-	// Reload field and verify that it is persisted.
-	if err := f.Reopen(); err != nil {
-		t.Fatal(err)
-	} else if q := f.CacheSize(); q != cacheSize {
-		t.Fatalf("unexpected field cache size (reopen): %d", q)
-	}
 }

--- a/test/holder.go
+++ b/test/holder.go
@@ -82,7 +82,7 @@ func (h *Holder) MustCreateIndexIfNotExists(index string, opt pilosa.IndexOption
 
 // MustCreateFieldIfNotExists returns a given field. Panic on error.
 func (h *Holder) MustCreateFieldIfNotExists(index, field string) *Field {
-	f, err := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{}).CreateFieldIfNotExists(field, pilosa.FieldOptions{})
+	f, err := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{}).CreateFieldIfNotExists(field, pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		panic(err)
 	}
@@ -92,7 +92,7 @@ func (h *Holder) MustCreateFieldIfNotExists(index, field string) *Field {
 // MustCreateRankedFragmentIfNotExists returns a given fragment with a ranked cache. Panic on error.
 func (h *Holder) MustCreateRankedFragmentIfNotExists(index, field, view string, slice uint64) *Fragment {
 	idx := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{})
-	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldOptions{CacheType: pilosa.CacheTypeRanked})
+	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldTypeOptionsSet{CacheType: pilosa.CacheTypeRanked})
 	if err != nil {
 		panic(err)
 	}
@@ -110,7 +110,7 @@ func (h *Holder) MustCreateRankedFragmentIfNotExists(index, field, view string, 
 // Row returns a Row for a given field.
 func (h *Holder) Row(index, field string, rowID uint64) *pilosa.Row {
 	idx := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{})
-	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldOptions{})
+	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		panic(err)
 	}
@@ -124,7 +124,7 @@ func (h *Holder) Row(index, field string, rowID uint64) *pilosa.Row {
 // ViewRow returns a Row for a given field and view.
 func (h *Holder) ViewRow(index, field, view string, rowID uint64) *pilosa.Row {
 	idx := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{})
-	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldOptions{})
+	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		panic(err)
 	}
@@ -138,7 +138,7 @@ func (h *Holder) ViewRow(index, field, view string, rowID uint64) *pilosa.Row {
 // SetBit clears a bit on the given field.
 func (h *Holder) SetBit(index, field string, rowID, columnID uint64) {
 	idx := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{})
-	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldOptions{})
+	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		panic(err)
 	}
@@ -148,7 +148,7 @@ func (h *Holder) SetBit(index, field string, rowID, columnID uint64) {
 // ClearBit clears a bit on the given field.
 func (h *Holder) ClearBit(index, field string, rowID, columnID uint64) {
 	idx := h.MustCreateIndexIfNotExists(index, pilosa.IndexOptions{})
-	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldOptions{})
+	f, err := idx.CreateFieldIfNotExists(field, pilosa.FieldTypeOptionsSet{})
 	if err != nil {
 		panic(err)
 	}

--- a/test/index.go
+++ b/test/index.go
@@ -74,7 +74,7 @@ func (i *Index) Reopen() error {
 }
 
 // CreateField creates a field with the given options.
-func (i *Index) CreateField(name string, opt pilosa.FieldOptions) (*Field, error) {
+func (i *Index) CreateField(name string, opt pilosa.FieldTypeOptions) (*Field, error) {
 	f, err := i.Index.CreateField(name, opt)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ func (i *Index) CreateField(name string, opt pilosa.FieldOptions) (*Field, error
 }
 
 // CreateFieldIfNotExists creates a field with the given options if it doesn't exist.
-func (i *Index) CreateFieldIfNotExists(name string, opt pilosa.FieldOptions) (*Field, error) {
+func (i *Index) CreateFieldIfNotExists(name string, opt pilosa.FieldTypeOptions) (*Field, error) {
 	f, err := i.Index.CreateFieldIfNotExists(name, opt)
 	if err != nil {
 		return nil, err

--- a/utils_internal_test.go
+++ b/utils_internal_test.go
@@ -104,7 +104,7 @@ func (t *ClusterCluster) CreateIndex(name string) error {
 	return nil
 }
 
-func (t *ClusterCluster) CreateField(index, field string, opt FieldOptions) error {
+func (t *ClusterCluster) CreateField(index, field string, opt FieldTypeOptions) error {
 	for _, c := range t.Clusters {
 		idx, err := c.Holder.CreateIndexIfNotExists(index, IndexOptions{})
 		if err != nil {
@@ -203,10 +203,6 @@ func (t *ClusterCluster) addCluster(i int, saveTopology bool) (*Cluster, error) 
 		ID:  id,
 		URI: uri,
 	}
-
-	// add URI to common
-	//t.common.NodeIDs = append(t.common.NodeIDs, id)
-	//sort.Sort(t.common.NodeIDs)
 
 	// add node to common
 	t.common.Nodes = append(t.common.Nodes, node)


### PR DESCRIPTION
## Overview

This PR replace the single `FieldOptions` struct with three, field type specific structs: `FieldTypeOptionsSet`, `FieldTypeOptionsInt`, and `FieldTypeOptionsTime`. There's a bit of custom JSON marshaling added to support this. Any feedback on how I handled that would be appreciated.

I'm going to follow this up with some additional tests around the new marshaling and validation logic, but I wanted to get this in review so it's not blocking anyone.

Fixes #1361

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
