### PR TITLE
Treat coordinator as primary translate store.

### DIFF
--- a/api.go
+++ b/api.go
@@ -136,9 +136,9 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 		}
 
 		// Translate column attributes, if necessary.
-		if api.server.holder.translateFile != nil {
+		if api.holder.translateFile != nil {
 			for _, col := range resp.ColumnAttrSets {
-				v, err := api.server.holder.translateFile.TranslateColumnToString(req.Index, col.ID)
+				v, err := api.holder.translateFile.TranslateColumnToString(req.Index, col.ID)
 				if err != nil {
 					return resp, err
 				}
@@ -764,7 +764,7 @@ func (api *API) ResizeAbort() error {
 
 // GetTranslateData provides a reader for key translation logs starting at offset.
 func (api *API) GetTranslateData(ctx context.Context, offset int64) (io.ReadCloser, error) {
-	rc, err := api.server.holder.translateFile.Reader(ctx, offset)
+	rc, err := api.holder.translateFile.Reader(ctx, offset)
 	if err != nil {
 		return nil, errors.Wrap(err, "read from translate store")
 	}

--- a/api.go
+++ b/api.go
@@ -136,9 +136,9 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 		}
 
 		// Translate column attributes, if necessary.
-		if api.server.translateFile != nil {
+		if api.server.holder.translateFile != nil {
 			for _, col := range resp.ColumnAttrSets {
-				v, err := api.server.translateFile.TranslateColumnToString(req.Index, col.ID)
+				v, err := api.server.holder.translateFile.TranslateColumnToString(req.Index, col.ID)
 				if err != nil {
 					return resp, err
 				}
@@ -764,7 +764,7 @@ func (api *API) ResizeAbort() error {
 
 // GetTranslateData provides a reader for key translation logs starting at offset.
 func (api *API) GetTranslateData(ctx context.Context, offset int64) (io.ReadCloser, error) {
-	rc, err := api.server.translateFile.Reader(ctx, offset)
+	rc, err := api.server.holder.translateFile.Reader(ctx, offset)
 	if err != nil {
 		return nil, errors.Wrap(err, "read from translate store")
 	}

--- a/cluster.go
+++ b/cluster.go
@@ -169,7 +169,7 @@ type nodeAction struct {
 type cluster struct { // nolint: maligned
 	id    string
 	Node  *Node
-	Nodes []*Node // TODO phase this out?
+	Nodes []*Node
 
 	// Hashing algorithm used to assign partitions to nodes.
 	Hasher Hasher
@@ -935,7 +935,6 @@ func (c *cluster) allNodesReady() (ret bool) {
 }
 
 func (c *cluster) handleNodeAction(nodeAction nodeAction) error {
-
 	c.mu.Lock()
 	j, err := c.unprotectedGenerateResizeJob(nodeAction)
 	c.mu.Unlock()
@@ -959,7 +958,7 @@ func (c *cluster) handleNodeAction(nodeAction nodeAction) error {
 	c.logger.Printf("wait for jobResult")
 	jobResult := <-j.result
 
-	// Make sure j.Run() didn't return an error.
+	// Make sure j.run() didn't return an error.
 	if eg.Wait() != nil {
 		return errors.Wrap(err, "running job")
 	}
@@ -1779,11 +1778,33 @@ func (c *cluster) mergeClusterStatus(cs *ClusterStatus) error {
 		}
 	}
 
+	// If the cluster membership has changed, reset the primary for
+	// translate store replication.
+	c.holder.setPrimaryTranslateStore(c.unprotectedPreviousNode())
+
 	c.unprotectedSetState(cs.State)
 
 	c.markAsJoined()
 
 	return nil
+}
+
+// unprotectedPreviousNode returns the node listed before the current node in c.Nodes.
+// If there is only one node in the cluster, returns nil.
+// If the current node is the first node in the list, returns the last node.
+func (c *cluster) unprotectedPreviousNode() *Node {
+	if len(c.Nodes) <= 1 {
+		return nil
+	}
+
+	pos := c.nodePositionByID(c.Node.ID)
+	if pos == -1 {
+		return nil
+	} else if pos == 0 {
+		return c.Nodes[len(c.Nodes)-1]
+	} else {
+		return c.Nodes[pos-1]
+	}
 }
 
 // setStatic is unprotected, but only called before the cluster has been started

--- a/cluster_internal_test.go
+++ b/cluster_internal_test.go
@@ -449,6 +449,60 @@ func TestCluster_Nodes(t *testing.T) {
 	})
 }
 
+func TestCluster_PreviousNode(t *testing.T) {
+	node0 := &Node{ID: "node0"}
+	node1 := &Node{ID: "node1"}
+	node2 := &Node{ID: "node2"}
+
+	t.Run("OneNode", func(t *testing.T) {
+		c := newCluster()
+		c.addNodeBasicSorted(node0)
+
+		c.Node = node0
+		if prev := c.unprotectedPreviousNode(); prev != nil {
+			t.Errorf("expected: nil, but got: %v", prev)
+		}
+	})
+
+	t.Run("TwoNode", func(t *testing.T) {
+		c := newCluster()
+		c.addNodeBasicSorted(node0)
+		c.addNodeBasicSorted(node1)
+
+		c.Node = node0
+		if prev := c.unprotectedPreviousNode(); prev != node1 {
+			t.Errorf("expected: node1, but got: %v", prev)
+		}
+
+		c.Node = node1
+		if prev := c.unprotectedPreviousNode(); prev != node0 {
+			t.Errorf("expected: node0, but got: %v", prev)
+		}
+	})
+
+	t.Run("ThreeNode", func(t *testing.T) {
+		c := newCluster()
+		c.addNodeBasicSorted(node0)
+		c.addNodeBasicSorted(node1)
+		c.addNodeBasicSorted(node2)
+
+		c.Node = node0
+		if prev := c.unprotectedPreviousNode(); prev != node2 {
+			t.Errorf("expected: node2, but got: %v", prev)
+		}
+
+		c.Node = node1
+		if prev := c.unprotectedPreviousNode(); prev != node0 {
+			t.Errorf("expected: node0, but got: %v", prev)
+		}
+
+		c.Node = node2
+		if prev := c.unprotectedPreviousNode(); prev != node1 {
+			t.Errorf("expected: node1, but got: %v", prev)
+		}
+	})
+}
+
 // NEXT: move this test to internal and unexport IsCoordinator
 func TestCluster_Coordinator(t *testing.T) {
 	uri1 := NewTestURIFromHostPort("node1", 0)

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -44,7 +44,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.DurationVarP((*time.Duration)(&srv.Config.Cluster.LongQueryTime), "cluster.long-query-time", "", time.Minute, "Duration that will trigger log and stat messages for slow queries.")
 
 	// Translation
-	flags.StringVarP(&srv.Config.Translation.PrimaryURL, "translation.primary-url", "", srv.Config.Translation.PrimaryURL, "URL for primary translation node for replication.")
+	flags.StringVarP(&srv.Config.Translation.PrimaryURL, "translation.primary-url", "", srv.Config.Translation.PrimaryURL, "DEPRECATED: URL for primary translation node for replication.")
 
 	// Gossip
 	flags.StringVarP(&srv.Config.Gossip.Port, "gossip.port", "", srv.Config.Gossip.Port, "Port to which pilosa should bind for internal state sharing.")

--- a/holder.go
+++ b/holder.go
@@ -46,6 +46,10 @@ type Holder struct {
 	// Indexes by name.
 	indexes map[string]*Index
 
+	// Key/ID translation
+	translateFile            *TranslateFile
+	NewPrimaryTranslateStore func(*Node) TranslateStore
+
 	// opened channel is closed once Open() completes.
 	opened chan struct{}
 
@@ -76,6 +80,9 @@ func NewHolder() *Holder {
 		closing: make(chan struct{}),
 
 		opened: make(chan struct{}),
+
+		translateFile:            NewTranslateFile(),
+		NewPrimaryTranslateStore: newNopTranslateStore,
 
 		broadcaster: NopBroadcaster,
 		Stats:       NopStatsClient,
@@ -160,6 +167,13 @@ func (h *Holder) Close() error {
 			return errors.Wrap(err, "closing index")
 		}
 	}
+
+	if h.translateFile != nil {
+		if err := h.translateFile.Close(); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -558,6 +572,14 @@ func (h *Holder) logStartup() error {
 	}
 
 	return nil
+}
+
+func (h *Holder) setPrimaryTranslateStore(node *Node) {
+	var nodeID string
+	if node != nil {
+		nodeID = node.ID
+	}
+	h.translateFile.SetPrimaryStore(nodeID, h.NewPrimaryTranslateStore(node))
 }
 
 // holderSyncer is an active anti-entropy tool that compares the local holder

--- a/holder.go
+++ b/holder.go
@@ -48,7 +48,7 @@ type Holder struct {
 
 	// Key/ID translation
 	translateFile            *TranslateFile
-	NewPrimaryTranslateStore func(*Node) TranslateStore
+	NewPrimaryTranslateStore func(interface{}) TranslateStore
 
 	// opened channel is closed once Open() completes.
 	opened chan struct{}

--- a/http/translator.go
+++ b/http/translator.go
@@ -19,12 +19,17 @@ var _ pilosa.TranslateStore = (*translateStore)(nil)
 // translateStore represents an implementation of pilosa.TranslateStore that
 // communicates over HTTP. This is used with the TranslateHandler.
 type translateStore struct {
-	URL string
+	node *pilosa.Node
 }
 
-// NewTranslateStore returns a new instance of TranslateStore.
-func NewTranslateStore(rawurl string) *translateStore {
-	return &translateStore{URL: rawurl}
+// DEPRECATED: NewTranslateStore returns a new instance of translateStore.
+func NewTranslateStore(rawurl string) *translateStore { // nolint: unparam
+	return &translateStore{node: nil}
+}
+
+// NewNodeTranslateStore returns a new instance of TranslateStore based on node.
+func NewNodeTranslateStore(node *pilosa.Node) pilosa.TranslateStore {
+	return &translateStore{node: node}
 }
 
 // TranslateColumnsToUint64 is not currently implemented.
@@ -50,7 +55,7 @@ func (s *translateStore) TranslateRowToString(index, frame string, values uint64
 // Reader returns a reader that can stream data from a remote store.
 func (s *translateStore) Reader(ctx context.Context, off int64) (io.ReadCloser, error) {
 	// Generate remote URL.
-	u, err := url.Parse(s.URL)
+	u, err := url.Parse(s.node.URI.String())
 	if err != nil {
 		return nil, err
 	}

--- a/server.go
+++ b/server.go
@@ -168,7 +168,7 @@ func OptServerPrimaryTranslateStore(store TranslateStore) ServerOption {
 	}
 }
 
-func OptServerPrimaryTranslateStoreFunc(tf func(*Node) TranslateStore) ServerOption {
+func OptServerPrimaryTranslateStoreFunc(tf func(interface{}) TranslateStore) ServerOption {
 	return func(s *Server) error {
 		s.holder.NewPrimaryTranslateStore = tf
 		return nil

--- a/server/config.go
+++ b/server/config.go
@@ -71,7 +71,7 @@ type Config struct {
 	// Gossip config is based around memberlist.Config.
 	Gossip gossip.Config `toml:"gossip"`
 
-	// Translation config supports translation store replication.
+	// DEPRECATED: Translation config supports translation store replication.
 	Translation struct {
 		PrimaryURL string `toml:"primary-url"`
 	} `toml:"translation"`

--- a/server/server.go
+++ b/server/server.go
@@ -250,10 +250,9 @@ func (m *Command) SetupServer() error {
 
 	c := http.GetHTTPClient(TLSConfig)
 
-	// Setup connection to primary store if this is a replica.
-	var primaryTranslateStore pilosa.TranslateStore
+	// Primary store configuration is handled automatically now.
 	if m.Config.Translation.PrimaryURL != "" {
-		primaryTranslateStore = http.NewTranslateStore(m.Config.Translation.PrimaryURL)
+		m.logger.Printf("DEPRECATED: The primary-url configuration option is no longer used.")
 	}
 
 	// Set Coordinator.
@@ -278,7 +277,7 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerStatsClient(statsClient),
 		pilosa.OptServerURI(uri),
 		pilosa.OptServerInternalClient(http.NewInternalClientFromURI(uri, c)),
-		pilosa.OptServerPrimaryTranslateStore(primaryTranslateStore),
+		pilosa.OptServerPrimaryTranslateStoreFunc(http.NewNodeTranslateStore),
 		pilosa.OptServerClusterDisabled(m.Config.Cluster.Disabled, m.Config.Cluster.Hosts),
 		pilosa.OptServerSerializer(proto.Serializer{}),
 		coordinatorOpt,

--- a/server/server.go
+++ b/server/server.go
@@ -277,7 +277,7 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerStatsClient(statsClient),
 		pilosa.OptServerURI(uri),
 		pilosa.OptServerInternalClient(http.NewInternalClientFromURI(uri, c)),
-		pilosa.OptServerPrimaryTranslateStoreFunc(http.NewNodeTranslateStore),
+		pilosa.OptServerPrimaryTranslateStoreFunc(http.NewTranslateStore),
 		pilosa.OptServerClusterDisabled(m.Config.Cluster.Disabled, m.Config.Cluster.Hosts),
 		pilosa.OptServerSerializer(proto.Serializer{}),
 		coordinatorOpt,

--- a/translate.go
+++ b/translate.go
@@ -1083,7 +1083,7 @@ var nopTStore TranslateStore = nopTranslateStore{}
 
 // newNopTranslateStore returns a translate store which does nothing. It returns a global
 // object to avoid unnecessary allocations.
-func newNopTranslateStore(*Node) TranslateStore { return nopTStore }
+func newNopTranslateStore(interface{}) TranslateStore { return nopTStore }
 
 // nopTranslateStore represents a no-op implementation of the TranslateStore interface.
 type nopTranslateStore struct{}

--- a/translate_test.go
+++ b/translate_test.go
@@ -383,7 +383,7 @@ func TestTranslateFile_PrimaryTranslateStore(t *testing.T) {
 
 	// Create a replica that accepts writes from primary.
 	replica := NewTranslateFile()
-	replica.PrimaryTranslateStore = primary
+	replica.SetPrimaryStore("primary", primary)
 	if err := replica.Open(); err != nil {
 		t.Fatal(err)
 	}
@@ -567,7 +567,7 @@ func (s *TranslateFile) Reopen() error {
 	s.TranslateFile = pilosa.NewTranslateFile()
 	s.lock.Unlock()
 	s.Path = prev.Path
-	s.PrimaryTranslateStore = prev.PrimaryTranslateStore
+	s.SetPrimaryStore("restored-primary", prev.PrimaryTranslateStore)
 	return s.Open()
 }
 


### PR DESCRIPTION
## Overview
This PR moves `translateFile` from `Server` to `Holder`.
Additionally, it uses `cluster.Coordinator` as the primary translate store for key replication.
Replication to multiple nodes are daisy-chained across the cluster: 
```
node0 (coordinator) -> node1 -> node2
```
In that example, if `node1` is removed, the replication on `node2` will cleanly stop, change its primary translate store to be `node0`, and start replication again.

This PR also deprecates the `translation.primary-url` configuration option.

Note that a couple of items have been left in for API stability even though they are no longer used. Marked here as `DEPRECATED`.

Fixes #1578

TODO:
- [x] Add tests
- [ ] Update docs

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
