### PR TITLE
rename gossip.NewGossipMemberSet to gossip.NewMemberSet

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -317,7 +317,7 @@ func (m *Command) setupNetworking() error {
 		return errors.Wrap(err, "getting transport")
 	}
 
-	gossipMemberSet, err := gossip.NewGossipMemberSet(
+	gossipMemberSet, err := gossip.NewMemberSet(
 		m.Config.Gossip,
 		m.API,
 		gossip.WithLogger(m.logger.Logger()),


### PR DESCRIPTION
This PR renames `gossip.NewGossipMemberSet` to `gossip.NewMemberSet`.
It also removes the `gossip` from several internal names.