### PR TITLE
make sure time range views are calculated correctly across months

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -1279,7 +1279,7 @@ func TestExecutor_Time_Clear_Quantums(t *testing.T) {
 		expected []uint64
 	}{
 		{quantum: "Y", expected: []uint64{3, 4, 5, 6}},
-		{quantum: "M", expected: []uint64{3, 4, 6}},
+		{quantum: "M", expected: []uint64{3, 4, 5, 6}},
 		{quantum: "D", expected: []uint64{3, 4, 5, 6}},
 		{quantum: "H", expected: []uint64{3, 4, 5, 6, 7}},
 		{quantum: "YM", expected: []uint64{3, 4, 5, 6}},

--- a/time.go
+++ b/time.go
@@ -140,7 +140,7 @@ func viewsByTimeRange(name string, start, end time.Time, q TimeQuantum) []string
 					break
 				} else if t.Month() != 1 {
 					results = append(results, viewByTimeUnit(name, t, 'M'))
-					t = t.AddDate(0, 1, 0)
+					t = addMonth(t)
 					continue
 				}
 			}
@@ -159,7 +159,7 @@ func viewsByTimeRange(name string, start, end time.Time, q TimeQuantum) []string
 			t = t.AddDate(1, 0, 0)
 		} else if hasMonth && nextMonthGTE(t, end) {
 			results = append(results, viewByTimeUnit(name, t, 'M'))
-			t = t.AddDate(0, 1, 0)
+			t = addMonth(t)
 		} else if hasDay && nextDayGTE(t, end) {
 			results = append(results, viewByTimeUnit(name, t, 'D'))
 			t = t.AddDate(0, 0, 1)
@@ -172,6 +172,19 @@ func viewsByTimeRange(name string, start, end time.Time, q TimeQuantum) []string
 	}
 
 	return results
+}
+
+// addMonth adds a month similar to time.AddDate(0, 1, 0), but
+// in certain edge cases it doesn't normalize for days late in the month.
+// In the "YM" case where t.Day is greater than 28, there are
+// edge cases where using time.AddDate() to add a month will result
+// in two "months" being added (Jan 31 + 1mo = March 2).
+func addMonth(t time.Time) time.Time {
+	if t.Day() > 28 {
+		t = time.Date(t.Year(), t.Month(), 1, t.Hour(), 0, 0, 0, t.Location())
+	}
+	t = t.AddDate(0, 1, 0)
+	return t
 }
 
 func nextYearGTE(t time.Time, end time.Time) bool {

--- a/time_internal_test.go
+++ b/time_internal_test.go
@@ -97,6 +97,24 @@ func TestViewsByTimeRange(t *testing.T) {
 			t.Fatalf("unexpected fields: %#v", a)
 		}
 	})
+	t.Run("YM31up", func(t *testing.T) {
+		a := viewsByTimeRange("F", mustParseTime("2001-10-31 00:00"), mustParseTime("2003-04-01 00:00"), mustParseTimeQuantum("YM"))
+		if !reflect.DeepEqual(a, []string{"F_200110", "F_200111", "F_200112", "F_2002", "F_200301", "F_200302", "F_200303"}) {
+			t.Fatalf("unexpected fields: %#v", a)
+		}
+	})
+	t.Run("YM31mid", func(t *testing.T) {
+		a := viewsByTimeRange("F", mustParseTime("1999-12-31 00:00"), mustParseTime("2000-04-01 00:00"), mustParseTimeQuantum("YM"))
+		if !reflect.DeepEqual(a, []string{"F_199912", "F_200001", "F_200002", "F_200003"}) {
+			t.Fatalf("unexpected fields: %#v", a)
+		}
+	})
+	t.Run("YM31down", func(t *testing.T) {
+		a := viewsByTimeRange("F", mustParseTime("2000-01-31 00:00"), mustParseTime("2001-04-01 00:00"), mustParseTimeQuantum("YM"))
+		if !reflect.DeepEqual(a, []string{"F_2000", "F_200101", "F_200102", "F_200103"}) {
+			t.Fatalf("unexpected fields: %#v", a)
+		}
+	})
 	t.Run("YMD", func(t *testing.T) {
 		a := viewsByTimeRange("F", mustParseTime("2000-11-28 00:00"), mustParseTime("2003-03-02 00:00"), mustParseTimeQuantum("YMD"))
 		if !reflect.DeepEqual(a, []string{"F_20001128", "F_20001129", "F_20001130", "F_200012", "F_2001", "F_2002", "F_200301", "F_200302", "F_20030301"}) {


### PR DESCRIPTION
## Overview

This PR adjusts the `viewsByTimeRange()` function to avoid date normalization problems in "YM" time quantum cases. 

Fixes #1436

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
