### PR TITLE
Adds --field-keys and --index-keys options to pilosa import

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,10 +41,12 @@ type InternalClient interface {
 	ImportK(ctx context.Context, index, field string, bits []Bit) error
 	EnsureIndex(ctx context.Context, name string, options IndexOptions) error
 	EnsureField(ctx context.Context, indexName string, fieldName string) error
+	EnsureFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error
 	ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue) error
 	ImportValueK(ctx context.Context, index, field string, vals []FieldValue) error
 	ExportCSV(ctx context.Context, index, field string, shard uint64, w io.Writer) error
 	CreateField(ctx context.Context, index, field string) error
+	CreateFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error
 	FragmentBlocks(ctx context.Context, uri *URI, index, field, view string, shard uint64) ([]FragmentBlock, error)
 	BlockData(ctx context.Context, uri *URI, index, field, view string, shard uint64, block int) ([]uint64, []uint64, error)
 	ColumnAttrDiff(ctx context.Context, uri *URI, index string, blks []AttrBlock) (map[uint64]map[string]interface{}, error)
@@ -112,6 +114,9 @@ func (n nopInternalClient) EnsureIndex(ctx context.Context, name string, options
 func (n nopInternalClient) EnsureField(ctx context.Context, indexName string, fieldName string) error {
 	return nil
 }
+func (n nopInternalClient) EnsureFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error {
+	return nil
+}
 func (n nopInternalClient) ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue) error {
 	return nil
 }
@@ -122,6 +127,9 @@ func (n nopInternalClient) ExportCSV(ctx context.Context, index, field string, s
 	return nil
 }
 func (n nopInternalClient) CreateField(ctx context.Context, index, field string) error { return nil }
+func (n nopInternalClient) CreateFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error {
+	return nil
+}
 func (n nopInternalClient) FragmentBlocks(ctx context.Context, uri *URI, index, field, view string, shard uint64) ([]FragmentBlock, error) {
 	return nil, nil
 }

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -51,7 +51,6 @@ omitted. If it is present then its format should be YYYY-MM-DDTHH:MM.
 	flags.StringVarP(&Importer.Host, "host", "", "localhost:10101", "host:port of Pilosa.")
 	flags.StringVarP(&Importer.Index, "index", "i", "", "Pilosa index to import into.")
 	flags.StringVarP(&Importer.Field, "field", "f", "", "Field to import into.")
-	flags.BoolVar(&Importer.StringKeys, "string-keys", false, "REMOVED (key type is now determined by index/field configuration): Treat payload as string keys.")
 	flags.BoolVar(&Importer.IndexKeys, "index-keys", false, "use keys=true when creating an index")
 	flags.BoolVar(&Importer.FieldKeys, "field-keys", false, "use keys=true when creating a field")
 	flags.IntVarP(&Importer.BufferSize, "buffer-size", "s", 10000000, "Number of bits to buffer/sort before importing.")

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -52,6 +52,8 @@ omitted. If it is present then its format should be YYYY-MM-DDTHH:MM.
 	flags.StringVarP(&Importer.Index, "index", "i", "", "Pilosa index to import into.")
 	flags.StringVarP(&Importer.Field, "field", "f", "", "Field to import into.")
 	flags.BoolVar(&Importer.StringKeys, "string-keys", false, "REMOVED (key type is now determined by index/field configuration): Treat payload as string keys.")
+	flags.BoolVar(&Importer.IndexKeys, "index-keys", false, "use keys=true when creating an index")
+	flags.BoolVar(&Importer.FieldKeys, "field-keys", false, "use keys=true when creating a field")
 	flags.IntVarP(&Importer.BufferSize, "buffer-size", "s", 10000000, "Number of bits to buffer/sort before importing.")
 	flags.BoolVarP(&Importer.Sort, "sort", "", false, "Enables sorting before import.")
 	flags.BoolVarP(&Importer.CreateSchema, "create", "e", false, "Create the schema if it does not exist before import.")

