### PR TITLE
Fix TestTranslateStore_Reader tests

### DIFF
--- a/api.go
+++ b/api.go
@@ -48,7 +48,7 @@ type APIOption func(*API) error
 func OptAPIServer(s *Server) APIOption {
 	return func(a *API) error {
 		a.server = s
-		a.TranslateStore = s.translateFile
+		a.TranslateStore = s.primaryTranslateStore
 		a.Holder = s.holder
 		a.Broadcaster = s
 		a.Cluster = s.Cluster


### PR DESCRIPTION
## Overview

Fix TestTranslateStore_Reader tests. They were left non-working after refactoring to use `test.MustRunMainWithCluster`, so this gets them working again.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
