### PR TITLE
implements Not() query

### DIFF
--- a/docs/administration.md
+++ b/docs/administration.md
@@ -294,6 +294,8 @@ We currently track the following events
 - **Union:** Count of Union queries.
 - **Intersection:** Count of Intersection queries.
 - **Difference:** Count of Difference queries.
+- **Xor:** Count of Xor queries.
+- **Not:** Count of Not queries.
 - **Count:** Count of Count queries.
 - **Range:** Count of Range queries.
 - **Snapshot:** Event count when the snapshot process is triggered.

--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -48,7 +48,7 @@ curl localhost:10101/index/repository/query \
 * `UINT` An unsigned integer (e.g. 42839)
 * `ATTR_NAME` Must be a valid identifier `[A-Za-z][A-Za-z0-9._-]*`
 * `ATTR_VALUE` Can be a string, float, integer, or bool.
-* `ROW_CALL` Any query which returns a row, such as `Row`, `Union`, `Difference`, `Xor`, `Intersect`, `Range`
+* `ROW_CALL` Any query which returns a row, such as `Row`, `Union`, `Difference`, `Xor`, `Intersect`, `Range`, `Not`
 * `[]ATTR_VALUE` Denotes an array of `ATTR_VALUE`s. (e.g. `["a", "b", "c"]`)
 
 ### Write Operations
@@ -94,7 +94,7 @@ Set(10, stargazer=1, 2016-01-01T00:00)
 
 Set multiple bits in a single request:
 ```request
-Set(1, stargazer=10) Set(2, stargazer=10) Set(1, stargazer=20) Set(2, stargazer=30)
+Set(10, stargazer=1) Set(20, stargazer=1) Set(10, stargazer=2) Set(30, stargazer=2)
 ```
 ```response
 {"results":[false,true,true,true]}
@@ -358,7 +358,7 @@ Difference(Row(stargazer=2), Row(stargazer=1))
 {"attrs":{},"columns":[30]}
 ```
 
-* columnss are repositories that were starred by user 2 BUT NOT user 1
+* columns are repositories that were starred by user 2 BUT NOT user 1
 
 #### Xor
 
@@ -384,10 +384,38 @@ Query columns with a bit set in exactly one of two rows (repositories that are s
 Xor(Row(stargazer=2), Row(stargazer=1))
 ```
 ```response
-{"results":[{"attrs":{},"columns":[10,20,30]}]}
+{"results":[{"attrs":{},"columns":[20,30]}]}
 ```
 
 * columns are repositories that were starred by user 1 XOR user 2 (user 1 or user 2, but not both)
+
+#### Not
+
+**Spec:**
+
+```
+Not(<ROW_CALL>)
+```
+
+**Description:**
+
+Not returns the inverse of all of the bits from the `ROW_CALL` argument. The Not query requires that `trackExistence` has been enabled on the Index.
+
+**Result Type:** object with attrs and columns
+
+attrs will always be empty
+
+**Examples:**
+
+Query columns with a bit set in one row and not another (repositories that are starred by one user and not another):
+```request
+Not(Row(stargazer=1))
+```
+```response
+{"results":[{"attrs":{},"columns":[30]}]}
+```
+
+* columns are repositories that were not starred by user 1
 
 #### Count
 **Spec:**

--- a/internal/test/querygenerator.go
+++ b/internal/test/querygenerator.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import (
@@ -95,9 +109,15 @@ func Difference(args ...*pql.Call) *pql.Call {
 	kvargs, children := magic(args)
 	return &pql.Call{Name: "Difference", Args: kvargs, Children: children}
 }
+
 func Xor(args ...*pql.Call) *pql.Call {
 	kvargs, children := magic(args)
 	return &pql.Call{Name: "Xor", Args: kvargs, Children: children}
+}
+
+func Not(args ...*pql.Call) *pql.Call {
+	kvargs, children := magic(args)
+	return &pql.Call{Name: "Not", Args: kvargs, Children: children}
 }
 
 func Between(_ string, min, max int) *pql.Call {

--- a/internal/test/querygenerator_test.go
+++ b/internal/test/querygenerator_test.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package test
 
 import (
@@ -202,6 +216,24 @@ func TestPQL_Generator(t *testing.T) {
 								{
 									Name: "Row",
 									Args: map[string]interface{}{"frame": "aaa", "row": 12},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				pql:  `Not(Row(aaa=10))`,
+				calc: PQL(Not(Row("aaa", 10))),
+				exp: &pql.Query{
+					Calls: []*pql.Call{
+						{
+							Name: "Not",
+							Args: map[string]interface{}{},
+							Children: []*pql.Call{
+								{
+									Name: "Row",
+									Args: map[string]interface{}{"frame": "aaa", "row": 10},
 								},
 							},
 						},


### PR DESCRIPTION
## Overview

Uses the `trackExistence` field to support a `Not()` query.

Fixes #807 
Fixes #1587 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
