### PR TITLE
continue simplifying memberset and pilosa setup

### DIFF
--- a/broadcast.go
+++ b/broadcast.go
@@ -27,7 +27,7 @@ import (
 type MemberSet interface {
 	// Open starts any network activity implemented by the MemberSet
 	// Node is the local node, used for membership broadcasts.
-	Open(n *Node) error
+	Open() error
 }
 
 // StaticMemberSet represents a basic MemberSet for testing.
@@ -43,7 +43,7 @@ func NewStaticMemberSet(nodes []*Node) *StaticMemberSet {
 }
 
 // Open implements the MemberSet interface to start network activity, but for a static MemberSet it does nothing.
-func (s *StaticMemberSet) Open(n *Node) error {
+func (s *StaticMemberSet) Open() error {
 	return nil
 }
 

--- a/cluster.go
+++ b/cluster.go
@@ -861,7 +861,7 @@ func (h *jmphasher) Hash(key uint64, n int) int {
 	return int(b)
 }
 
-func (c *Cluster) open() error {
+func (c *Cluster) setup() error {
 	// Cluster always comes up in state STARTING until cluster membership is determined.
 	c.state = ClusterStateStarting
 
@@ -876,7 +876,7 @@ func (c *Cluster) open() error {
 	if c.isCoordinator() {
 		err := c.considerTopology()
 		if err != nil {
-			return fmt.Errorf("considerTopology: %v", err)
+			return errors.Wrap(err, "considerTopology")
 		}
 	}
 
@@ -885,10 +885,21 @@ func (c *Cluster) open() error {
 	if err != nil {
 		return errors.Wrap(err, "adding local node")
 	}
+	return nil
+}
 
+func (c *Cluster) open() error {
+	err := c.setup()
+	if err != nil {
+		return errors.Wrap(err, "setting up cluster")
+	}
+	return c.waitForStarted()
+}
+
+func (c *Cluster) waitForStarted() error {
 	// Open MemberSet communication.
-	if err := c.MemberSet.Open(c.Node); err != nil {
-		return fmt.Errorf("opening MemberSet: %v", err)
+	if err := c.MemberSet.Open(); err != nil {
+		return errors.Wrap(err, "opening MemberSet")
 	}
 
 	// If not coordinator then wait for ClusterStatus from coordinator.

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/pilosa/pilosa/internal"
+	"github.com/pkg/errors"
 )
 
 // Ensure that fragCombos creates the correct fragment mapping.
@@ -591,10 +592,10 @@ func TestCluster_ResizeStates(t *testing.T) {
 		tc.WriteTopology(node.Path, top)
 
 		// Open TestCluster.
-		expected := "considerTopology: coordinator node0 is not in topology: [some-other-host]"
+		expected := "coordinator node0 is not in topology: [some-other-host]"
 		err := tc.Open()
-		if err == nil || err.Error() != expected {
-			t.Errorf("did not receive expected error: %s", expected)
+		if err == nil || errors.Cause(err).Error() != expected {
+			t.Errorf("did not receive expected error, got: %s", errors.Cause(err).Error())
 		}
 
 		// Close TestCluster.

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -196,13 +196,6 @@ func (m *Main) RunWithTransport(host string, bindPort int, joinSeeds []string) (
 	   - SetupNetworking (does the gossip or static stuff) - calls NewTransport
 	   - Open server - calls OpenListener
 	*/
-
-	// SetupServer
-	err = m.SetupServer()
-	if err != nil {
-		return seed, err
-	}
-
 	// Open gossip transport to use in SetupServer.
 	transport, err := gossip.NewTransport(host, bindPort, nil)
 	if err != nil {
@@ -215,16 +208,20 @@ func (m *Main) RunWithTransport(host string, bindPort int, joinSeeds []string) (
 	} else {
 		m.Config.Gossip.Seeds = []string{transport.URI.String()}
 	}
-
 	seed = transport.URI.String()
+
+	// SetupServer
+	m.Config.Cluster.Disabled = false
+	err = m.SetupServer()
+	if err != nil {
+		return seed, err
+	}
 
 	// SetupNetworking
 	err = m.SetupNetworking()
 	if err != nil {
 		return seed, err
 	}
-
-	m.Server.Cluster.Static = false
 
 	go func() {
 		err := m.Handler.Serve()


### PR DESCRIPTION
## Overview

since the gossip MemberSet has access to Server, it wasn't really necessary to
pass it a Node object when calling Open on it from Cluster. The end goal is to
have it be removed from Cluster entirely, and have it be Opened externally, and
this is a step toward that.

Exposing Node method on Server doesn't really expose any more than was already
there as the same info can be gotten from LocalStatus with a bit of type
casting. I figured adding the method was a little cleaner, and we could collapse
all the functionality when the dust has settled.

The Cluster.open method has been broken into two parts - one of which happens
earlier (at NewServer time), and the other will eventually just be "waiting to
make sure we've joined the cluster". Right now it's calling Memberset.Open, and
then waiting to make sure the cluster has been joined.

partially addresses #1247 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
