### PR TITLE
Wrap translation store errors, decrease test map size to prevent failure on 32-bit

### DIFF
--- a/server.go
+++ b/server.go
@@ -337,20 +337,20 @@ func (s *Server) Open() error {
 
 	// Initialize id-key storage.
 	if err := s.holder.translateFile.Open(); err != nil {
-		return err
+		return errors.Wrap(err, "opening TranslateFile")
 	}
 
 	// Open Cluster management.
 	if err := s.cluster.waitForStarted(); err != nil {
-		return fmt.Errorf("opening Cluster: %v", err)
+		return errors.Wrap(err, "opening Cluster")
 	}
 
 	// Open holder.
 	if err := s.holder.Open(); err != nil {
-		return fmt.Errorf("opening Holder: %v", err)
+		return errors.Wrap(err, "opening Holder")
 	}
 	if err := s.cluster.setNodeState(nodeStateReady); err != nil {
-		return fmt.Errorf("setting nodeState: %v", err)
+		return errors.Wrap(err, "setting nodeState")
 	}
 
 	// Listen for joining nodes.

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -63,17 +63,13 @@ func newCommand(opts ...server.CommandOption) *Command {
 	// does not fail on 32-bit systems.
 	opts = append([]server.CommandOption{
 		server.OptCommandCloseTimeout(time.Millisecond * 2),
-		server.OptCommandServerOptions(
-			pilosa.OptServerTranslateFileMapSize(
-				2 << 25,
-			),
-		),
 	}, opts...)
 	m := &Command{commandOptions: opts}
 	m.Command = server.NewCommand(bytes.NewReader(nil), ioutil.Discard, ioutil.Discard, opts...)
 	m.Config.DataDir = path
 	m.Config.Bind = "http://localhost:0"
 	m.Config.Cluster.Disabled = true
+	m.Config.Translation.MapSize = 100000
 
 	if testing.Verbose() {
 		m.Command.Stdout = os.Stdout

--- a/translate.go
+++ b/translate.go
@@ -131,20 +131,20 @@ func NewTranslateFile(opts ...TranslateFileOption) *TranslateFile {
 func (s *TranslateFile) Open() (err error) {
 	// Open writer & buffered writer.
 	if err := os.MkdirAll(filepath.Dir(s.Path), 0777); err != nil {
-		return err
+		return errors.Wrapf(err, "mkdir %s", filepath.Dir(s.Path))
 	} else if s.file, err = os.OpenFile(s.Path, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666); err != nil {
-		return err
+		return errors.Wrapf(err, "open file %s", s.Path)
 	}
 	s.w = bufio.NewWriter(s.file)
 
 	// Memory map data file.
 	if s.data, err = syscall.Mmap(int(s.file.Fd()), 0, s.mapSize, syscall.PROT_READ, syscall.MAP_SHARED); err != nil {
-		return err
+		return errors.Wrapf(err, "creating Mmap (size: %d)", s.mapSize)
 	}
 
 	// Replay the log.
 	if err := s.replayEntries(); err != nil {
-		return err
+		return errors.Wrap(err, "replay log")
 	}
 
 	// Listen to primaryStoreEvents channel.

--- a/translate.go
+++ b/translate.go
@@ -144,7 +144,7 @@ func (s *TranslateFile) Open() (err error) {
 
 	// Replay the log.
 	if err := s.replayEntries(); err != nil {
-		return errors.Wrap(err, "replay log")
+		return errors.Wrap(err, "replaying log entries")
 	}
 
 	// Listen to primaryStoreEvents channel.


### PR DESCRIPTION
## Overview

Still getting a few intermittent memory allocation errors on 32-bit builds. This further decreases the map size to avoid those errors and also adds better error wrapping.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
