### PR TITLE
fix places where empty IndexOptions were being used

### DIFF
--- a/holder.go
+++ b/holder.go
@@ -248,8 +248,7 @@ func (h *Holder) limitedSchema() []*IndexInfo {
 func (h *Holder) applySchema(schema *Schema) error {
 	// Create indexes that don't exist.
 	for _, index := range schema.Indexes {
-		opt := IndexOptions{}
-		idx, err := h.CreateIndexIfNotExists(index.Name, opt)
+		idx, err := h.CreateIndexIfNotExists(index.Name, index.Options)
 		if err != nil {
 			return errors.Wrap(err, "creating index")
 		}

--- a/server.go
+++ b/server.go
@@ -457,8 +457,8 @@ func (s *Server) receiveMessage(m Message) error {
 		}
 		idx.setRemoteMaxShard(obj.Shard)
 	case *CreateIndexMessage:
-		opt := IndexOptions{}
-		_, err := s.holder.CreateIndex(obj.Index, opt)
+		opt := obj.Meta
+		_, err := s.holder.CreateIndex(obj.Index, *opt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Overview

When we removed `IndexOptions` earlier, we stubbed out the places it was being used with `IndexOptions{}`. This PR replaces two of those cases.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
