### PR TITLE
Make translate map size configurable

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -42,7 +42,7 @@ func TestServerConfig(t *testing.T) {
 	tests := []commandTest{
 		// TEST 0
 		{
-			args: []string{"server", "--data-dir", actualDataDir, "--cluster.hosts", "localhost:10111,localhost:10110", "--bind", "localhost:10111"},
+			args: []string{"server", "--data-dir", actualDataDir, "--cluster.hosts", "localhost:10111,localhost:10110", "--bind", "localhost:10111", "--translation.map-size", "100000"},
 			env:  map[string]string{"PILOSA_DATA_DIR": "/tmp/myEnvDatadir", "PILOSA_CLUSTER_LONG_QUERY_TIME": "1m30s", "PILOSA_MAX_WRITES_PER_REQUEST": "2000"},
 			cfgFileContent: `
 	data-dir = "/tmp/myFileDatadir"
@@ -65,13 +65,14 @@ func TestServerConfig(t *testing.T) {
 				v.Check(cmd.Server.Config.Cluster.Hosts, []string{"localhost:10111", "localhost:10110"})
 				v.Check(cmd.Server.Config.Cluster.LongQueryTime, toml.Duration(time.Second*90))
 				v.Check(cmd.Server.Config.MaxWritesPerRequest, 2000)
+				v.Check(cmd.Server.Config.Translation.MapSize, 100000)
 				return v.Error()
 			},
 		},
 		// TEST 1
 		{
 			args: []string{"server", "--anti-entropy.interval", "9m0s"},
-			env:  map[string]string{"PILOSA_CLUSTER_HOSTS": "localhost:1110,localhost:1111", "PILOSA_BIND": "localhost:1110"},
+			env:  map[string]string{"PILOSA_CLUSTER_HOSTS": "localhost:1110,localhost:1111", "PILOSA_BIND": "localhost:1110", "PILOSA_TRANSLATION_MAP_SIZE": "100000"},
 			cfgFileContent: `
 	bind = "localhost:0"
 	data-dir = "` + actualDataDir + `"
@@ -85,12 +86,13 @@ func TestServerConfig(t *testing.T) {
 				v := validator{}
 				v.Check(cmd.Server.Config.Cluster.Hosts, []string{"localhost:1110", "localhost:1111"})
 				v.Check(cmd.Server.Config.AntiEntropy.Interval, toml.Duration(time.Minute*9))
+				v.Check(cmd.Server.Config.Translation.MapSize, 100000)
 				return v.Error()
 			},
 		},
 		// TEST 2
 		{
-			args: []string{"server", "--log-path", logFile.Name(), "--cluster.disabled", "true"},
+			args: []string{"server", "--log-path", logFile.Name(), "--cluster.disabled", "true", "--translation.map-size", "100000"},
 			env:  map[string]string{},
 			cfgFileContent: `
 	bind = "localhost:19444"

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -45,7 +45,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 
 	// Translation
 	flags.StringVarP(&srv.Config.Translation.PrimaryURL, "translation.primary-url", "", srv.Config.Translation.PrimaryURL, "DEPRECATED: URL for primary translation node for replication.")
-	flags.IntVarP(&srv.Config.Translation.MapSize, "translation.map-size", "", srv.Config.Translation.MapSize, "Size of mmap to allocate for key translation.")
+	flags.IntVarP(&srv.Config.Translation.MapSize, "translation.map-size", "", srv.Config.Translation.MapSize, "Size in bytes of mmap to allocate for key translation.")
 
 	// Gossip
 	flags.StringVarP(&srv.Config.Gossip.Port, "gossip.port", "", srv.Config.Gossip.Port, "Port to which pilosa should bind for internal state sharing.")

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -45,6 +45,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 
 	// Translation
 	flags.StringVarP(&srv.Config.Translation.PrimaryURL, "translation.primary-url", "", srv.Config.Translation.PrimaryURL, "DEPRECATED: URL for primary translation node for replication.")
+	flags.IntVarP(&srv.Config.Translation.MapSize, "translation.map-size", "", srv.Config.Translation.MapSize, "Size of mmap to allocate for key translation.")
 
 	// Gossip
 	flags.StringVarP(&srv.Config.Gossip.Port, "gossip.port", "", srv.Config.Gossip.Port, "Port to which pilosa should bind for internal state sharing.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -307,6 +307,18 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
     skip-verify = true
     ```
 
+#### Translation Map Size
+
+* Description: Size in bytes of mmap to allocate for key translation
+* Flag: `translation.map-size`
+* Env: `PILOSA_TRANSLATION_MAP_SIZE`
+* Config:
+
+    ```toml
+    [translation]
+    map-size = 10737418240
+    ```
+
 ### Example Cluster Configuration
 
 A three node cluster running on different hosts could be minimally configured as follows:

--- a/holder.go
+++ b/holder.go
@@ -77,19 +77,9 @@ type Holder struct {
 	Logger Logger
 }
 
-// HolderOption is a functional option type for pilosa.Holder
-type HolderOption func(f *Holder) error
-
-func OptHolderTranslateFileMapSize(mapSize int) HolderOption {
-	return func(h *Holder) error {
-		h.translateFile = NewTranslateFile(OptTranslateFileMapSize(mapSize))
-		return nil
-	}
-}
-
 // NewHolder returns a new instance of Holder.
-func NewHolder(opts ...HolderOption) *Holder {
-	h := &Holder{
+func NewHolder() *Holder {
+	return &Holder{
 		indexes: make(map[string]*Index),
 		closing: make(chan struct{}),
 
@@ -107,15 +97,6 @@ func NewHolder(opts ...HolderOption) *Holder {
 
 		Logger: NopLogger,
 	}
-
-	for _, opt := range opts {
-		err := opt(h)
-		if err != nil {
-			// TODO (2.0): Change func signature to return error
-			panic(errors.Wrap(err, "applying option"))
-		}
-	}
-	return h
 }
 
 // Open initializes the root data directory for the holder.

--- a/server.go
+++ b/server.go
@@ -234,6 +234,18 @@ func OptServerClusterHasher(h Hasher) ServerOption {
 	}
 }
 
+func OptServerHolderOptions(opts ...HolderOption) ServerOption {
+	return func(s *Server) error {
+		for _, opt := range opts {
+			err := opt(s.holder)
+			if err != nil {
+				return errors.Wrap(err, "applying option")
+			}
+		}
+		return nil
+	}
+}
+
 // NewServer returns a new instance of Server.
 func NewServer(opts ...ServerOption) (*Server, error) {
 	s := &Server{

--- a/server.go
+++ b/server.go
@@ -234,14 +234,9 @@ func OptServerClusterHasher(h Hasher) ServerOption {
 	}
 }
 
-func OptServerHolderOptions(opts ...HolderOption) ServerOption {
+func OptServerTranslateFileMapSize(mapSize int) ServerOption {
 	return func(s *Server) error {
-		for _, opt := range opts {
-			err := opt(s.holder)
-			if err != nil {
-				return errors.Wrap(err, "applying option")
-			}
-		}
+		s.holder.translateFile = NewTranslateFile(OptTranslateFileMapSize(mapSize))
 		return nil
 	}
 }

--- a/server/config.go
+++ b/server/config.go
@@ -71,8 +71,9 @@ type Config struct {
 	// Gossip config is based around memberlist.Config.
 	Gossip gossip.Config `toml:"gossip"`
 
-	// DEPRECATED: Translation config supports translation store replication.
 	Translation struct {
+		MapSize int `toml:"map-size"`
+		// DEPRECATED: Translation config supports translation store replication.
 		PrimaryURL string `toml:"primary-url"`
 	} `toml:"translation"`
 

--- a/server/server.go
+++ b/server/server.go
@@ -286,10 +286,8 @@ func (m *Command) SetupServer() error {
 	if m.Config.Translation.MapSize > 0 {
 		serverOptions = append(
 			serverOptions,
-			pilosa.OptServerHolderOptions(
-				pilosa.OptHolderTranslateFileMapSize(
-					m.Config.Translation.MapSize,
-				),
+			pilosa.OptServerTranslateFileMapSize(
+				m.Config.Translation.MapSize,
 			),
 		)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -283,6 +283,16 @@ func (m *Command) SetupServer() error {
 		coordinatorOpt,
 	}
 
+	if m.Config.Translation.MapSize > 0 {
+		serverOptions = append(
+			serverOptions,
+			pilosa.OptServerHolderOptions(
+				pilosa.OptHolderTranslateFileMapSize(
+					m.Config.Translation.MapSize,
+				),
+			),
+		)
+	}
 	serverOptions = append(serverOptions, m.serverOptions...)
 
 	m.Server, err = pilosa.NewServer(serverOptions...)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -498,6 +498,7 @@ func TestClusteringNodesReplica2(t *testing.T) {
 	// Create new main with the same config.
 	config = cluster[1].Command.Config
 	// config.Bind = cluster[1].API.Node().URI.HostPort()
+	config.Translation.MapSize = 100000
 
 	// this isn't necessary, but makes the test run way faster
 	config.Gossip.Port = strconv.Itoa(int(cluster[1].Command.GossipTransport().URI.Port))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -403,6 +403,7 @@ func TestClusteringNodesReplica1(t *testing.T) {
 
 	// Create new main with the same config.
 	config := cluster[2].Command.Config
+	config.Translation.MapSize = 100000
 	// config.Bind = cluster[2].API.Node().URI.HostPort()
 
 	// this isn't necessary, but makes the test run way faster
@@ -476,6 +477,7 @@ func TestClusteringNodesReplica2(t *testing.T) {
 
 	// Create new main with the same config.
 	config := cluster[2].Command.Config
+	config.Translation.MapSize = 100000
 	// config.Bind = cluster[2].API.Node().URI.HostPort()
 
 	// this isn't necessary, but makes the test run way faster

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -66,7 +66,7 @@ func newCommand(opts ...server.CommandOption) *Command {
 		server.OptCommandServerOptions(
 			pilosa.OptServerHolderOptions(
 				pilosa.OptHolderTranslateFileMapSize(
-					2 << 26,
+					2 << 25,
 				),
 			),
 		),

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -64,10 +64,8 @@ func newCommand(opts ...server.CommandOption) *Command {
 	opts = append([]server.CommandOption{
 		server.OptCommandCloseTimeout(time.Millisecond * 2),
 		server.OptCommandServerOptions(
-			pilosa.OptServerHolderOptions(
-				pilosa.OptHolderTranslateFileMapSize(
-					2 << 25,
-				),
+			pilosa.OptServerTranslateFileMapSize(
+				2 << 25,
 			),
 		),
 	}, opts...)

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -55,11 +55,22 @@ func newCommand(opts ...server.CommandOption) *Command {
 		panic(err)
 	}
 
-	// set aggressive close timeout by default to avoid hanging tests. This was
+	// Set aggressive close timeout by default to avoid hanging tests. This was
 	// a problem with PDK tests which used go-pilosa as well. We put it at the
 	// beginning of the option slice so that it can be overridden by user-passed
 	// options.
-	opts = append([]server.CommandOption{server.OptCommandCloseTimeout(time.Millisecond * 2)}, opts...)
+	// Also set TranslateFile MapSize to a smaller number so memory allocation
+	// does not fail on 32-bit systems.
+	opts = append([]server.CommandOption{
+		server.OptCommandCloseTimeout(time.Millisecond * 2),
+		server.OptCommandServerOptions(
+			pilosa.OptServerHolderOptions(
+				pilosa.OptHolderTranslateFileMapSize(
+					2 << 26,
+				),
+			),
+		),
+	}, opts...)
 	m := &Command{commandOptions: opts}
 	m.Command = server.NewCommand(bytes.NewReader(nil), ioutil.Discard, ioutil.Discard, opts...)
 	m.Config.DataDir = path

--- a/translate.go
+++ b/translate.go
@@ -93,7 +93,7 @@ func OptTranslateFileMapSize(mapSize int) TranslateFileOption {
 
 // NewTranslateFile returns a new instance of TranslateFile.
 func NewTranslateFile(opts ...TranslateFileOption) *TranslateFile {
-	var defaultMapSize64 int64 = 1 << 33
+	var defaultMapSize64 int64 = 10 * (1 << 30)
 	var defaultMapSize int
 
 	if ^uint(0)>>32 > 0 {
@@ -103,7 +103,6 @@ func NewTranslateFile(opts ...TranslateFileOption) *TranslateFile {
 		// Use 2GB default map size on 32-bit systems
 		defaultMapSize = (1 << 31) - 1
 	}
-
 	f := &TranslateFile{
 		writeNotify: make(chan struct{}),
 		closing:     make(chan struct{}),

--- a/translate.go
+++ b/translate.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cespare/xxhash"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -81,9 +81,26 @@ type TranslateFile struct {
 	replicationRetryInterval time.Duration
 }
 
+// TranslateFileOption is a functional option type for pilosa.TranslateFile
+type TranslateFileOption func(f *TranslateFile) error
+
+func OptTranslateFileMapSize(mapSize int) TranslateFileOption {
+	return func(f *TranslateFile) error {
+		f.mapSize = mapSize
+		return nil
+	}
+}
+
 // NewTranslateFile returns a new instance of TranslateFile.
-func NewTranslateFile() *TranslateFile {
-	return &TranslateFile{
+func NewTranslateFile(opts ...TranslateFileOption) *TranslateFile {
+	// 10GB default map size
+	defaultMapSize := 10 * (1 << 30)
+	// Use 2GB default map size on 32-bit systems
+	if 32<<(^uint(0)>>32&1) == 32 {
+		defaultMapSize = (1 << 31) - 1 // 2GB
+	}
+
+	f := &TranslateFile{
 		writeNotify: make(chan struct{}),
 		closing:     make(chan struct{}),
 		cols:        make(map[string]*index),
@@ -96,6 +113,16 @@ func NewTranslateFile() *TranslateFile {
 
 		replicationRetryInterval: defaultReplicationRetryInterval,
 	}
+
+	for _, opt := range opts {
+		err := opt(f)
+		if err != nil {
+			// TODO (2.0): Change func signature to return error
+			panic(errors.Wrap(err, "applying option"))
+		}
+	}
+
+	return f
 }
 
 func (s *TranslateFile) Open() (err error) {

--- a/translate.go
+++ b/translate.go
@@ -93,11 +93,15 @@ func OptTranslateFileMapSize(mapSize int) TranslateFileOption {
 
 // NewTranslateFile returns a new instance of TranslateFile.
 func NewTranslateFile(opts ...TranslateFileOption) *TranslateFile {
-	// 10GB default map size
-	defaultMapSize := 10 * (1 << 30)
-	// Use 2GB default map size on 32-bit systems
-	if 32<<(^uint(0)>>32&1) == 32 {
-		defaultMapSize = (1 << 31) - 1 // 2GB
+	var defaultMapSize64 int64 = 1 << 33
+	var defaultMapSize int
+
+	if ^uint(0)>>32 > 0 {
+		// 10GB default map size
+		defaultMapSize = int(defaultMapSize64)
+	} else {
+		// Use 2GB default map size on 32-bit systems
+		defaultMapSize = (1 << 31) - 1
 	}
 
 	f := &TranslateFile{

--- a/translate_mapsize_386.go
+++ b/translate_mapsize_386.go
@@ -1,5 +1,0 @@
-package pilosa
-
-// defaultMapSize is the default size of mapped memory for the translate store.
-// It is passed as an int to syscall.Mmap and so must be < 2^31
-const defaultMapSize = (1 << 31) - 1 // 2GB

--- a/translate_mapsize_all64bitsystems.go
+++ b/translate_mapsize_all64bitsystems.go
@@ -1,8 +1,0 @@
-// +build !386
-
-package pilosa
-
-// defaultMapSize is the default size of mapped memory for the translate store.
-// It is passed as an int to syscall.Mmap and so can only be larger than 2^31 on
-// 64bit systems.
-const defaultMapSize = 10 * (1 << 30) // 10GB

--- a/translate_test.go
+++ b/translate_test.go
@@ -367,7 +367,7 @@ func TestPrintTranslateFile(t *testing.T) {
 	}
 	f.Close()
 
-	s := pilosa.NewTranslateFile()
+	s := pilosa.NewTranslateFile(pilosa.OptTranslateFileMapSize(2 << 25))
 	s.Path = f.Name()
 	err = s.Open()
 	if err != nil {
@@ -809,7 +809,7 @@ func NewTranslateFile() *TranslateFile {
 	}
 	f.Close()
 
-	s := &TranslateFile{TranslateFile: pilosa.NewTranslateFile()}
+	s := &TranslateFile{TranslateFile: pilosa.NewTranslateFile(pilosa.OptTranslateFileMapSize(2 << 25))}
 	s.Path = f.Name()
 	return s
 }
@@ -847,7 +847,7 @@ func (s *TranslateFile) Reopen() error {
 	}
 
 	s.lock.Lock()
-	s.TranslateFile = pilosa.NewTranslateFile()
+	s.TranslateFile = pilosa.NewTranslateFile(pilosa.OptTranslateFileMapSize(2 << 25))
 	s.lock.Unlock()
 	s.Path = prev.Path
 	s.SetPrimaryStore("restored-primary", prev.PrimaryTranslateStore)


### PR DESCRIPTION
## Overview

This adds a configuration flag for the translate map size. This configuration is used to lower the map size on 32-bit systems so the allocator should no longer fail in tests.

Fixes #1604
Fixes #1546 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
