### PR TITLE
add a configurable timeout to http handler closing

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -111,7 +111,7 @@ func OptHandlerListener(ln net.Listener) handlerOption {
 	}
 }
 
-// OptHandlerCloseTimeout controls how long we'll wait for the http Server to
+// OptHandlerCloseTimeout controls how long to wait for the http Server to
 // shutdown cleanly before forcibly destroying it. Default is 30 seconds.
 func OptHandlerCloseTimeout(d time.Duration) handlerOption {
 	return func(h *Handler) error {

--- a/server.go
+++ b/server.go
@@ -386,7 +386,7 @@ func (s *Server) Close() error {
 	// some way to combine all the errors, but probably not important enough to
 	// warrant the extra complexity.
 	if errh != nil {
-		return errors.Wrap(errh, "closing handler")
+		return errors.Wrap(errh, "closing holder")
 	} else if errt != nil {
 		return errors.Wrap(errt, "closing translateFile")
 	}

--- a/server.go
+++ b/server.go
@@ -381,14 +381,14 @@ func (s *Server) Close() error {
 	if s.translateFile != nil {
 		errt = s.translateFile.Close()
 	}
-	// prefer to return handler error over translateFile error over cluster
+	// prefer to return holder error over translateFile error over cluster
 	// error. This order is somewhat arbitrary. It would be better if we had
 	// some way to combine all the errors, but probably not important enough to
 	// warrant the extra complexity.
 	if errh != nil {
 		return errors.Wrap(errh, "closing handler")
 	} else if errt != nil {
-		return errors.Wrap(errt, "closing translatFile")
+		return errors.Wrap(errt, "closing translateFile")
 	}
 	return errors.Wrap(errc, "closing cluster")
 }

--- a/server.go
+++ b/server.go
@@ -369,17 +369,28 @@ func (s *Server) Close() error {
 	close(s.closing)
 	s.wg.Wait()
 
+	var errh error
+	var errt error
+	var errc error
 	if s.cluster != nil {
-		s.cluster.close()
+		errc = s.cluster.close()
 	}
 	if s.holder != nil {
-		s.holder.Close()
+		errh = s.holder.Close()
 	}
 	if s.translateFile != nil {
-		s.translateFile.Close()
+		errt = s.translateFile.Close()
 	}
-
-	return nil
+	// prefer to return handler error over translateFile error over cluster
+	// error. This order is somewhat arbitrary. It would be better if we had
+	// some way to combine all the errors, but probably not important enough to
+	// warrant the extra complexity.
+	if errh != nil {
+		return errors.Wrap(errh, "closing handler")
+	} else if errt != nil {
+		return errors.Wrap(errt, "closing translatFile")
+	}
+	return errors.Wrap(errc, "closing cluster")
 }
 
 // loadNodeID gets NodeID from disk, or creates a new value.

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pilosa/pilosa/http"
 	"github.com/pilosa/pilosa/server"
@@ -55,6 +56,11 @@ func newCommand(opts ...server.CommandOption) *Command {
 		panic(err)
 	}
 
+	// set aggressive close timeout by default to avoid hanging tests. This was
+	// a probably with PDK tests which used go-pilosa as well. We put it at the
+	// beginning of the option slice so that it can be overridden by an
+	// user-passed options.
+	opts = append([]server.CommandOption{server.OptCommandCloseTimeout(time.Millisecond * 2)}, opts...)
 	m := &Command{Command: server.NewCommand(os.Stdin, os.Stdout, os.Stderr, opts...), commandOptions: opts}
 	m.Config.DataDir = path
 	m.Config.Bind = "http://localhost:0"

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -57,9 +57,9 @@ func newCommand(opts ...server.CommandOption) *Command {
 	}
 
 	// set aggressive close timeout by default to avoid hanging tests. This was
-	// a probably with PDK tests which used go-pilosa as well. We put it at the
-	// beginning of the option slice so that it can be overridden by an
-	// user-passed options.
+	// a problem with PDK tests which used go-pilosa as well. We put it at the
+	// beginning of the option slice so that it can be overridden by user-passed
+	// options.
 	opts = append([]server.CommandOption{server.OptCommandCloseTimeout(time.Millisecond * 2)}, opts...)
 	m := &Command{Command: server.NewCommand(os.Stdin, os.Stdout, os.Stderr, opts...), commandOptions: opts}
 	m.Config.DataDir = path


### PR DESCRIPTION
refactor handler Close func to use errgroup to be a bit less messy.

refactor pilosa.Server closing to actually return an underlying error if one occurs

add option to pilosa/test.Cluster and pilosa/server.Command to control close
timeout. currently is only used by the http handler, but conceivably could be
passed as a parameter to other subsystems of pilosa/server.Command

Fixes: pdk tests were hanging due to the soft shutdown w/o timeout in http handler.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
