### PR TITLE
Implements Query call and excludeRowAttrs, excludeColumns, columnAttrs and shards args

### DIFF
--- a/api.go
+++ b/api.go
@@ -109,8 +109,9 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 	}
 	execOpts := &execOptions{
 		Remote:          req.Remote,
-		ExcludeRowAttrs: req.ExcludeRowAttrs,
-		ExcludeColumns:  req.ExcludeColumns,
+		ExcludeRowAttrs: req.ExcludeRowAttrs, // NOTE: Kept for Pilosa 1.x compat.
+		ExcludeColumns:  req.ExcludeColumns,  // NOTE: Kept for Pilosa 1.x compat.
+		ColumnAttrs:     req.ColumnAttrs,     // NOTE: Kept for Pilosa 1.x compat.
 	}
 	results, err := api.server.executor.Execute(ctx, req.Index, q, req.Shards, execOpts)
 	if err != nil {
@@ -119,7 +120,8 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 	resp.Results = results
 
 	// Fill column attributes if requested.
-	if req.ColumnAttrs && !req.ExcludeColumns {
+	// execOpts.ColumnAttrs and execOpts.ExcludeColumns are out params from api.server.executor.Execute
+	if execOpts.ColumnAttrs && !execOpts.ExcludeColumns {
 		// Consolidate all column ids across all calls.
 		var columnIDs []uint64
 		for _, result := range results {

--- a/api.go
+++ b/api.go
@@ -120,7 +120,7 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 	resp.Results = results
 
 	// Fill column attributes if requested.
-	// execOpts.ColumnAttrs and execOpts.ExcludeColumns are out params from api.server.executor.Execute
+	// execOpts.ColumnAttrs is an out param from api.server.executor.Execute
 	if execOpts.ColumnAttrs {
 		// Consolidate all column ids across all calls.
 		var columnIDs []uint64

--- a/api.go
+++ b/api.go
@@ -120,7 +120,7 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 	resp.Results = results
 
 	// Fill column attributes if requested.
-	// execOpts.ColumnAttrs is an out param from api.server.executor.Execute
+	// execOpts.ColumnAttrs may be set by the Execute method if any of the Calls use Options(columnAttrs=true)
 	if execOpts.ColumnAttrs {
 		// Consolidate all column ids across all calls.
 		var columnIDs []uint64

--- a/api.go
+++ b/api.go
@@ -121,7 +121,7 @@ func (api *API) Query(ctx context.Context, req *QueryRequest) (QueryResponse, er
 
 	// Fill column attributes if requested.
 	// execOpts.ColumnAttrs and execOpts.ExcludeColumns are out params from api.server.executor.Execute
-	if execOpts.ColumnAttrs && !execOpts.ExcludeColumns {
+	if execOpts.ColumnAttrs {
 		// Consolidate all column ids across all calls.
 		var columnIDs []uint64
 		for _, result := range results {

--- a/executor.go
+++ b/executor.go
@@ -194,8 +194,8 @@ func (e *executor) executeCall(ctx context.Context, index string, c *pql.Call, s
 	case "TopN":
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeTopN(ctx, index, c, shards, opt)
-	case "Opt":
-		return e.executeOptCall(ctx, index, c, shards, opt)
+	case "Options":
+		return e.executeOptionsCall(ctx, index, c, shards, opt)
 	default:
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeBitmapCall(ctx, index, c, shards, opt)
@@ -221,7 +221,7 @@ func (e *executor) validateCallArgs(c *pql.Call) error {
 	return nil
 }
 
-func (e *executor) executeOptCall(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (interface{}, error) {
+func (e *executor) executeOptionsCall(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (interface{}, error) {
 	optCopy := &execOptions{}
 	*optCopy = *opt
 	if arg, ok := c.Args["columnAttrs"]; ok {

--- a/executor.go
+++ b/executor.go
@@ -194,6 +194,8 @@ func (e *executor) executeCall(ctx context.Context, index string, c *pql.Call, s
 	case "TopN":
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeTopN(ctx, index, c, shards, opt)
+	case "Query":
+		return e.executeQueryCall(ctx, index, c, shards, opt)
 	default:
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeBitmapCall(ctx, index, c, shards, opt)
@@ -217,6 +219,42 @@ func (e *executor) validateCallArgs(c *pql.Call) error {
 		}
 	}
 	return nil
+}
+
+func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (interface{}, error) {
+	optCopy := &execOptions{}
+	*optCopy = *opt
+	if arg, ok := c.Args["excludeRowAttrs"]; ok {
+		if value, ok := arg.(bool); ok {
+			optCopy.ExcludeRowAttrs = value
+		} else {
+			return nil, errors.New("Query(): excludeRowAttrs must be a bool")
+		}
+	}
+	if arg, ok := c.Args["excludeColumns"]; ok {
+		if value, ok := arg.(bool); ok {
+			optCopy.ExcludeColumns = value
+		} else {
+			return nil, errors.New("Query(): excludeColumns must be a bool")
+		}
+	}
+	if arg, ok := c.Args["shards"]; ok {
+		if optShards, ok := arg.([]interface{}); ok {
+			shards = []uint64{}
+			for _, s := range optShards {
+				if shard, ok := s.(int64); ok {
+					shards = append(shards, uint64(shard))
+				} else {
+					return nil, errors.New("Query(): shards must be a list of unsigned integers")
+				}
+
+			}
+		} else {
+			return nil, errors.New("Query(): shards must be a list of unsigned integers")
+		}
+
+	}
+	return e.executeCall(ctx, index, c.Children[0], shards, optCopy)
 }
 
 // executeSum executes a Sum() call.

--- a/executor.go
+++ b/executor.go
@@ -224,9 +224,17 @@ func (e *executor) validateCallArgs(c *pql.Call) error {
 func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (interface{}, error) {
 	optCopy := &execOptions{}
 	*optCopy = *opt
+	if arg, ok := c.Args["columnAttrs"]; ok {
+		if value, ok := arg.(bool); ok {
+			opt.ColumnAttrs = value
+		} else {
+			return nil, errors.New("Query(): columnAttrs must be a bool")
+		}
+	}
 	if arg, ok := c.Args["excludeRowAttrs"]; ok {
 		if value, ok := arg.(bool); ok {
 			optCopy.ExcludeRowAttrs = value
+			opt.ExcludeRowAttrs = value
 		} else {
 			return nil, errors.New("Query(): excludeRowAttrs must be a bool")
 		}
@@ -234,6 +242,7 @@ func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Ca
 	if arg, ok := c.Args["excludeColumns"]; ok {
 		if value, ok := arg.(bool); ok {
 			optCopy.ExcludeColumns = value
+			opt.ExcludeColumns = value
 		} else {
 			return nil, errors.New("Query(): excludeColumns must be a bool")
 		}
@@ -1715,6 +1724,7 @@ type execOptions struct {
 	Remote          bool
 	ExcludeRowAttrs bool
 	ExcludeColumns  bool
+	ColumnAttrs     bool
 }
 
 // hasOnlySetRowAttrs returns true if calls only contains SetRowAttrs() calls.

--- a/executor.go
+++ b/executor.go
@@ -194,8 +194,8 @@ func (e *executor) executeCall(ctx context.Context, index string, c *pql.Call, s
 	case "TopN":
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeTopN(ctx, index, c, shards, opt)
-	case "Query":
-		return e.executeQueryCall(ctx, index, c, shards, opt)
+	case "Opt":
+		return e.executeOptCall(ctx, index, c, shards, opt)
 	default:
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeBitmapCall(ctx, index, c, shards, opt)
@@ -221,7 +221,7 @@ func (e *executor) validateCallArgs(c *pql.Call) error {
 	return nil
 }
 
-func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (interface{}, error) {
+func (e *executor) executeOptCall(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (interface{}, error) {
 	optCopy := &execOptions{}
 	*optCopy = *opt
 	if arg, ok := c.Args["columnAttrs"]; ok {
@@ -234,7 +234,6 @@ func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Ca
 	if arg, ok := c.Args["excludeRowAttrs"]; ok {
 		if value, ok := arg.(bool); ok {
 			optCopy.ExcludeRowAttrs = value
-			opt.ExcludeRowAttrs = value
 		} else {
 			return nil, errors.New("Query(): excludeRowAttrs must be a bool")
 		}
@@ -242,7 +241,6 @@ func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Ca
 	if arg, ok := c.Args["excludeColumns"]; ok {
 		if value, ok := arg.(bool); ok {
 			optCopy.ExcludeColumns = value
-			opt.ExcludeColumns = value
 		} else {
 			return nil, errors.New("Query(): excludeColumns must be a bool")
 		}
@@ -261,7 +259,6 @@ func (e *executor) executeQueryCall(ctx context.Context, index string, c *pql.Ca
 		} else {
 			return nil, errors.New("Query(): shards must be a list of unsigned integers")
 		}
-
 	}
 	return e.executeCall(ctx, index, c.Children[0], shards, optCopy)
 }

--- a/executor_test.go
+++ b/executor_test.go
@@ -1371,7 +1371,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), excludeRowAttrs=true)`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Options(Row(f=10), excludeRowAttrs=true)`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1397,7 +1397,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), excludeColumns=true)`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Options(Row(f=10), excludeColumns=true)`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1427,7 +1427,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			{ID: 100, Attrs: map[string]interface{}{"foo": "bar"}},
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), columnAttrs=true)`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Options(Row(f=10), columnAttrs=true)`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1454,7 +1454,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), shards=[0, 2])`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Options(Row(f=10), shards=[0, 2])`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100, ShardWidth * 2}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1480,7 +1480,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 
 		req := &pilosa.QueryRequest{
 			Index: "i",
-			Query: `Opt(Row(f=10), excludeColumns=true)Opt(Row(f=10), excludeRowAttrs=true)`,
+			Query: `Options(Row(f=10), excludeColumns=true)Options(Row(f=10), excludeRowAttrs=true)`,
 		}
 		if res, err := c[0].API.Query(context.Background(), req); err != nil {
 			t.Fatal(err)

--- a/executor_test.go
+++ b/executor_test.go
@@ -1424,7 +1424,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 		}
 
 		targetColAttrSets := []*pilosa.ColumnAttrSet{
-			&pilosa.ColumnAttrSet{ID: 100, Attrs: map[string]interface{}{"foo": "bar"}},
+			{ID: 100, Attrs: map[string]interface{}{"foo": "bar"}},
 		}
 
 		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Query(Row(f=10), columnAttrs=true)`}); err != nil {

--- a/executor_test.go
+++ b/executor_test.go
@@ -1371,7 +1371,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Query(Row(f=10), excludeRowAttrs=true)`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), excludeRowAttrs=true)`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1397,7 +1397,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Query(Row(f=10), excludeColumns=true)`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), excludeColumns=true)`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1427,7 +1427,7 @@ func TestExecutor_QueryCall(t *testing.T) {
 			{ID: 100, Attrs: map[string]interface{}{"foo": "bar"}},
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Query(Row(f=10), columnAttrs=true)`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), columnAttrs=true)`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100}) {
 			t.Fatalf("unexpected columns: %+v", bits)
@@ -1454,10 +1454,44 @@ func TestExecutor_QueryCall(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Query(Row(f=10), shards=[0, 2])`}); err != nil {
+		if res, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Opt(Row(f=10), shards=[0, 2])`}); err != nil {
 			t.Fatal(err)
 		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100, ShardWidth * 2}) {
 			t.Fatalf("unexpected columns: %+v", bits)
+		}
+	})
+
+	t.Run("multipleOpt", func(t *testing.T) {
+		c := test.MustRunCluster(t, 1)
+		defer c.Close()
+		hldr := test.Holder{Holder: c[0].Server.Holder()}
+
+		// Set columns for rows 0, 10, & 20 across two shards.
+		if idx, err := hldr.CreateIndex("i", pilosa.IndexOptions{}); err != nil {
+			t.Fatal(err)
+		} else if _, err := idx.CreateField("f", pilosa.OptFieldTypeDefault()); err != nil {
+			t.Fatal(err)
+		} else if _, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `
+				Set(100, f=10)
+				SetRowAttrs(f, 10, foo="bar")
+			`}); err != nil {
+			t.Fatal(err)
+		}
+
+		req := &pilosa.QueryRequest{
+			Index: "i",
+			Query: `Opt(Row(f=10), excludeColumns=true)Opt(Row(f=10), excludeRowAttrs=true)`,
+		}
+		if res, err := c[0].API.Query(context.Background(), req); err != nil {
+			t.Fatal(err)
+		} else if bits := res.Results[0].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{}) {
+			t.Fatalf("unexpected columns: %+v", bits)
+		} else if attrs := res.Results[0].(*pilosa.Row).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{"foo": "bar"}) {
+			t.Fatalf("unexpected attrs: %s", spew.Sdump(attrs))
+		} else if bits := res.Results[1].(*pilosa.Row).Columns(); !reflect.DeepEqual(bits, []uint64{100}) {
+			t.Fatalf("unexpected columns: %+v", bits)
+		} else if attrs := res.Results[1].(*pilosa.Row).Attrs; !reflect.DeepEqual(attrs, map[string]interface{}{}) {
+			t.Fatalf("unexpected attrs: %s", spew.Sdump(attrs))
 		}
 	})
 }

--- a/pql/pqlpeg_test.go
+++ b/pql/pqlpeg_test.go
@@ -596,10 +596,10 @@ func TestPQLDeepEquality(t *testing.T) {
 				},
 			}},
 		{
-			name: "QueryWrapper",
-			call: "Query(Row(f1=123), excludeRowAttrs=true)",
+			name: "OptionsWrapper",
+			call: "Options(Row(f1=123), excludeRowAttrs=true)",
 			exp: &Call{
-				Name: "Query",
+				Name: "Options",
 				Args: map[string]interface{}{
 					"excludeRowAttrs": true,
 				},

--- a/pql/pqlpeg_test.go
+++ b/pql/pqlpeg_test.go
@@ -595,6 +595,23 @@ func TestPQLDeepEquality(t *testing.T) {
 					{Name: "Row"},
 				},
 			}},
+		{
+			name: "QueryWrapper",
+			call: "Query(Row(f1=123), excludeRowAttrs=true)",
+			exp: &Call{
+				Name: "Query",
+				Args: map[string]interface{}{
+					"excludeRowAttrs": true,
+				},
+				Children: []*Call{
+					{
+						Name: "Row",
+						Args: map[string]interface{}{
+							"f1": int64(123),
+						},
+					},
+				},
+			}},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
## Overview
Implements Query call excludeRowAttrs, excludeColumns, columnAttrs and shards args. I didn't remove the older http query argument code which sets those options in order to not break compatibility with Pilosa 1.x.

~TODO: columnAttrs arg. This requires adding attributes at the reduce stage `api.server.executor.Execute` or `api.Query` and as far as I see it would break compatibility with Pilosa 1.x Looking for a way that doesn't break compatibility. The alternative is matching `Query(..., columnAttrs=true)` at `api.Query` enable column attributes there which won't break the compatibility.~

Fixes #700

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
