### PR TITLE
removing bounds check

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2136,15 +2136,26 @@ func intersectArrayBitmap(a, b *Container) *Container {
 }
 
 func intersectBitmapBitmap(a, b *Container) *Container {
-	output := &Container{bitmap: make([]uint64, bitmapN), containerType: containerBitmap}
+	var (
 
-	for i := range a.bitmap {
-		v := a.bitmap[i] & b.bitmap[i]
-		output.bitmap[i] = v
-		output.n += int(popcount(v))
+	ab = a.bitmap[:bitmapN]
+	bb = b.bitmap[:bitmapN]
+	buf = make([]uint64, bitmapN)
+	ob =buf[:bitmapN]
 
+	n int
+)
+	for i := 0; i < bitmapN; i++ {
+		v := ab[i] & bb[i]
+		ob[i] = v
+		n += int(popcount(v))
 	}
-	output.optimize()
+
+	output := &Container{
+		bitmap: ob,
+		n:      n,
+		containerType: containerBitmap,
+	}
 	return output
 }
 
@@ -2434,17 +2445,26 @@ func unionArrayBitmap(a, b *Container) *Container {
 }
 
 func unionBitmapBitmap(a, b *Container) *Container {
-	output := &Container{
-		bitmap:        make([]uint64, bitmapN),
-		containerType: containerBitmap,
-	}
+	var (
+		ab = a.bitmap[:bitmapN]
+		bb = b.bitmap[:bitmapN]
+		buf = make([]uint64, bitmapN)
+		ob =buf[:bitmapN]
+
+		n int
+	)
 
 	for i := 0; i < bitmapN; i++ {
-		v := a.bitmap[i] | b.bitmap[i]
-		output.bitmap[i] = v
-		output.n += int(popcount(v))
+		v := ab[i] | bb[i]
+		ob[i] = v
+		n += int(popcount(v))
 	}
 
+	output := &Container{
+		bitmap: ob,
+		n:      n,
+		containerType: containerBitmap,
+	}
 	return output
 }
 
@@ -2780,13 +2800,25 @@ func differenceBitmapArray(a, b *Container) *Container {
 }
 
 func differenceBitmapBitmap(a, b *Container) *Container {
-	output := &Container{bitmap: make([]uint64, bitmapN), containerType: containerBitmap}
+	var (
+		ab = a.bitmap[:bitmapN]
+		bb = b.bitmap[:bitmapN]
+		buf = make([]uint64, bitmapN)
+		ob =buf[:bitmapN]
 
-	for i := range a.bitmap {
-		v := a.bitmap[i] & (^b.bitmap[i])
-		output.bitmap[i] = v
-		output.n += int(popcount(v))
+		n int
+	)
 
+	for i := 0; i < bitmapN; i++ {
+		v := ab[i] & (^bb[i])
+		ob[i] = v
+		n += int(popcount(v))
+	}
+
+	output := &Container{
+		bitmap: ob,
+		n:      n,
+		containerType: containerBitmap,
 	}
 	if output.n < ArrayMaxSize {
 		output.bitmapToArray()
@@ -2871,16 +2903,26 @@ func xorArrayBitmap(a, b *Container) *Container {
 }
 
 func xorBitmapBitmap(a, b *Container) *Container {
-	output := &Container{
-		bitmap:        make([]uint64, bitmapN),
-		containerType: containerBitmap,
-	}
+	var (
+		ab = a.bitmap[:bitmapN]
+		bb = b.bitmap[:bitmapN]
+		buf = make([]uint64, bitmapN)
+		ob =buf[:bitmapN]
+
+		n int
+	)
+
 	for i := 0; i < bitmapN; i++ {
-		v := a.bitmap[i] ^ b.bitmap[i]
-		output.bitmap[i] = v
-		output.n += int(popcount(v))
+		v := ab[i] ^ bb[i]
+		ob[i] = v
+		n += int(popcount(v))
 	}
 
+	output := &Container{
+		bitmap: ob,
+		n:      n,
+		containerType: containerBitmap,
+	}
 	if output.count() < ArrayMaxSize {
 		output.bitmapToArray()
 	}
@@ -3333,9 +3375,16 @@ func popcount(x uint64) uint64 {
 }
 
 func popcountAndSlice(s, m []uint64) uint64 {
+	var (
+		a=s[:bitmapN]
+		b=m[:bitmapN]
+	)
+	_ = a[bitmapN-1]
+	_ = b[bitmapN-1]
+	
 	cnt := uint64(0)
-	for i := range s {
-		cnt += popcount(s[i] & m[i])
+	for i:=0;i<bitmapN ;i++ {
+		cnt += popcount(a[i] & b[i])
 	}
 	return cnt
 }

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -782,11 +782,11 @@ func TestDifferenceMixed(t *testing.T) {
 		t.Fatalf("test #3 expected empty but got %v", res.runs)
 	}
 
-	c.bitmap = []uint64{0x64}
+	c.bitmap = MakeBitmap([]uint64{0x64})
 	c.n = c.countRange(0, 100)
 	c.containerType = containerBitmap
 	res = difference(c, a)
-	if !reflect.DeepEqual(res.bitmap, []uint64{0x4}) {
+	if !reflect.DeepEqual(res.bitmap, MakeBitmap([]uint64{0x4})) {
 		t.Fatalf("test #4 expected %v, but got %v", []uint16{4}, res.bitmap)
 	}
 


### PR DESCRIPTION
## Overview

Picked up some new goodness at gophercon 2018. so I added  some hints in order to remove bounds check (BCE)

`BenchmarkBitmap_Union-8                             3748          2890          -22.89%
BenchmarkBitmap_Intersect-8                         3752          2859          -23.80%
BenchmarkBitmap_Difference-8                        3853          2964          -23.07%`