### PR TITLE
Add IndexOptions to IndexInfo json response

### DIFF
--- a/holder.go
+++ b/holder.go
@@ -232,7 +232,7 @@ func (h *Holder) Schema() []*IndexInfo {
 func (h *Holder) limitedSchema() []*IndexInfo {
 	var a []*IndexInfo
 	for _, index := range h.Indexes() {
-		di := &IndexInfo{Name: index.Name()}
+		di := &IndexInfo{Name: index.Name(), Options: index.Options()}
 		for _, field := range index.Fields() {
 			fi := &FieldInfo{Name: field.Name(), Options: field.Options()}
 			di.Fields = append(di.Fields, fi)

--- a/http/handler_internal_test.go
+++ b/http/handler_internal_test.go
@@ -31,6 +31,7 @@ func TestPostIndexRequestUnmarshalJSON(t *testing.T) {
 		err      string
 	}{
 		{json: `{"options": {}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{}}},
+		{json: `{"options": {"keys": true}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{true}}},
 		{json: `{"options": 4}`, err: "options is not map[string]interface{}"},
 		{json: `{"option": {}}`, err: "Unknown key: option:map[]"},
 		{json: `{"options": {"badKey": "test"}}`, err: "Unknown key: badKey:test"},

--- a/http/handler_internal_test.go
+++ b/http/handler_internal_test.go
@@ -31,7 +31,7 @@ func TestPostIndexRequestUnmarshalJSON(t *testing.T) {
 		err      string
 	}{
 		{json: `{"options": {}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{}}},
-		{json: `{"options": {"keys": true}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{true}}},
+		{json: `{"options": {"keys": true}}`, expected: postIndexRequest{Options: pilosa.IndexOptions{Keys: true}}},
 		{json: `{"options": 4}`, err: "options is not map[string]interface{}"},
 		{json: `{"option": {}}`, err: "Unknown key: option:map[]"},
 		{json: `{"options": {"badKey": "test"}}`, err: "Unknown key: badKey:test"},

--- a/index.go
+++ b/index.go
@@ -95,7 +95,7 @@ func (i *Index) Options() IndexOptions {
 }
 
 func (i *Index) options() IndexOptions {
-	return IndexOptions{i.keys}
+	return IndexOptions{Keys: i.keys}
 }
 
 // Open opens and initializes the index.

--- a/index.go
+++ b/index.go
@@ -95,7 +95,7 @@ func (i *Index) Options() IndexOptions {
 }
 
 func (i *Index) options() IndexOptions {
-	return IndexOptions{}
+	return IndexOptions{i.keys}
 }
 
 // Open opens and initializes the index.
@@ -406,7 +406,7 @@ func (p indexSlice) Less(i, j int) bool { return p[i].Name() < p[j].Name() }
 // IndexInfo represents schema information for an index.
 type IndexInfo struct {
 	Name    string       `json:"name"`
-	options IndexOptions `json:"options"`
+	Options IndexOptions `json:"options"`
 	Fields  []*FieldInfo `json:"fields"`
 }
 


### PR DESCRIPTION
This adds IndexOptions to responses that serialize IndexInfo, including /schema, /index, and /index/{index}.

This came up during discussion on #1540.