### PR TITLE
Require a valid port that isn't greater than 65,535

### DIFF
--- a/uri.go
+++ b/uri.go
@@ -173,6 +173,9 @@ func parseAddress(address string) (uri *URI, err error) {
 		if err != nil {
 			return nil, errors.New("converting port string to int")
 		}
+		if port > 65535 {
+			return nil, errors.New("port must be in range 0 - 65535")
+		}
 	}
 	uri = &URI{
 		Scheme: scheme,

--- a/uri_internal_test.go
+++ b/uri_internal_test.go
@@ -172,5 +172,5 @@ func validFixture() []uriItem {
 }
 
 func invalidFixture() []string {
-	return []string{"foo:bar", "http://foo:", "foo:", ":bar", "http://pilosa.com:129999999999999999999999993", "fd42:4201:f86b:7e09:216:3eff:fefa:ed80"}
+	return []string{"foo:bar", "http://foo:", "foo:", ":bar", "http://pilosa.com:129999999999999999999999993", "fd42:4201:f86b:7e09:216:3eff:fefa:ed80", ":65536"}
 }


### PR DESCRIPTION
## Overview

This change simply adds a check to make sure the port is valid.  Prior to this, any integer value was happily accepted (and a choice over 65,535 resulted in no error thrown).

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
