### PR TITLE
Import key values

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,6 +42,7 @@ type InternalClient interface {
 	EnsureIndex(ctx context.Context, name string, options IndexOptions) error
 	EnsureField(ctx context.Context, indexName string, fieldName string) error
 	ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue) error
+	ImportValueK(ctx context.Context, index, field string, vals []FieldValue) error
 	ExportCSV(ctx context.Context, index, field string, shard uint64, w io.Writer) error
 	CreateField(ctx context.Context, index, field string) error
 	FragmentBlocks(ctx context.Context, uri *URI, index, field string, shard uint64) ([]FragmentBlock, error)
@@ -112,6 +113,9 @@ func (n nopInternalClient) EnsureField(ctx context.Context, indexName string, fi
 	return nil
 }
 func (n nopInternalClient) ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue) error {
+	return nil
+}
+func (n nopInternalClient) ImportValueK(ctx context.Context, index, field string, vals []FieldValue) error {
 	return nil
 }
 func (n nopInternalClient) ExportCSV(ctx context.Context, index, field string, shard uint64, w io.Writer) error {

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -890,6 +890,7 @@ func decodeRow(pr *internal.Row) *pilosa.Row {
 
 	r := pilosa.NewRow()
 	r.Attrs = decodeAttrs(pr.Attrs)
+	r.Keys = pr.Keys
 	for _, v := range pr.Columns {
 		r.SetBit(v)
 	}


### PR DESCRIPTION
## Overview

This PR adds support for importing into integer fields with column keys.
There was a bug in protobuf decoding of `pilosa.Row` which is addressed here as well.

Fixes #1594 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
