### PR TITLE
Add CommandOptions and use OptCommandServerOptions to inject mock TranslateStore

### DIFF
--- a/http/translator_test.go
+++ b/http/translator_test.go
@@ -54,7 +54,7 @@ func TestTranslateStore_Reader(t *testing.T) {
 			}
 
 			opts := server.OptCommandServerOptions(pilosa.OptServerPrimaryTranslateStore(translateStore))
-			main := test.MustRunMainWithCluster(t, 1, opts)[0]
+			main := test.MustRunMainWithCluster(t, 1, []server.CommandOption{opts})[0]
 			defer main.Close()
 
 			// Connect to server and stream all available data.
@@ -98,7 +98,7 @@ func TestTranslateStore_Reader(t *testing.T) {
 			}
 
 			opts := server.OptCommandServerOptions(pilosa.OptServerPrimaryTranslateStore(translateStore))
-			main := test.MustRunMainWithCluster(t, 1, opts)[0]
+			main := test.MustRunMainWithCluster(t, 1, []server.CommandOption{opts})[0]
 
 			defer main.Close()
 			defer close(done)
@@ -127,7 +127,7 @@ func TestTranslateStore_Reader(t *testing.T) {
 		}
 
 		opts := server.OptCommandServerOptions(pilosa.OptServerPrimaryTranslateStore(translateStore))
-		main := test.MustRunMainWithCluster(t, 1, opts)[0]
+		main := test.MustRunMainWithCluster(t, 1, []server.CommandOption{opts})[0]
 
 		_, err := http.NewTranslateStore(main.Server.URI.String()).Reader(context.Background(), 0)
 		if err != pilosa.ErrNotImplemented {

--- a/http/translator_test.go
+++ b/http/translator_test.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/http"
 	"github.com/pilosa/pilosa/mock"
+	"github.com/pilosa/pilosa/server"
 	"github.com/pilosa/pilosa/test"
 )
 
@@ -52,13 +52,14 @@ func TestTranslateStore_Reader(t *testing.T) {
 				}
 				return &mrc, nil
 			}
-			h := test.MustNewHandler()
-			h.API.TranslateStore = &translateStore
-			s := httptest.NewServer(h)
-			defer s.Close()
+
+			opts := server.OptCommandServerOptions(pilosa.OptServerPrimaryTranslateStore(translateStore))
+			main := test.MustRunMainWithCluster(t, 1, opts)[0]
+			defer main.Close()
 
 			// Connect to server and stream all available data.
