### PR TITLE
Fix test

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -1579,7 +1579,7 @@ func (e *executor) translateCall(index string, idx *Index, c *pql.Call) error {
 		if field == nil {
 			// Instead of returning ErrFieldNotFound here,
 			// we just return, and don't attempt the translation.
-			// The assumption is that the non-existant field
+			// The assumption is that the non-existent field
 			// will raise an error downstream when it's used.
 			return nil
 		}

--- a/executor.go
+++ b/executor.go
@@ -1059,6 +1059,16 @@ func (e *executor) executeClearBitField(ctx context.Context, index string, c *pq
 
 // executeSet executes a Set() call.
 func (e *executor) executeSet(ctx context.Context, index string, c *pql.Call, opt *execOptions) (bool, error) {
+
+	// Read colID.
+	colID, ok, err := c.UintArg("_" + columnLabel)
+	if err != nil {
+		return false, fmt.Errorf("reading Set() column: %v", err)
+	} else if !ok {
+		return false, fmt.Errorf("Set() column argument '%v' required", columnLabel)
+	}
+
+	// Read field name.
 	fieldName, err := c.FieldArg()
 	if err != nil {
 		return false, errors.New("Set() argument required: field")
@@ -1072,14 +1082,6 @@ func (e *executor) executeSet(ctx context.Context, index string, c *pql.Call, op
 	f := idx.Field(fieldName)
 	if f == nil {
 		return false, ErrFieldNotFound
-	}
-
-	// Read colID using labels.
-	colID, ok, err := c.UintArg("_" + columnLabel)
-	if err != nil {
-		return false, fmt.Errorf("reading Set() column: %v", err)
-	} else if !ok {
-		return false, fmt.Errorf("Set() column argument '%v' required", columnLabel)
 	}
 
 	if f.Type() == FieldTypeInt {
@@ -1575,7 +1577,11 @@ func (e *executor) translateCall(index string, idx *Index, c *pql.Call) error {
 	if fieldName != "" {
 		field := idx.Field(fieldName)
 		if field == nil {
-			return ErrFieldNotFound
+			// Instead of returning ErrFieldNotFound here,
+			// we just return, and don't attempt the translation.
+			// The assumption is that the non-existant field
+			// will raise an error downstream when it's used.
+			return nil
 		}
 		if field.keys() {
 			if c.Args[rowKey] != nil && !isString(c.Args[rowKey]) {

--- a/executor_test.go
+++ b/executor_test.go
@@ -440,7 +440,7 @@ func TestExecutor_Execute_SetValue(t *testing.T) {
 		}
 
 		t.Run("ErrColumnBSIGroupRequired", func(t *testing.T) {
-			if _, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Set(invalid_column_name=10, f=100)`}); err == nil || errors.Cause(err).Error() != `field not found` {
+			if _, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Set(invalid_column_name=10, f=100)`}); err == nil || errors.Cause(err).Error() != `Set() column argument 'col' required` {
 				t.Fatalf("unexpected error: %s", err)
 			}
 		})

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -336,7 +336,7 @@ func TestHandler_Endpoints(t *testing.T) {
 		h.ServeHTTP(w, test.MustNewHTTPRequest("POST", "/index/i0/query", strings.NewReader(`Row(row=30)`)))
 		if w.Code != gohttp.StatusBadRequest {
 			t.Fatalf("unexpected status code: %d", w.Code)
-		} else if body := w.Body.String(); body != `{"error":"executing: field not found"}`+"\n" {
+		} else if body := w.Body.String(); body != `{"error":"executing: map reduce: field not found"}`+"\n" {
 			t.Fatalf("unexpected body: %q", body)
 		}
 	})
@@ -353,7 +353,7 @@ func TestHandler_Endpoints(t *testing.T) {
 		var resp pilosa.QueryResponse
 		if err := cmd.API.Serializer.Unmarshal(w.Body.Bytes(), &resp); err != nil {
 			t.Fatal(err)
-		} else if s := resp.Err.Error(); s != `executing: field not found` {
+		} else if s := resp.Err.Error(); s != `executing: map reduce: field not found` {
 			t.Fatalf("unexpected error: %s", s)
 		}
 	})


### PR DESCRIPTION
## Overview

This test was failing with a different error depending on the order of the `call.Args` map. I removed the error being raised in `translateCall()` and assume that it will be handled appropriately downstream.

