### PR TITLE
move internal http endpoints under /internal

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -232,7 +232,7 @@ Note: This will only work when the replication factor is >= 2
   - List of all indexes on your cluster
   - List of all frames in your indexes
   - Max slice per index, listed in the `/slices/max` endpoint
-- With this information you can query the `/fragment/nodes` endpoint and iterate over each slice
+- With this information you can query the `/internal/fragment/nodes` endpoint and iterate over each slice
 - Using the list of slices owned by this node you will then need to manually:
   - setup a directory structure similar to the other nodes with a path for each Index/Frame
   - copy each owned slice for an existing node to this new node

--- a/http/client.go
+++ b/http/client.go
@@ -81,7 +81,7 @@ func (c *InternalClient) MaxShardByIndex(ctx context.Context) (map[string]uint64
 // maxShardByIndex returns the number of shards on a server by index.
 func (c *InternalClient) maxShardByIndex(ctx context.Context) (map[string]uint64, error) {
 	// Execute request against the host.
-	u := uriPathToURL(c.defaultURI, "/shards/max")
+	u := uriPathToURL(c.defaultURI, "/internal/shards/max")
 
 	// Build request.
 	req, err := http.NewRequest("GET", u.String(), nil)
@@ -187,7 +187,7 @@ func (c *InternalClient) CreateIndex(ctx context.Context, index string, opt pilo
 // FragmentNodes returns a list of nodes that own a shard.
 func (c *InternalClient) FragmentNodes(ctx context.Context, index string, shard uint64) ([]*pilosa.Node, error) {
 	// Execute request against the host.
-	u := uriPathToURL(c.defaultURI, "/fragment/nodes")
+	u := uriPathToURL(c.defaultURI, "/internal/fragment/nodes")
 	u.RawQuery = (url.Values{"index": {index}, "shard": {strconv.FormatUint(shard, 10)}}).Encode()
 
 	// Build request.
@@ -675,7 +675,7 @@ func (c *InternalClient) FragmentBlocks(ctx context.Context, uri *pilosa.URI, in
 	if uri == nil {
 		uri = c.defaultURI
 	}
-	u := uriPathToURL(uri, "/fragment/blocks")
+	u := uriPathToURL(uri, "/internal/fragment/blocks")
 	u.RawQuery = url.Values{
 		"index": {index},
 		"field": {field},
@@ -730,7 +730,7 @@ func (c *InternalClient) BlockData(ctx context.Context, uri *pilosa.URI, index, 
 		return nil, nil, errors.Wrap(err, "marshaling")
 	}
 
-	u := uriPathToURL(uri, "/fragment/block/data")
+	u := uriPathToURL(uri, "/internal/fragment/block/data")
 	req, err := http.NewRequest("GET", u.String(), bytes.NewReader(buf))
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "creating request")
@@ -770,7 +770,7 @@ func (c *InternalClient) ColumnAttrDiff(ctx context.Context, uri *pilosa.URI, in
 	if uri == nil {
 		uri = c.defaultURI
 	}
-	u := uriPathToURL(uri, fmt.Sprintf("/index/%s/attr/diff", index))
+	u := uriPathToURL(uri, fmt.Sprintf("/internal/index/%s/attr/diff", index))
 
 	// Encode request.
 	buf, err := json.Marshal(postIndexAttrDiffRequest{Blocks: blks})
@@ -814,7 +814,7 @@ func (c *InternalClient) RowAttrDiff(ctx context.Context, uri *pilosa.URI, index
 	if uri == nil {
 		uri = c.defaultURI
 	}
-	u := uriPathToURL(uri, fmt.Sprintf("/index/%s/field/%s/attr/diff", index, field))
+	u := uriPathToURL(uri, fmt.Sprintf("/internal/index/%s/field/%s/attr/diff", index, field))
 
 	// Encode request.
 	buf, err := json.Marshal(postFieldAttrDiffRequest{Blocks: blks})
@@ -862,7 +862,7 @@ func (c *InternalClient) SendMessage(ctx context.Context, uri *pilosa.URI, pb pr
 		return fmt.Errorf("marshaling message: %v", err)
 	}
 
-	u := uriPathToURL(uri, "/cluster/message")
+	u := uriPathToURL(uri, "/internal/cluster/message")
 	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(msg))
 	if err != nil {
 		return errors.Wrap(err, "making new request")

--- a/http/translator.go
+++ b/http/translator.go
@@ -54,7 +54,7 @@ func (s *TranslateStore) Reader(ctx context.Context, off int64) (io.ReadCloser, 
 	if err != nil {
 		return nil, err
 	}
-	u.Path = "/translate/data"
+	u.Path = "/internal/translate/data"
 	u.RawQuery = (url.Values{
 		"offset": {strconv.FormatInt(off, 10)},
 	}).Encode()

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -124,7 +124,7 @@ func TestHandler_Endpoints(t *testing.T) {
 
 	t.Run("Max Shard", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		h.ServeHTTP(w, test.MustNewHTTPRequest("GET", "/shards/max", nil))
+		h.ServeHTTP(w, test.MustNewHTTPRequest("GET", "/internal/shards/max", nil))
 		if w.Code != gohttp.StatusOK {
 			t.Fatalf("unexpected status code: %d", w.Code)
 		} else if body := w.Body.String(); body != `{"standard":{"i0":3,"i1":0}}`+"\n" {
@@ -436,7 +436,7 @@ func TestHandler_Endpoints(t *testing.T) {
 		// Send block checksums to determine diff.
 		req := test.MustNewHTTPRequest(
 			"POST",
-			"/index/i/attr/diff",
+			"/internal/index/i/attr/diff",
 			strings.NewReader(`{"blocks":`+string(test.MustMarshalJSON(blks))+`}`),
 		)
 		req.Header.Set("Content-Type", "application/json")
@@ -476,7 +476,7 @@ func TestHandler_Endpoints(t *testing.T) {
 		// Send block checksums to determine diff.
 		req := test.MustNewHTTPRequest(
 			"POST",
-			"/index/i/field/meta/attr/diff",
+			"/internal/index/i/field/meta/attr/diff",
 			strings.NewReader(`{"blocks":`+string(test.MustMarshalJSON(blks))+`}`),
 		)
 		req.Header.Set("Content-Type", "application/json")
@@ -507,7 +507,7 @@ func TestHandler_Endpoints(t *testing.T) {
 
 	t.Run("Fragment Nodes", func(t *testing.T) {
 		w := httptest.NewRecorder()
-		r := test.MustNewHTTPRequest("GET", "/fragment/nodes?index=i&shard=0", nil)
+		r := test.MustNewHTTPRequest("GET", "/internal/fragment/nodes?index=i&shard=0", nil)
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusOK {
 			t.Fatalf("unexpected status code: %d", w.Code)
@@ -520,7 +520,7 @@ func TestHandler_Endpoints(t *testing.T) {
 
 		// invalid argument should return BadRequest
 		w = httptest.NewRecorder()
-		r = test.MustNewHTTPRequest("GET", "/fragment/nodes?db=X&shard=0", nil)
+		r = test.MustNewHTTPRequest("GET", "/internal/fragment/nodes?db=X&shard=0", nil)
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusBadRequest {
 			t.Fatalf("unexpected status code: %d", w.Code)
@@ -528,7 +528,7 @@ func TestHandler_Endpoints(t *testing.T) {
 
 		// index is required
 		w = httptest.NewRecorder()
-		r = test.MustNewHTTPRequest("GET", "/fragment/nodes?shard=0", nil)
+		r = test.MustNewHTTPRequest("GET", "/internal/fragment/nodes?shard=0", nil)
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusBadRequest {
 			t.Fatalf("unexpected status code: %d", w.Code)


### PR DESCRIPTION
## Overview

This PR addresses the `internal` part of #1371.
The portion pertaining to import consolidation is a bit more involved, so I'm treating that separately.

