### PR TITLE
Support keys on import CLI.

### DIFF
--- a/api.go
+++ b/api.go
@@ -609,9 +609,29 @@ func (api *API) Import(ctx context.Context, req *ImportRequest) error {
 		return errors.Wrap(err, "validating api method")
 	}
 
-	_, field, err := api.indexField(req.Index, req.Field, req.Shard)
+	index, field, err := api.indexField(req.Index, req.Field, req.Shard)
 	if err != nil {
 		return errors.Wrap(err, "getting field")
+	}
+
+	// Translate row keys.
+	if field.keys() {
+		if len(req.RowIDs) != 0 {
+			return errors.New("row ids cannot be used because field uses string keys")
+		}
+		if req.RowIDs, err = api.server.translateFile.TranslateRowsToUint64(index.Name(), field.Name(), req.RowKeys); err != nil {
+			return errors.Wrap(err, "translating rows")
+		}
+	}
+
+	// Translate column keys.
+	if index.Keys() {
+		if len(req.ColumnIDs) != 0 {
+			return errors.New("column ids cannot be used because index uses string keys")
+		}
+		if req.ColumnIDs, err = api.server.translateFile.TranslateColumnsToUint64(index.Name(), req.ColumnKeys); err != nil {
+			return errors.Wrap(err, "translating columns")
+		}
 	}
 
 	// Convert timestamps to time.Time.

--- a/client.go
+++ b/client.go
@@ -18,8 +18,9 @@ type Bit struct {
 // FieldValue represents the value for a column within a
 // range-encoded field.
 type FieldValue struct {
-	ColumnID uint64
-	Value    int64
+	ColumnID  uint64
+	ColumnKey string
+	Value     int64
 }
 
 // InternalClient should be implemented by any struct that enables any transport between nodes

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -54,7 +54,6 @@ omitted. If it is present then its format should be YYYY-MM-DDTHH:MM.
 	flags.StringVarP(&Importer.Host, "host", "", "localhost:10101", "host:port of Pilosa.")
 	flags.StringVarP(&Importer.Index, "index", "i", "", "Pilosa index to import into.")
 	flags.StringVarP(&Importer.Field, "field", "f", "", "Field to import into.")
-	flags.BoolVar(&Importer.StringKeys, "string-keys", false, "Treat payload as string keys.")
 	flags.IntVarP(&Importer.BufferSize, "buffer-size", "s", 10000000, "Number of bits to buffer/sort before importing.")
 	flags.BoolVarP(&Importer.Sort, "sort", "", false, "Enables sorting before import.")
 	flags.BoolVarP(&Importer.CreateSchema, "create", "e", false, "Create the schema if it does not exist before import.")

--- a/holder.go
+++ b/holder.go
@@ -232,7 +232,7 @@ func (h *Holder) Schema() []*IndexInfo {
 func (h *Holder) limitedSchema() []*IndexInfo {
 	var a []*IndexInfo
 	for _, index := range h.Indexes() {
-		di := &IndexInfo{Name: index.Name()}
+		di := &IndexInfo{Name: index.Name(), Options: index.Options()}
 		for _, field := range index.Fields() {
 			fi := &FieldInfo{Name: field.Name(), Options: field.Options()}
 			di.Fields = append(di.Fields, fi)

--- a/index.go
+++ b/index.go
@@ -95,7 +95,7 @@ func (i *Index) Options() IndexOptions {
 }
 
 func (i *Index) options() IndexOptions {
-	return IndexOptions{}
+	return IndexOptions{Keys: i.keys}
 }
 
 // Open opens and initializes the index.
@@ -406,7 +406,7 @@ func (p indexSlice) Less(i, j int) bool { return p[i].Name() < p[j].Name() }
 // IndexInfo represents schema information for an index.
 type IndexInfo struct {
 	Name    string       `json:"name"`
-	options IndexOptions `json:"options"`
+	Options IndexOptions `json:"options"`
 	Fields  []*FieldInfo `json:"fields"`
 }
 


### PR DESCRIPTION
## Overview

This pull request adds support for specifying string keys with `pilosa import`. There was an existing partial implementation but it did not work and required both the index and field to use string keys.

Keys are translated server-side so performance will be limited by the translation file speed. Previous tests show the speed to be quite high though.

## Usage

Given an index `i`, a field `f`, and the following `data.csv` file: 

```
FOO,BAR
FOO,BAZ
```

The import can be run using the normal import command:

```sh
$ pilosa import -i i -f f data.csv
```

---

Fixes #1488

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
