### PR TITLE
remove broadcaster from server

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1010,6 +1010,9 @@ func (c *Cluster) handleNodeAction(nodeAction nodeAction) error {
 
 func (c *Cluster) setStateAndBroadcast(state string) error {
 	c.SetState(state)
+	if c.Static {
+		return nil
+	}
 	// Broadcast cluster status changes to the cluster.
 	c.Logger.Printf("broadcasting ClusterStatus: %s", state)
 	return c.Broadcaster.SendSync(c.Status())

--- a/server.go
+++ b/server.go
@@ -62,7 +62,6 @@ type Server struct {
 
 	// External
 	handler           Handler
-	Broadcaster       Broadcaster
 	BroadcastReceiver BroadcastReceiver
 	systemInfo        SystemInfo
 	gcNotifier        GCNotifier
@@ -223,7 +222,6 @@ func NewServer(opts ...ServerOption) (*Server, error) {
 		closing:           make(chan struct{}),
 		Cluster:           NewCluster(),
 		holder:            NewHolder(),
-		Broadcaster:       NopBroadcaster,
 		BroadcastReceiver: NopBroadcastReceiver,
 		diagnostics:       NewDiagnosticsCollector(DefaultDiagnosticServer),
 		systemInfo:        NewNopSystemInfo(),
@@ -315,19 +313,19 @@ func (s *Server) Open() error {
 	}
 
 	// Cluster settings.
-	s.Cluster.Broadcaster = s.Broadcaster
+	s.Cluster.Broadcaster = s
 	s.Cluster.MaxWritesPerRequest = s.maxWritesPerRequest
 
 	// Initialize HTTP handler.
 	api := s.handler.GetAPI()
 	api.Holder = s.holder
-	api.Broadcaster = s.Broadcaster
+	api.Broadcaster = s
 	api.BroadcastHandler = s
 	api.StatusHandler = s
 	api.Cluster = s.Cluster
 
 	// Initialize Holder.
-	s.holder.Broadcaster = s.Broadcaster
+	s.holder.Broadcaster = s
 
 	// Serve handler.
 	go s.handler.Serve(s.ln, s.closing)

--- a/server/server.go
+++ b/server/server.go
@@ -293,7 +293,6 @@ func (m *Command) SetupNetworking() error {
 	}
 	gossipMemberSet.Logger = m.logger
 	m.Server.Cluster.MemberSet = gossipMemberSet
-	m.Server.Broadcaster = m.Server
 	m.Server.BroadcastReceiver = gossipMemberSet
 	return nil
 }


### PR DESCRIPTION
## Overview

removes the broadcaster field from the server. The server itself was almost always the broadcaster - only one test was depending on server having a NopBroadcaster, and that was fixed by having cluster not broadcast node state changes when clustering is disabled.

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
