### PR TITLE
consolidate import and import-value endpoints

### DIFF
--- a/api.go
+++ b/api.go
@@ -277,6 +277,19 @@ func (api *API) CreateField(ctx context.Context, indexName string, fieldName str
 	return field, nil
 }
 
+// Field retrieves the named field.
+func (api *API) Field(ctx context.Context, indexName, fieldName string) (*Field, error) {
+	if err := api.validate(apiField); err != nil {
+		return nil, errors.Wrap(err, "validating api method")
+	}
+
+	field := api.holder.Field(indexName, fieldName)
+	if field == nil {
+		return nil, NewNotFoundError(ErrFieldNotFound)
+	}
+	return field, nil
+}
+
 // DeleteField removes the named field from the named index. If the index is not
 // found, an error is returned. If the field is not found, it is ignored and no
 // action is taken.
@@ -866,6 +879,7 @@ const (
 	apiExportCSV
 	apiFragmentBlockData
 	apiFragmentBlocks
+	apiField
 	apiFieldAttrDiff
 	//apiHosts // not implemented
 	apiImport
@@ -909,6 +923,7 @@ var methodsNormal = map[apiMethod]struct{}{
 	apiExportCSV:         struct{}{},
 	apiFragmentBlockData: struct{}{},
 	apiFragmentBlocks:    struct{}{},
+	apiField:             struct{}{},
 	apiFieldAttrDiff:     struct{}{},
 	apiImport:            struct{}{},
 	apiImportValue:       struct{}{},

--- a/apimethod_string.go
+++ b/apimethod_string.go
@@ -4,9 +4,9 @@ package pilosa
 
 import "strconv"
 
-const _apiMethod_name = "apiClusterMessageapiCreateFieldapiCreateIndexapiDeleteFieldapiDeleteIndexapiDeleteViewapiExportCSVapiFragmentBlockDataapiFragmentBlocksapiFieldAttrDiffapiImportapiImportValueapiIndexapiIndexAttrDiffapiMarshalFragmentapiQueryapiRecalculateCachesapiRemoveNodeapiResizeAbortapiSetCoordinatorapiShardNodesapiUnmarshalFragmentapiViews"
+const _apiMethod_name = "apiClusterMessageapiCreateFieldapiCreateIndexapiDeleteFieldapiDeleteIndexapiDeleteViewapiExportCSVapiFragmentBlockDataapiFragmentBlocksapiFieldapiFieldAttrDiffapiImportapiImportValueapiIndexapiIndexAttrDiffapiMarshalFragmentapiQueryapiRecalculateCachesapiRemoveNodeapiResizeAbortapiSetCoordinatorapiShardNodesapiUnmarshalFragmentapiViews"
 
-var _apiMethod_index = [...]uint16{0, 17, 31, 45, 59, 73, 86, 98, 118, 135, 151, 160, 174, 182, 198, 216, 224, 244, 257, 271, 288, 301, 321, 329}
+var _apiMethod_index = [...]uint16{0, 17, 31, 45, 59, 73, 86, 98, 118, 135, 143, 159, 168, 182, 190, 206, 224, 232, 252, 265, 279, 296, 309, 329, 337}
 
 func (i apiMethod) String() string {
 	if i < 0 || i >= apiMethod(len(_apiMethod_index)-1) {

--- a/http/client.go
+++ b/http/client.go
@@ -445,7 +445,7 @@ func (c *InternalClient) ImportValue(ctx context.Context, index, field string, s
 
 	// Import to each node.
 	for _, node := range nodes {
-		if err := c.importValueNode(ctx, node, index, field, buf); err != nil {
+		if err := c.importNode(ctx, node, index, field, buf); err != nil {
 			return fmt.Errorf("import node: host=%s, err=%s", node.URI, err)
 		}
 	}
@@ -471,45 +471,6 @@ func marshalImportValuePayload(index, field string, shard uint64, vals []pilosa.
 		return nil, fmt.Errorf("marshal import request: %s", err)
 	}
 	return buf, nil
-}
-
-// importValueNode sends a pre-marshaled import request to a node.
-func (c *InternalClient) importValueNode(ctx context.Context, node *pilosa.Node, index, field string, buf []byte) error {
-	// Create URL & HTTP request.
-	path := fmt.Sprintf("/index/%s/field/%s/import", index, field)
-	u := nodePathToURL(node, path)
-	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(buf))
-	if err != nil {
-		return errors.Wrap(err, "creating request")
-	}
-	req.Header.Set("Content-Length", strconv.Itoa(len(buf)))
-	req.Header.Set("Content-Type", "application/x-protobuf")
-	req.Header.Set("Accept", "application/x-protobuf")
-	req.Header.Set("User-Agent", "pilosa/"+pilosa.Version)
-
-	// Execute request against the host.
-	resp, err := c.HTTPClient.Do(req.WithContext(ctx))
-	if err != nil {
-		return errors.Wrap(err, "executing request")
-	}
-	defer resp.Body.Close()
-
-	// Read body and unmarshal response.
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return errors.Wrap(err, "reading")
-	} else if resp.StatusCode != http.StatusOK {
-		return errors.New(string(body))
-	}
-
-	var isresp internal.ImportResponse
-	if err := proto.Unmarshal(body, &isresp); err != nil {
-		return fmt.Errorf("unmarshal import response: %s", err)
-	} else if s := isresp.Err; s != "" {
-		return errors.New(s)
-	}
-
-	return nil
 }
 
 // ExportCSV bulk exports data for a single shard from a host to CSV format.

--- a/http/client.go
+++ b/http/client.go
@@ -293,7 +293,7 @@ func (c *InternalClient) Import(ctx context.Context, index, field string, shard 
 
 	// Import to each node.
 	for _, node := range nodes {
-		if err := c.importNode(ctx, node, buf); err != nil {
+		if err := c.importNode(ctx, node, index, field, buf); err != nil {
 			return fmt.Errorf("import node: host=%s, err=%s", node.URI, err)
 		}
 	}
@@ -319,7 +319,7 @@ func (c *InternalClient) ImportK(ctx context.Context, index, field string, colum
 	}
 
 	// Import to node.
-	if err := c.importNode(ctx, node, buf); err != nil {
+	if err := c.importNode(ctx, node, index, field, buf); err != nil {
 		return fmt.Errorf("import node: host=%s, err=%s", node.URI, err)
 	}
 
@@ -386,9 +386,10 @@ func marshalImportPayloadK(index, field string, bits []pilosa.Bit) ([]byte, erro
 }
 
 // importNode sends a pre-marshaled import request to a node.
-func (c *InternalClient) importNode(ctx context.Context, node *pilosa.Node, buf []byte) error {
+func (c *InternalClient) importNode(ctx context.Context, node *pilosa.Node, index, field string, buf []byte) error {
 	// Create URL & HTTP request.
-	u := nodePathToURL(node, "/import")
+	path := fmt.Sprintf("/index/%s/field/%s/import", index, field)
+	u := nodePathToURL(node, path)
 	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(buf))
 	if err != nil {
 		return errors.Wrap(err, "creating request")
@@ -444,7 +445,7 @@ func (c *InternalClient) ImportValue(ctx context.Context, index, field string, s
 
 	// Import to each node.
 	for _, node := range nodes {
-		if err := c.importValueNode(ctx, node, buf); err != nil {
+		if err := c.importValueNode(ctx, node, index, field, buf); err != nil {
 			return fmt.Errorf("import node: host=%s, err=%s", node.URI, err)
 		}
 	}
@@ -473,9 +474,10 @@ func marshalImportValuePayload(index, field string, shard uint64, vals []pilosa.
 }
 
 // importValueNode sends a pre-marshaled import request to a node.
-func (c *InternalClient) importValueNode(ctx context.Context, node *pilosa.Node, buf []byte) error {
+func (c *InternalClient) importValueNode(ctx context.Context, node *pilosa.Node, index, field string, buf []byte) error {
 	// Create URL & HTTP request.
-	u := nodePathToURL(node, "/import-value")
+	path := fmt.Sprintf("/index/%s/field/%s/import", index, field)
+	u := nodePathToURL(node, path)
 	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(buf))
 	if err != nil {
 		return errors.Wrap(err, "creating request")


### PR DESCRIPTION
## Overview

This PR consolidates the `/import` and `/import-value` http endpoints into a single `/index/{index}/field/{field}/import` endpoint.

Fixes #1371 

