### PR TITLE
fixes pass-by-value issue in proto decode

### DIFF
--- a/api.go
+++ b/api.go
@@ -801,6 +801,8 @@ func importExistenceColumns(index *Index, columnIDs []uint64) error {
 }
 
 // MaxShards returns the maximum shard number for each index in a map.
+// TODO (2.0): This method has been deprecated. Instead, use
+// AvailableShardsByIndex.
 func (api *API) MaxShards(_ context.Context) map[string]uint64 {
 	m := make(map[string]uint64)
 	for k, v := range api.holder.availableShardsByIndex() {

--- a/encoding/proto/proto.go
+++ b/encoding/proto/proto.go
@@ -1,3 +1,17 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package proto
 
 import (
@@ -803,30 +817,32 @@ func decodeNodeEventMessage(pb *internal.NodeEventMessage, m *pilosa.NodeEvent) 
 
 func decodeNodeStatus(pb *internal.NodeStatus, m *pilosa.NodeStatus) {
 	m.Node = &pilosa.Node{}
-	decodeIndexStatuses(pb.Indexes, m.Indexes)
+	m.Indexes = decodeIndexStatuses(pb.Indexes)
 	m.Schema = &pilosa.Schema{}
 	decodeSchema(pb.Schema, m.Schema)
 }
 
-func decodeIndexStatuses(a []*internal.IndexStatus, m []*pilosa.IndexStatus) {
-	m = m[:0]
+func decodeIndexStatuses(a []*internal.IndexStatus) []*pilosa.IndexStatus {
+	m := make([]*pilosa.IndexStatus, 0)
 	for i := range a {
 		m = append(m, &pilosa.IndexStatus{})
 		decodeIndexStatus(a[i], m[i])
 	}
+	return m
 }
 
 func decodeIndexStatus(pb *internal.IndexStatus, m *pilosa.IndexStatus) {
 	m.Name = pb.Name
-	decodeFieldStatuses(pb.Fields, m.Fields)
+	m.Fields = decodeFieldStatuses(pb.Fields)
 }
 
-func decodeFieldStatuses(a []*internal.FieldStatus, m []*pilosa.FieldStatus) {
-	m = m[:0]
+func decodeFieldStatuses(a []*internal.FieldStatus) []*pilosa.FieldStatus {
+	m := make([]*pilosa.FieldStatus, 0)
 	for i := range a {
 		m = append(m, &pilosa.FieldStatus{})
 		decodeFieldStatus(a[i], m[i])
 	}
+	return m
 }
 
 func decodeFieldStatus(pb *internal.FieldStatus, m *pilosa.FieldStatus) {

--- a/server.go
+++ b/server.go
@@ -640,7 +640,7 @@ func (s *Server) mergeRemoteStatus(ns *NodeStatus) error {
 		for _, fs := range is.Fields {
 			f := s.holder.Field(is.Name, fs.Name)
 
-			// if we don't know about an field locally, log a error because
+			// if we don't know about a field locally, log an error because
 			// fields should be created and synced prior to shard creation
 			if f == nil {
 				s.logger.Printf("Local Field not found: %s/%s", is.Name, fs.Name)


### PR DESCRIPTION
## Overview

This PR fixes a bug in the proto decoder caused by passing a zero-length slice and then modifying it (which doesn't modify the underlying array).