--- a/ctl/import.go
+++ b/ctl/import.go
@@ -40,8 +40,11 @@ type ImportCommand struct { // nolint: maligned
 	Index string `json:"index"`
 	Field string `json:"field"`
 
-	// Options for index & field to be created if they don't exist
+	// Options for the index to be created if it doesn't exist
 	indexOptions pilosa.IndexOptions
+
+	// Options for the field to be created if it doesn't exist
+	fieldOptions pilosa.FieldOptions
 
 	// CreateSchema ensures the schema exists before import
 	CreateSchema bool
@@ -49,6 +52,12 @@ type ImportCommand struct { // nolint: maligned
 	// REMOVED: Indicates that the payload should be treated as string keys.
 	// TODO: remove this in a future release
 	StringKeys bool `json:"StringKeys"`
+
+	// IndexKeys makes the import command use keys=true when creating an index
+	IndexKeys bool `json:"indexKeys"`
+
+	// FieldKeys makes the import command use keys=true when creating a field
+	FieldKeys bool `json:"fieldKeys"`
 
 	// Filenames to import from.
 	Paths []string `json:"paths"`
@@ -102,6 +111,12 @@ func (cmd *ImportCommand) Run(ctx context.Context) error {
 	cmd.client = client
 
 	if cmd.CreateSchema {
+		cmd.indexOptions = pilosa.IndexOptions{
+			Keys: cmd.IndexKeys,
+		}
+		cmd.fieldOptions = pilosa.FieldOptions{
+			Keys: cmd.FieldKeys,
+		}
 		err := cmd.ensureSchema(ctx)
 		if err != nil {
 			return errors.Wrap(err, "ensuring schema")
@@ -146,7 +161,7 @@ func (cmd *ImportCommand) ensureSchema(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("Error Creating Index: %s", err)
 	}
-	err = cmd.client.EnsureField(ctx, cmd.Index, cmd.Field)
+	err = cmd.client.EnsureFieldWithOptions(ctx, cmd.Index, cmd.Field, cmd.fieldOptions)
 	if err != nil {
 		return fmt.Errorf("Error Creating Field: %s", err)
 	}

--- a/ctl/import.go
+++ b/ctl/import.go
@@ -49,10 +49,6 @@ type ImportCommand struct { // nolint: maligned
 	// CreateSchema ensures the schema exists before import
 	CreateSchema bool
 
-	// REMOVED: Indicates that the payload should be treated as string keys.
-	// TODO: remove this in a future release
-	StringKeys bool `json:"StringKeys"`
-
 	// IndexKeys makes the import command use keys=true when creating an index
 	IndexKeys bool `json:"indexKeys"`
 
@@ -88,11 +84,6 @@ func NewImportCommand(stdin io.Reader, stdout, stderr io.Writer) *ImportCommand 
 // Run executes the main program execution.
 func (cmd *ImportCommand) Run(ctx context.Context) error {
 	logger := log.New(cmd.Stderr, "", log.LstdFlags)
-
-	// REMOVED: warning that --string-keys flag has been deprecated.
-	if cmd.StringKeys {
-		logger.Printf("REMOVED: The string-keys flag is no longer used.")
-	}
 
 	// Validate arguments.
 	// Index and field are validated early before the files are parsed.


### PR DESCRIPTION
## Overview

* I had to add `client.CreateFieldWithOptions` and `client.EnsureFieldWithOptions` functions in order to be able to pass create a field with options.
* `client.CreateFieldWithOptions` takes a `pilosa.FieldOptions` argument, but `http.postFieldRequest` requires the options as `http.fieldOptions`. Had to  convert from the former to the latter. I had to set different fields depending on the type of the field, since e.g., setting `Min` or `Max` is invalid for `set` fields (I'm happy that the tests cover that)
* I had to use `--index-keys` and `--field-keys` since `--index.keys` and `--field.keys` makes a few tests fail
* I didn't remove `--string-keys`. Should I ?

Fixes #1570


## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
