### PR TITLE
ensure /schema excludes views and includes all field options (like "keys")

### DIFF
--- a/api.go
+++ b/api.go
@@ -477,8 +477,14 @@ func (api *API) ClusterMessage(ctx context.Context, reqBody io.Reader) error {
 }
 
 // Schema returns information about each index in Pilosa including which fields
+// they contain.
+func (api *API) Schema(ctx context.Context) []*IndexInfo {
+	return api.holder.Schema()
+}
+
+// Indexes returns all indexes in Pilosa including which fields
 // and views they contain.
-func (api *API) Schema(ctx context.Context) []*Index {
+func (api *API) Indexes(ctx context.Context) []*Index {
 	return api.holder.Indexes()
 }
 

--- a/field.go
+++ b/field.go
@@ -1094,9 +1094,9 @@ func (f *Field) ImportValue(columnIDs []uint64, values []int64) error {
 
 func (f *Field) MarshalJSON() ([]byte, error) {
 	thing := struct {
-		Name    string
-		Options fieldOptions
-		Views   []*viewInfo
+		Name    string       `json:"name"`
+		Options fieldOptions `json:"options"`
+		Views   []*viewInfo  `json:"views"`
 	}{
 		Name:    f.Name(),
 		Options: f.Options(),
@@ -1153,7 +1153,7 @@ type fieldOptions struct {
 	Min         int64       `json:"min,omitempty"`
 	Max         int64       `json:"max,omitempty"`
 	TimeQuantum TimeQuantum `json:"timeQuantum,omitempty"`
-	Keys        bool        `json:"keys,omitempty"`
+	Keys        bool        `json:"keys"`
 }
 
 // applyDefaultOptions returns a new fieldOptions object
@@ -1211,28 +1211,34 @@ func (o *fieldOptions) MarshalJSON() ([]byte, error) {
 			Type      string `json:"type"`
 			CacheType string `json:"cacheType"`
 			CacheSize uint32 `json:"cacheSize"`
+			Keys      bool   `json:"keys"`
 		}{
 			o.Type,
 			o.CacheType,
 			o.CacheSize,
+			o.Keys,
 		})
 	case FieldTypeInt:
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			Min  int64  `json:"min"`
 			Max  int64  `json:"max"`
+			Keys bool   `json:"keys"`
 		}{
 			o.Type,
 			o.Min,
 			o.Max,
+			o.Keys,
 		})
 	case FieldTypeTime:
 		return json.Marshal(struct {
 			Type        string      `json:"type"`
 			TimeQuantum TimeQuantum `json:"timeQuantum"`
+			Keys        bool        `json:"keys"`
 		}{
 			o.Type,
 			o.TimeQuantum,
+			o.Keys,
 		})
 	}
 	return nil, errors.New("invalid field type")

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -251,7 +251,7 @@ func (g *GossipMemberSet) LocalState(join bool) []byte {
 	pb := &internal.NodeStatus{
 		Node:      pilosa.EncodeNode(g.papi.Node()),
 		MaxShards: &internal.MaxShards{Standard: g.papi.MaxShards(context.Background())},
-		Schema:    &internal.Schema{Indexes: pilosa.EncodeIndexes(g.papi.Schema(context.Background()))},
+		Schema:    &internal.Schema{Indexes: pilosa.EncodeIndexes(g.papi.Indexes(context.Background()))},
 	}
 
 	// Marshal nodestate data to bytes.

--- a/http/handler.go
+++ b/http/handler.go
@@ -465,7 +465,7 @@ func (h *Handler) handleGetIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	indexName := mux.Vars(r)["index"]
 	for _, idx := range h.API.Schema(r.Context()) {
-		if idx.Name() == indexName {
+		if idx.Name == indexName {
 			if err := json.NewEncoder(w).Encode(idx); err != nil {
 				h.Logger.Printf("write response error: %s", err)
 			}

--- a/index.go
+++ b/index.go
@@ -83,11 +83,13 @@ func (i *Index) MarshalJSON() ([]byte, error) {
 		fields = append(fields, f)
 	}
 	thing := struct {
-		Name   string
-		Fields []*Field
+		Name    string       `json:"name"`
+		Options IndexOptions `json:"options"`
+		Fields  []*Field     `json:"fields"`
 	}{
-		Name:   i.name,
-		Fields: fields,
+		Name:    i.name,
+		Options: i.Options(),
+		Fields:  fields,
 	}
 	return json.Marshal(thing)
 }
@@ -422,8 +424,9 @@ func (p indexSlice) Less(i, j int) bool { return p[i].Name() < p[j].Name() }
 
 // IndexInfo represents schema information for an index.
 type IndexInfo struct {
-	Name   string       `json:"name"`
-	Fields []*FieldInfo `json:"fields"`
+	Name    string       `json:"name"`
+	Options IndexOptions `json:"options"`
+	Fields  []*FieldInfo `json:"fields"`
 }
 
 type indexInfoSlice []*IndexInfo


### PR DESCRIPTION
## Overview

This PR ensures that `views` are excluded from external calls to `/schema`.
It also adds `API.Indexes()` for use by the `gossip` package.
Finally, it adds the `keys` field option in schema output.

Fixes #1349 