### PR TITLE
remove view argument from Field.SetBit and Field.ClearBit

### DIFF
--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -153,19 +153,19 @@ func TestFragSources(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = field.SetBit("standard", 1, 101, nil)
+	_, err = field.SetBit(1, 101, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = field.SetBit("standard", 1, 1300000, nil)
+	_, err = field.SetBit(1, 1300000, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = field.SetBit("standard", 1, 2600000, nil)
+	_, err = field.SetBit(1, 2600000, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = field.SetBit("standard", 1, 3900000, nil)
+	_, err = field.SetBit(1, 3900000, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -699,8 +699,8 @@ func TestCluster_ResizeStates(t *testing.T) {
 		if err := tc.CreateField("i", "f", FieldOptions{}); err != nil {
 			t.Fatal(err)
 		}
-		tc.SetBit("i", "f", "standard", 1, 101, nil)
-		tc.SetBit("i", "f", "standard", 1, 1300000, nil)
+		tc.SetBit("i", "f", 1, 101, nil)
+		tc.SetBit("i", "f", 1, 1300000, nil)
 
 		// Before starting the resize, get the CheckSum to use for
 		// comparison later.

--- a/executor.go
+++ b/executor.go
@@ -1026,17 +1026,17 @@ func (e *Executor) executeClearBit(ctx context.Context, index string, c *pql.Cal
 		return false, fmt.Errorf("ClearBit col field '%v' required", columnLabel)
 	}
 
-	return e.executeClearBitView(ctx, index, c, f, ViewStandard, colID, rowID, opt)
+	return e.executeClearBitField(ctx, index, c, f, colID, rowID, opt)
 }
 
-// executeClearBitView executes a ClearBit() call for a single view.
-func (e *Executor) executeClearBitView(ctx context.Context, index string, c *pql.Call, f *Field, view string, colID, rowID uint64, opt *ExecOptions) (bool, error) {
+// executeClearBitField executes a ClearBit() call for a single view.
+func (e *Executor) executeClearBitField(ctx context.Context, index string, c *pql.Call, f *Field, colID, rowID uint64, opt *ExecOptions) (bool, error) {
 	slice := colID / SliceWidth
 	ret := false
 	for _, node := range e.Cluster.sliceNodes(index, slice) {
 		// Update locally if host matches.
 		if node.ID == e.Node.ID {
-			val, err := f.ClearBit(view, rowID, colID, nil)
+			val, err := f.ClearBit(rowID, colID, nil)
 			if err != nil {
 				return false, err
 			} else if val {
@@ -1101,18 +1101,18 @@ func (e *Executor) executeSetBit(ctx context.Context, index string, c *pql.Call,
 		timestamp = &t
 	}
 
-	return e.executeSetBitView(ctx, index, c, f, ViewStandard, colID, rowID, timestamp, opt)
+	return e.executeSetBitField(ctx, index, c, f, colID, rowID, timestamp, opt)
 }
 
-// executeSetBitView executes a SetBit() call for a specific view.
-func (e *Executor) executeSetBitView(ctx context.Context, index string, c *pql.Call, f *Field, view string, colID, rowID uint64, timestamp *time.Time, opt *ExecOptions) (bool, error) {
+// executeSetBitField executes a SetBit() call for a specific view.
+func (e *Executor) executeSetBitField(ctx context.Context, index string, c *pql.Call, f *Field, colID, rowID uint64, timestamp *time.Time, opt *ExecOptions) (bool, error) {
 	slice := colID / SliceWidth
 	ret := false
 
 	for _, node := range e.Cluster.sliceNodes(index, slice) {
 		// Update locally if host matches.
 		if node.ID == e.Node.ID {
-			val, err := f.SetBit(view, rowID, colID, timestamp)
+			val, err := f.SetBit(rowID, colID, timestamp)
 			if err != nil {
 				return false, err
 			} else if val {

--- a/field.go
+++ b/field.go
@@ -654,14 +654,11 @@ func (f *Field) ViewRow(viewName string, rowID uint64) (*Row, error) {
 }
 
 // SetBit sets a bit on a view within the field.
-func (f *Field) SetBit(name string, rowID, colID uint64, t *time.Time) (changed bool, err error) {
-	// Validate view name.
-	if !isValidView(name) {
-		return false, ErrInvalidView
-	}
+func (f *Field) SetBit(rowID, colID uint64, t *time.Time) (changed bool, err error) {
+	viewName := ViewStandard
 
 	// Retrieve view. Exit if it doesn't exist.
-	view, err := f.CreateViewIfNotExists(name)
+	view, err := f.CreateViewIfNotExists(viewName)
 	if err != nil {
 		return changed, errors.Wrap(err, "creating view")
 	}
@@ -679,7 +676,7 @@ func (f *Field) SetBit(name string, rowID, colID uint64, t *time.Time) (changed 
 	}
 
 	// If a timestamp is specified then set bits across all views for the quantum.
-	for _, subname := range viewsByTime(name, *t, f.TimeQuantum()) {
+	for _, subname := range viewsByTime(viewName, *t, f.TimeQuantum()) {
 		view, err := f.CreateViewIfNotExists(subname)
 		if err != nil {
 			return changed, errors.Wrapf(err, "creating view %s", subname)
@@ -696,14 +693,11 @@ func (f *Field) SetBit(name string, rowID, colID uint64, t *time.Time) (changed 
 }
 
 // ClearBit clears a bit within the field.
-func (f *Field) ClearBit(name string, rowID, colID uint64, t *time.Time) (changed bool, err error) {
-	// Validate view name.
-	if !isValidView(name) {
-		return false, ErrInvalidView
-	}
+func (f *Field) ClearBit(rowID, colID uint64, t *time.Time) (changed bool, err error) {
+	viewName := ViewStandard
 
 	// Retrieve view. Exit if it doesn't exist.
-	view, err := f.CreateViewIfNotExists(name)
+	view, err := f.CreateViewIfNotExists(viewName)
 	if err != nil {
 		return changed, errors.Wrap(err, "creating view")
 	}
@@ -721,7 +715,7 @@ func (f *Field) ClearBit(name string, rowID, colID uint64, t *time.Time) (change
 	}
 
 	// If a timestamp is specified then clear bits across all views for the quantum.
-	for _, subname := range viewsByTime(name, *t, f.TimeQuantum()) {
+	for _, subname := range viewsByTime(viewName, *t, f.TimeQuantum()) {
 		view, err := f.CreateViewIfNotExists(subname)
 		if err != nil {
 			return changed, errors.Wrapf(err, "creating view %s", subname)

--- a/holder_test.go
+++ b/holder_test.go
@@ -210,7 +210,7 @@ func TestHolder_Open(t *testing.T) {
 			t.Fatal(err)
 		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
 			t.Fatal(err)
-		} else if _, err := field.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+		} else if _, err := field.SetBit(0, 0, nil); err != nil {
 			t.Fatal(err)
 		} else if err := h.Holder.Close(); err != nil {
 			t.Fatal(err)
@@ -231,7 +231,7 @@ func TestHolder_Open(t *testing.T) {
 			t.Fatal(err)
 		} else if field, err := idx.CreateField("bar", pilosa.FieldOptions{}); err != nil {
 			t.Fatal(err)
-		} else if _, err := field.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+		} else if _, err := field.SetBit(0, 0, nil); err != nil {
 			t.Fatal(err)
 		} else if err := h.Holder.Close(); err != nil {
 			t.Fatal(err)
@@ -257,7 +257,7 @@ func TestHolder_Open(t *testing.T) {
 			t.Fatal(err)
 		} else if view, err := field.CreateViewIfNotExists(pilosa.ViewStandard); err != nil {
 			t.Fatal(err)
-		} else if _, err := field.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+		} else if _, err := field.SetBit(0, 0, nil); err != nil {
 			t.Fatal(err)
 		} else if err := view.Fragment(0).FlushCache(); err != nil {
 			t.Fatal(err)

--- a/http/handler_test.go
+++ b/http/handler_test.go
@@ -85,12 +85,12 @@ func TestHandler_Schema(t *testing.T) {
 
 	if f, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+	} else if _, err := f.SetBit(0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if f, err := i1.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+	} else if _, err := f.SetBit(0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := i0.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
@@ -122,12 +122,12 @@ func TestHandler_Status(t *testing.T) {
 
 	if f, err := i0.CreateFieldIfNotExists("f1", pilosa.FieldOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+	} else if _, err := f.SetBit(0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if f, err := i1.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {
 		t.Fatal(err)
-	} else if _, err := f.SetBit(pilosa.ViewStandard, 0, 0, nil); err != nil {
+	} else if _, err := f.SetBit(0, 0, nil); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := i0.CreateFieldIfNotExists("f0", pilosa.FieldOptions{}); err != nil {

--- a/test/field.go
+++ b/test/field.go
@@ -18,7 +18,6 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/pilosa/pilosa"
 )
@@ -73,15 +72,6 @@ func (f *Field) Reopen() error {
 		return err
 	}
 	return nil
-}
-
-// MustSetBit sets a bit on the field. Panic on error.
-func (f *Field) MustSetBit(view string, rowID, columnID uint64, t *time.Time) (changed bool) {
-	changed, err := f.SetBit(view, rowID, columnID, t)
-	if err != nil {
-		panic(err)
-	}
-	return changed
 }
 
 // Ensure field can set its cache

--- a/test/holder.go
+++ b/test/holder.go
@@ -142,7 +142,7 @@ func (h *Holder) SetBit(index, field string, rowID, columnID uint64) {
 	if err != nil {
 		panic(err)
 	}
-	f.SetBit(pilosa.ViewStandard, rowID, columnID, nil)
+	f.SetBit(rowID, columnID, nil)
 }
 
 // ClearBit clears a bit on the given field.
@@ -152,7 +152,7 @@ func (h *Holder) ClearBit(index, field string, rowID, columnID uint64) {
 	if err != nil {
 		panic(err)
 	}
-	f.ClearBit(pilosa.ViewStandard, rowID, columnID, nil)
+	f.ClearBit(rowID, columnID, nil)
 }
 
 // MustSetBits sets columns on a row. Panic on error.

--- a/utils_internal_test.go
+++ b/utils_internal_test.go
@@ -117,7 +117,7 @@ func (t *ClusterCluster) CreateField(index, field string, opt FieldOptions) erro
 	return nil
 }
 
-func (t *ClusterCluster) SetBit(index, field, view string, rowID, colID uint64, x *time.Time) error {
+func (t *ClusterCluster) SetBit(index, field string, rowID, colID uint64, x *time.Time) error {
 	// Determine which node should receive the SetBit.
 	c0 := t.Clusters[0] // use the first node's cluster to determine slice location.
 	slice := colID / SliceWidth
@@ -132,7 +132,7 @@ func (t *ClusterCluster) SetBit(index, field, view string, rowID, colID uint64, 
 		if f == nil {
 			return fmt.Errorf("index/field does not exist: %s/%s", index, field)
 		}
-		_, err := f.SetBit(view, rowID, colID, x)
+		_, err := f.SetBit(rowID, colID, x)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Overview

This PR removes the `view` argument from `Field.SetBit()` and `Field.ClearBit()`.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
