### PR TITLE
ensure /schema excludes views and includes all field options (like "keys")

### DIFF
--- a/api.go
+++ b/api.go
@@ -482,9 +482,9 @@ func (api *API) ClusterMessage(ctx context.Context, reqBody io.Reader) error {
 }
 
 // Schema returns information about each index in Pilosa including which fields
-// and views they contain.
-func (api *API) Schema(ctx context.Context) []*Index {
-	return api.holder.Indexes()
+// they contain.
+func (api *API) Schema(ctx context.Context) []*IndexInfo {
+	return api.holder.limitedSchema()
 }
 
 // Views returns the views in the given field.

--- a/field.go
+++ b/field.go
@@ -1094,9 +1094,9 @@ func (f *Field) ImportValue(columnIDs []uint64, values []int64) error {
 
 func (f *Field) MarshalJSON() ([]byte, error) {
 	thing := struct {
-		Name    string
-		Options FieldOptions
-		Views   []*ViewInfo
+		Name    string       `json:"name"`
+		Options FieldOptions `json:"options"`
+		Views   []*ViewInfo  `json:"views"`
 	}{
 		Name:    f.Name(),
 		Options: f.Options(),
@@ -1134,7 +1134,7 @@ type FieldOptions struct {
 	Min         int64       `json:"min,omitempty"`
 	Max         int64       `json:"max,omitempty"`
 	TimeQuantum TimeQuantum `json:"timeQuantum,omitempty"`
-	Keys        bool        `json:"keys,omitempty"`
+	Keys        bool        `json:"keys"`
 }
 
 // applyDefaultOptions returns a new FieldOptions object
@@ -1177,28 +1177,34 @@ func (o *FieldOptions) MarshalJSON() ([]byte, error) {
 			Type      string `json:"type"`
 			CacheType string `json:"cacheType"`
 			CacheSize uint32 `json:"cacheSize"`
+			Keys      bool   `json:"keys"`
 		}{
 			o.Type,
 			o.CacheType,
 			o.CacheSize,
+			o.Keys,
 		})
 	case FieldTypeInt:
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			Min  int64  `json:"min"`
 			Max  int64  `json:"max"`
+			Keys bool   `json:"keys"`
 		}{
 			o.Type,
 			o.Min,
 			o.Max,
+			o.Keys,
 		})
 	case FieldTypeTime:
 		return json.Marshal(struct {
 			Type        string      `json:"type"`
 			TimeQuantum TimeQuantum `json:"timeQuantum"`
+			Keys        bool        `json:"keys"`
 		}{
 			o.Type,
 			o.TimeQuantum,
+			o.Keys,
 		})
 	}
 	return nil, errors.New("invalid field type")

--- a/holder.go
+++ b/holder.go
@@ -228,6 +228,22 @@ func (h *Holder) Schema() []*IndexInfo {
 	return a
 }
 
+// limitedSchema returns schema information for all indexes and fields.
+func (h *Holder) limitedSchema() []*IndexInfo {
+	var a []*IndexInfo
+	for _, index := range h.Indexes() {
+		di := &IndexInfo{Name: index.Name()}
+		for _, field := range index.Fields() {
+			fi := &FieldInfo{Name: field.Name(), Options: field.Options()}
+			di.Fields = append(di.Fields, fi)
+		}
+		sort.Sort(fieldInfoSlice(di.Fields))
+		a = append(a, di)
+	}
+	sort.Sort(indexInfoSlice(a))
+	return a
+}
+
 // applySchema applies an internal Schema to Holder.
 func (h *Holder) applySchema(schema *Schema) error {
 	// Create indexes that don't exist.

--- a/http/handler.go
+++ b/http/handler.go
@@ -463,7 +463,7 @@ func (h *Handler) handleGetIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	indexName := mux.Vars(r)["index"]
 	for _, idx := range h.API.Schema(r.Context()) {
-		if idx.Name() == indexName {
+		if idx.Name == indexName {
 			if err := json.NewEncoder(w).Encode(idx); err != nil {
 				h.Logger.Printf("write response error: %s", err)
 			}

--- a/index.go
+++ b/index.go
@@ -83,11 +83,13 @@ func (i *Index) MarshalJSON() ([]byte, error) {
 		fields = append(fields, f)
 	}
 	thing := struct {
-		Name   string
-		Fields []*Field
+		Name    string       `json:"name"`
+		Options IndexOptions `json:"options"`
+		Fields  []*Field     `json:"fields"`
 	}{
-		Name:   i.name,
-		Fields: fields,
+		Name:    i.name,
+		Options: i.Options(),
+		Fields:  fields,
 	}
 	return json.Marshal(thing)
 }
@@ -422,8 +424,9 @@ func (p indexSlice) Less(i, j int) bool { return p[i].Name() < p[j].Name() }
 
 // IndexInfo represents schema information for an index.
 type IndexInfo struct {
-	Name   string       `json:"name"`
-	Fields []*FieldInfo `json:"fields"`
+	Name    string       `json:"name"`
+	Options IndexOptions `json:"options"`
+	Fields  []*FieldInfo `json:"fields"`
 }
 
 type indexInfoSlice []*IndexInfo


### PR DESCRIPTION
## Overview

This PR ensures that `views` are excluded from external calls to `/schema`.
It also adds the `keys` field option in schema output.

Fixes #1349 