-			store := http.NewTranslateStore(s.URL)
+			store := http.NewTranslateStore(main.Server.URI.String())
+
 			rc, err := store.Reader(context.Background(), 100)
 			if err != nil {
 				t.Fatal(err)
@@ -95,15 +96,16 @@ func TestTranslateStore_Reader(t *testing.T) {
 			translateStore.ReaderFunc = func(ctx context.Context, off int64) (io.ReadCloser, error) {
 				return &mrc, nil
 			}
-			h := test.MustNewHandler()
-			h.API.TranslateStore = &translateStore
-			s := httptest.NewServer(h)
-			defer s.Close()
+
+			opts := server.OptCommandServerOptions(pilosa.OptServerPrimaryTranslateStore(translateStore))
+			main := test.MustRunMainWithCluster(t, 1, opts)[0]
+
+			defer main.Close()
 			defer close(done)
 
 			// Connect to server and begin streaming.
 			ctx, cancel := context.WithCancel(context.Background())
-			store := http.NewTranslateStore(s.URL)
+			store := http.NewTranslateStore(main.Server.URI.String())
 			if _, err := store.Reader(ctx, 0); err != nil {
 				t.Fatal(err)
 			}
@@ -123,12 +125,11 @@ func TestTranslateStore_Reader(t *testing.T) {
 		translateStore.ReaderFunc = func(ctx context.Context, off int64) (io.ReadCloser, error) {
 			return nil, pilosa.ErrNotImplemented
 		}
-		h := test.MustNewHandler()
-		h.API.TranslateStore = &translateStore
-		s := httptest.NewServer(h)
-		defer s.Close()
 
-		_, err := http.NewTranslateStore(s.URL).Reader(context.Background(), 0)
+		opts := server.OptCommandServerOptions(pilosa.OptServerPrimaryTranslateStore(translateStore))
+		main := test.MustRunMainWithCluster(t, 1, opts)[0]
+
+		_, err := http.NewTranslateStore(main.Server.URI.String()).Reader(context.Background(), 0)
 		if err != pilosa.ErrNotImplemented {
 			t.Fatalf("unexpected error: %s", err)
 		}

--- a/mock/translator.go
+++ b/mock/translator.go
@@ -17,22 +17,22 @@ type TranslateStore struct {
 	ReaderFunc                   func(ctx context.Context, off int64) (io.ReadCloser, error)
 }
 
-func (s *TranslateStore) TranslateColumnsToUint64(index string, values []string) ([]uint64, error) {
+func (s TranslateStore) TranslateColumnsToUint64(index string, values []string) ([]uint64, error) {
 	return s.TranslateColumnsToUint64Func(index, values)
 }
 
-func (s *TranslateStore) TranslateColumnToString(index string, values uint64) (string, error) {
+func (s TranslateStore) TranslateColumnToString(index string, values uint64) (string, error) {
 	return s.TranslateColumnToStringFunc(index, values)
 }
 
-func (s *TranslateStore) TranslateRowsToUint64(index, frame string, values []string) ([]uint64, error) {
+func (s TranslateStore) TranslateRowsToUint64(index, frame string, values []string) ([]uint64, error) {
 	return s.TranslateRowsToUint64Func(index, frame, values)
 }
 
-func (s *TranslateStore) TranslateRowToString(index, frame string, value uint64) (string, error) {
+func (s TranslateStore) TranslateRowToString(index, frame string, value uint64) (string, error) {
 	return s.TranslateRowToStringFunc(index, frame, value)
 }
 
-func (s *TranslateStore) Reader(ctx context.Context, off int64) (io.ReadCloser, error) {
+func (s TranslateStore) Reader(ctx context.Context, off int64) (io.ReadCloser, error) {
 	return s.ReaderFunc(ctx, off)
 }

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pilosa/pilosa"
 	"github.com/pilosa/pilosa/http"
 	"github.com/pilosa/pilosa/internal"
+	"github.com/pilosa/pilosa/server"
 	"github.com/pilosa/pilosa/test"
 )
 
@@ -565,7 +566,7 @@ func TestHandler_Endpoints(t *testing.T) {
 			t.Fatalf("CORS preflight status should be 405, but is %v", result.StatusCode)
 		}
 
-		clus := test.MustRunMainWithCluster(t, 1, test.OptAllowedOrigins([]string{"http://test/"}))
+		clus := test.MustRunMainWithCluster(t, 1, []server.CommandOption{test.OptAllowedOrigins([]string{"http://test/"})})
 		w = httptest.NewRecorder()
 		h := clus[0].Handler.(*http.Handler).Handler
 		h.ServeHTTP(w, req)

--- a/server/server.go
+++ b/server/server.go
@@ -77,14 +77,14 @@ type Command struct {
 	Handler pilosa.Handler
 	ln      net.Listener
 
-	ServerOptions []pilosa.ServerOption
+	serverOptions []pilosa.ServerOption
 }
 
 type CommandOption func(c *Command) error
 
 func OptCommandServerOptions(opts ...pilosa.ServerOption) CommandOption {
 	return func(c *Command) error {
-		c.ServerOptions = append(c.ServerOptions, opts...)
+		c.serverOptions = append(c.serverOptions, opts...)
 		return nil
 	}
 }
@@ -266,7 +266,7 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerClusterDisabled(m.Config.Cluster.Disabled, m.Config.Cluster.Hosts),
 	}
 
-	serverOptions = append(serverOptions, m.ServerOptions...)
+	serverOptions = append(serverOptions, m.serverOptions...)
 
 	m.Server, err = pilosa.NewServer(serverOptions...)
 

--- a/server/server.go
+++ b/server/server.go
@@ -77,14 +77,14 @@ type Command struct {
 	Handler pilosa.Handler
 	ln      net.Listener
 
-	serverOptions []pilosa.ServerOption
+	ServerOptions []pilosa.ServerOption
 }
 
 type CommandOption func(c *Command) error
 
 func OptCommandServerOptions(opts ...pilosa.ServerOption) CommandOption {
 	return func(c *Command) error {
-		c.serverOptions = append(c.serverOptions, opts...)
+		c.ServerOptions = append(c.ServerOptions, opts...)
 		return nil
 	}
 }
@@ -266,7 +266,7 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerClusterDisabled(m.Config.Cluster.Disabled, m.Config.Cluster.Hosts),
 	}
 
-	serverOptions = append(serverOptions, m.serverOptions...)
+	serverOptions = append(serverOptions, m.ServerOptions...)
 
 	m.Server, err = pilosa.NewServer(serverOptions...)
 

--- a/server_test.go
+++ b/server_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pilosa/pilosa"
+	"github.com/pilosa/pilosa/server"
 	"github.com/pilosa/pilosa/test"
 )
 
@@ -27,7 +28,7 @@ import (
 // pilosa.Server was not having its remoteClient field set by an option and so
 // it was using a nil client in monitorAntiEntropy.
 func TestMonitorAntiEntropy(t *testing.T) {
-	cluster := test.MustRunMainWithCluster(t, 3, test.OptAntiEntropyInterval(time.Millisecond*20))
+	cluster := test.MustRunMainWithCluster(t, 3, []server.CommandOption{test.OptAntiEntropyInterval(time.Millisecond * 20)})
 	client := cluster[1].Client()
 	err := client.CreateIndex(context.Background(), "balh", pilosa.IndexOptions{})
 	if err != nil {

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -38,6 +38,8 @@ import (
 type Main struct {
 	*server.Command
 
+	commandOptions []server.CommandOption
+
 	Stdin  bytes.Buffer
 	Stdout bytes.Buffer
 	Stderr bytes.Buffer
@@ -64,7 +66,7 @@ func NewMain(opts ...server.CommandOption) *Main {
 		panic(err)
 	}
 
-	m := &Main{Command: server.NewCommand(os.Stdin, os.Stdout, os.Stderr, opts...)}
+	m := &Main{Command: server.NewCommand(os.Stdin, os.Stdout, os.Stderr, opts...), commandOptions: opts}
 	m.Config.DataDir = path
 	m.Config.Bind = "http://localhost:0"
 	m.Config.Cluster.Disabled = true
@@ -156,7 +158,7 @@ func (m *Main) Reopen() error {
 
 	// Create new main with the same config.
 	config := m.Command.Config
-	m.Command = server.NewCommand(os.Stdin, os.Stdout, os.Stderr, server.OptCommandServerOptions(m.ServerOptions...))
+	m.Command = server.NewCommand(os.Stdin, os.Stdout, os.Stderr, m.commandOptions...)
 	m.Command.Config = config
 	err := m.SetupServer()
 	if err != nil {


### PR DESCRIPTION
## Overview

This adds functional options for for server.Command so that ServerOptions can be injected. Refactored existing MainOpts to use ServerOptions instead. Used in TranslateStore tests for mock injection. This will allow us to remove the TranslateStore from the API struct.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
