### PR TITLE
Store() function

### DIFF
--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -292,6 +292,14 @@ Store(Row(stargazer=1), stargazer=2)
 {"results":[true]}
 ```
 
+Store the results of the intersection of stargazer rows 10 and 11 into stargazer row 20.
+```request
+Store(Intersect(Row(stargazer=10), Row(stargazer=11)), stargazer=20)
+```
+```response
+{"results":[true]}
+```
+
 ### Read Operations
 
 #### Row

--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -266,6 +266,32 @@ ClearRow(stargazer=1)
 
 This represents removing the relationship between the user with id=1 and all repositories.
 
+#### Store
+
+**Spec:**
+
+```
+Store(<ROW_CALL>, <FIELD>=<ROW>)
+```
+
+**Description:**
+
+`Store` writes the results of <ROW_CALL> to the specified row. If the row already exists, it will be replaced. The destination field must be of field type `set`.
+
+**Result Type:** boolean
+
+Upon success, this method always returns `true`. A future version of Pilosa may use this boolean result to indicate whether or not the data in the destination row was changed by the `Store` call.
+
+**Examples:**
+
+Store the contents of stargazer row 1 into stargazer row 2:
+```request
+Store(Row(stargazer=1), stargazer=2)
+```
+```response
+{"results":[true]}
+```
+
 ### Read Operations
 
 #### Row

--- a/executor.go
+++ b/executor.go
@@ -1226,11 +1226,7 @@ func (e *executor) executeSetRow(ctx context.Context, index string, c *pql.Call,
 	if field == nil {
 		return false, ErrFieldNotFound
 	}
-
-	switch field.Type() {
-	case FieldTypeSet:
-		// These field types support SetRow().
-	default:
+	if field.Type() != FieldTypeSet {
 		return false, fmt.Errorf("SetRow() is not supported on %s field types", field.Type())
 	}
 
@@ -1298,11 +1294,11 @@ func (e *executor) executeSetRowShard(ctx context.Context, index string, c *pql.
 			return false, errors.Wrapf(err, "creating fragment: %d", shard)
 		}
 	}
-	cleared, err := fragment.setRow(src, rowID)
+	set, err := fragment.setRow(src, rowID)
 	if err != nil {
 		return false, errors.Wrapf(err, "setting row %d on view %s shard %d", rowID, viewStandard, shard)
 	}
-	changed = changed || cleared
+	changed = changed || set
 
 	return changed, nil
 }

--- a/executor.go
+++ b/executor.go
@@ -184,6 +184,8 @@ func (e *executor) executeCall(ctx context.Context, index string, c *pql.Call, s
 		return e.executeClearBit(ctx, index, c, opt)
 	case "ClearRow":
 		return e.executeClearRow(ctx, index, c, shards, opt)
+	case "Store":
+		return e.executeSetRow(ctx, index, c, shards, opt)
 	case "Count":
 		e.Holder.Stats.CountWithCustomTags(c.Name, 1, 1.0, []string{indexTag})
 		return e.executeCount(ctx, index, c, shards, opt)
@@ -1209,6 +1211,98 @@ func (e *executor) executeClearRowShard(_ context.Context, index string, c *pql.
 		}
 		changed = changed || cleared
 	}
+
+	return changed, nil
+}
+
+// executeSetRow executes a SetRow() call.
+func (e *executor) executeSetRow(ctx context.Context, index string, c *pql.Call, shards []uint64, opt *execOptions) (bool, error) {
+	// Ensure the field type supports SetRow().
+	fieldName, err := c.FieldArg()
+	if err != nil {
+		return false, errors.New("SetRow() argument required: field")
+	}
+	field := e.Holder.Field(index, fieldName)
+	if field == nil {
+		return false, ErrFieldNotFound
+	}
+
+	switch field.Type() {
+	case FieldTypeSet:
+		// These field types support SetRow().
+	default:
+		return false, fmt.Errorf("SetRow() is not supported on %s field types", field.Type())
+	}
+
+	// Execute calls in bulk on each remote node and merge.
+	mapFn := func(shard uint64) (interface{}, error) {
+		return e.executeSetRowShard(ctx, index, c, shard)
+	}
+
+	// Merge returned results at coordinating node.
+	reduceFn := func(prev, v interface{}) interface{} {
+		val := v.(bool)
+		if prev == nil {
+			return val
+		}
+		return val || prev.(bool)
+	}
+
+	result, err := e.mapReduce(ctx, index, shards, c, opt, mapFn, reduceFn)
+	return result.(bool), err
+}
+
+// executeSetRowShard executes a SetRow() call for a single shard.
+func (e *executor) executeSetRowShard(ctx context.Context, index string, c *pql.Call, shard uint64) (bool, error) {
+	fieldName, err := c.FieldArg()
+	if err != nil {
+		return false, errors.New("SetRow() argument required: field")
+	}
+
+	// Read fields using labels.
+	rowID, ok, err := c.UintArg(fieldName)
+	if err != nil {
+		return false, fmt.Errorf("reading SetRow() row: %v", err)
+	} else if !ok {
+		return false, fmt.Errorf("SetRow() row argument '%v' required", rowLabel)
+	}
+
+	field := e.Holder.Field(index, fieldName)
+	if field == nil {
+		return false, ErrFieldNotFound
+	}
+
+	// Retrieve source row.
+	var src *Row
+	if len(c.Children) == 1 {
+		row, err := e.executeBitmapCallShard(ctx, index, c.Children[0], shard)
+		if err != nil {
+			return false, errors.Wrap(err, "getting source row")
+		}
+		src = row
+	} else {
+		return false, errors.New("SetRow() requires a source row")
+	}
+
+	// Set the row on the standard view.
+	changed := false
+	fragment := e.Holder.fragment(index, fieldName, viewStandard, shard)
+	if fragment == nil {
+		// Since the destination fragment doesn't exist, create one.
+		view, err := field.createViewIfNotExists(viewStandard)
+		if err != nil {
+			return false, errors.Wrap(err, "creating view")
+		}
+		fragment, err = view.createFragmentIfNotExists(shard)
+		if err != nil {
+			return false, errors.Wrapf(err, "creating fragment: %d", shard)
+		}
+	}
+	cleared, err := fragment.setRow(src, rowID)
+	if err != nil {
+		return false, errors.Wrapf(err, "setting row %d on view %s shard %d", rowID, viewStandard, shard)
+	}
+	changed = changed || cleared
 
 	return changed, nil
 }

--- a/pql/pql.peg
+++ b/pql/pql.peg
@@ -11,6 +11,7 @@ Call <-  'Set' {p.startCall("Set")} open col comma args (comma timestamp)? close
        / 'SetColumnAttrs' {p.startCall("SetColumnAttrs")} open col comma args close {p.endCall()}
        / 'Clear' {p.startCall("Clear")} open col comma args close {p.endCall()}
        / 'ClearRow' {p.startCall("ClearRow")} open arg close {p.endCall()}
+       / 'Store' {p.startCall("Store")} open Call comma arg close {p.endCall()}
        / 'TopN' {p.startCall("TopN")} open posfield (comma allargs)? close {p.endCall()}
        / 'Range' {p.startCall("Range")} open (timerange / conditional / arg) close {p.endCall()}
        / < IDENT > { p.startCall(buffer[begin:end] ) } open allargs comma? close { p.endCall() }

--- a/pql/pql.peg.go
+++ b/pql/pql.peg.go
@@ -64,9 +64,9 @@ const (
 	ruleAction11
 	ruleAction12
 	ruleAction13
-	rulePegText
 	ruleAction14
 	ruleAction15
+	rulePegText
 	ruleAction16
 	ruleAction17
 	ruleAction18
@@ -101,6 +101,8 @@ const (
 	ruleAction47
 	ruleAction48
 	ruleAction49
+	ruleAction50
+	ruleAction51
 )
 
 var rul3s = [...]string{
@@ -153,9 +155,9 @@ var rul3s = [...]string{
 	"Action11",
 	"Action12",
 	"Action13",
-	"PegText",
 	"Action14",
 	"Action15",
+	"PegText",
 	"Action16",
 	"Action17",
 	"Action18",
@@ -190,6 +192,8 @@ var rul3s = [...]string{
 	"Action47",
 	"Action48",
 	"Action49",
+	"Action50",
+	"Action51",
 }
 
 type token32 struct {
@@ -306,7 +310,7 @@ type PQL struct {
 
 	Buffer string
 	buffer []rune
-	rules  [86]func() bool
+	rules  [88]func() bool
 	parse  func(rule ...int) error
 	reset  func()
 	Pretty bool
@@ -419,84 +423,88 @@ func (p *PQL) Execute() {
 		case ruleAction9:
 			p.endCall()
 		case ruleAction10:
-			p.startCall("TopN")
+			p.startCall("Store")
 		case ruleAction11:
 			p.endCall()
 		case ruleAction12:
-			p.startCall("Range")
+			p.startCall("TopN")
 		case ruleAction13:
 			p.endCall()
 		case ruleAction14:
-			p.startCall(buffer[begin:end])
+			p.startCall("Range")
 		case ruleAction15:
 			p.endCall()
 		case ruleAction16:
-			p.addBTWN()
+			p.startCall(buffer[begin:end])
 		case ruleAction17:
-			p.addLTE()
+			p.endCall()
 		case ruleAction18:
-			p.addGTE()
+			p.addBTWN()
 		case ruleAction19:
-			p.addEQ()
+			p.addLTE()
 		case ruleAction20:
-			p.addNEQ()
+			p.addGTE()
 		case ruleAction21:
-			p.addLT()
+			p.addEQ()
 		case ruleAction22:
-			p.addGT()
+			p.addNEQ()
 		case ruleAction23:
-			p.startConditional()
+			p.addLT()
 		case ruleAction24:
-			p.endConditional()
+			p.addGT()
 		case ruleAction25:
-			p.condAdd(buffer[begin:end])
+			p.startConditional()
 		case ruleAction26:
-			p.condAdd(buffer[begin:end])
+			p.endConditional()
 		case ruleAction27:
 			p.condAdd(buffer[begin:end])
 		case ruleAction28:
-			p.addPosStr("_start", buffer[begin:end])
+			p.condAdd(buffer[begin:end])
 		case ruleAction29:
-			p.addPosStr("_end", buffer[begin:end])
+			p.condAdd(buffer[begin:end])
 		case ruleAction30:
-			p.startList()
+			p.addPosStr("_start", buffer[begin:end])
 		case ruleAction31:
-			p.endList()
+			p.addPosStr("_end", buffer[begin:end])
 		case ruleAction32:
-			p.addVal(nil)
+			p.startList()
 		case ruleAction33:
-			p.addVal(true)
+			p.endList()
 		case ruleAction34:
-			p.addVal(false)
+			p.addVal(nil)
 		case ruleAction35:
-			p.addNumVal(buffer[begin:end])
+			p.addVal(true)
 		case ruleAction36:
-			p.addNumVal(buffer[begin:end])
+			p.addVal(false)
 		case ruleAction37:
-			p.addVal(buffer[begin:end])
+			p.addNumVal(buffer[begin:end])
 		case ruleAction38:
-			p.addVal(buffer[begin:end])
+			p.addNumVal(buffer[begin:end])
 		case ruleAction39:
 			p.addVal(buffer[begin:end])
 		case ruleAction40:
-			p.addField(buffer[begin:end])
+			p.addVal(buffer[begin:end])
 		case ruleAction41:
-			p.addPosStr("_field", buffer[begin:end])
+			p.addVal(buffer[begin:end])
 		case ruleAction42:
-			p.addPosNum("_row", buffer[begin:end])
+			p.addField(buffer[begin:end])
 		case ruleAction43:
-			p.addPosNum("_col", buffer[begin:end])
+			p.addPosStr("_field", buffer[begin:end])
 		case ruleAction44:
-			p.addPosStr("_col", buffer[begin:end])
-		case ruleAction45:
-			p.addPosStr("_col", buffer[begin:end])
-		case ruleAction46:
 			p.addPosNum("_row", buffer[begin:end])
+		case ruleAction45:
+			p.addPosNum("_col", buffer[begin:end])
+		case ruleAction46:
+			p.addPosStr("_col", buffer[begin:end])
 		case ruleAction47:
-			p.addPosStr("_row", buffer[begin:end])
+			p.addPosStr("_col", buffer[begin:end])
 		case ruleAction48:
-			p.addPosStr("_row", buffer[begin:end])
+			p.addPosNum("_row", buffer[begin:end])
 		case ruleAction49:
+			p.addPosStr("_row", buffer[begin:end])
+		case ruleAction50:
+			p.addPosStr("_row", buffer[begin:end])
+		case ruleAction51:
 			p.addPosStr("_timestamp", buffer[begin:end])
 
 		}
@@ -609,7 +617,7 @@ func (p *PQL) Init() {
 			position, tokenIndex = position0, tokenIndex0
 			return false
 		},
-		/* 1 Call <- <(('S' 'e' 't' Action0 open col comma args (comma timestamp)? close Action1) / ('S' 'e' 't' 'R' 'o' 'w' 'A' 't' 't' 'r' 's' Action2 open posfield comma row comma args close Action3) / ('S' 'e' 't' 'C' 'o' 'l' 'u' 'm' 'n' 'A' 't' 't' 'r' 's' Action4 open col comma args close Action5) / ('C' 'l' 'e' 'a' 'r' Action6 open col comma args close Action7) / ('C' 'l' 'e' 'a' 'r' 'R' 'o' 'w' Action8 open arg close Action9) / ('T' 'o' 'p' 'N' Action10 open posfield (comma allargs)? close Action11) / ('R' 'a' 'n' 'g' 'e' Action12 open (timerange / conditional / arg) close Action13) / (<IDENT> Action14 open allargs comma? close Action15))> */
+		/* 1 Call <- <(('S' 'e' 't' Action0 open col comma args (comma timestamp)? close Action1) / ('S' 'e' 't' 'R' 'o' 'w' 'A' 't' 't' 'r' 's' Action2 open posfield comma row comma args close Action3) / ('S' 'e' 't' 'C' 'o' 'l' 'u' 'm' 'n' 'A' 't' 't' 'r' 's' Action4 open col comma args close Action5) / ('C' 'l' 'e' 'a' 'r' Action6 open col comma args close Action7) / ('C' 'l' 'e' 'a' 'r' 'R' 'o' 'w' Action8 open arg close Action9) / ('S' 't' 'o' 'r' 'e' Action10 open Call comma arg close Action11) / ('T' 'o' 'p' 'N' Action12 open posfield (comma allargs)? close Action13) / ('R' 'a' 'n' 'g' 'e' Action14 open (timerange / conditional / arg) close Action15) / (<IDENT> Action16 open allargs comma? close Action17))> */
 		func() bool {
 			position5, tokenIndex5 := position, tokenIndex
 			{
@@ -658,7 +666,7 @@ func (p *PQL) Init() {
 								add(rulePegText, position13)
 							}
 							{
-								add(ruleAction49, position)
+								add(ruleAction51, position)
 							}
 							add(ruletimestamp, position12)
 						}
@@ -744,7 +752,7 @@ func (p *PQL) Init() {
 								add(rulePegText, position21)
 							}
 							{
-								add(ruleAction46, position)
+								add(ruleAction48, position)
 							}
 							goto l19
 						l20:
@@ -765,7 +773,7 @@ func (p *PQL) Init() {
 							}
 							position++
 							{
-								add(ruleAction47, position)
+								add(ruleAction49, position)
 							}
 							goto l19
 						l23:
@@ -786,7 +794,7 @@ func (p *PQL) Init() {
 							}
 							position++
 							{
-								add(ruleAction48, position)
+								add(ruleAction50, position)
 							}
 						}
 					l19:
@@ -981,7 +989,11 @@ func (p *PQL) Init() {
 					goto l7
 				l35:
 					position, tokenIndex = position7, tokenIndex7
-					if buffer[position] != rune('T') {
+					if buffer[position] != rune('S') {
+						goto l38
+					}
+					position++
+					if buffer[position] != rune('t') {
 						goto l38
 					}
 					position++
@@ -989,11 +1001,11 @@ func (p *PQL) Init() {
 						goto l38
 					}
 					position++
-					if buffer[position] != rune('p') {
+					if buffer[position] != rune('r') {
 						goto l38
 					}
 					position++
-					if buffer[position] != rune('N') {
+					if buffer[position] != rune('e') {
 						goto l38
 					}
 					position++
@@ -1003,22 +1015,15 @@ func (p *PQL) Init() {
 					if !_rules[ruleopen]() {
 						goto l38
 					}
-					if !_rules[ruleposfield]() {
+					if !_rules[ruleCall]() {
 						goto l38
 					}
-					{
-						position40, tokenIndex40 := position, tokenIndex
-						if !_rules[rulecomma]() {
-							goto l40
-						}
-						if !_rules[ruleallargs]() {
-							goto l40
-						}
-						goto l41
-					l40:
-						position, tokenIndex = position40, tokenIndex40
+					if !_rules[rulecomma]() {
+						goto l38
 					}
-				l41:
+					if !_rules[rulearg]() {
+						goto l38
+					}
 					if !_rules[ruleclose]() {
 						goto l38
 					}
@@ -1028,193 +1033,240 @@ func (p *PQL) Init() {
 					goto l7
 				l38:
 					position, tokenIndex = position7, tokenIndex7
-					if buffer[position] != rune('R') {
-						goto l43
+					if buffer[position] != rune('T') {
+						goto l41
 					}
 					position++
-					if buffer[position] != rune('a') {
-						goto l43
+					if buffer[position] != rune('o') {
+						goto l41
 					}
 					position++
-					if buffer[position] != rune('n') {
-						goto l43
+					if buffer[position] != rune('p') {
+						goto l41
 					}
 					position++
-					if buffer[position] != rune('g') {
-						goto l43
-					}
-					position++
-					if buffer[position] != rune('e') {
-						goto l43
+					if buffer[position] != rune('N') {
+						goto l41
 					}
 					position++
 					{
 						add(ruleAction12, position)
 					}
 					if !_rules[ruleopen]() {
-						goto l43
+						goto l41
+					}
+					if !_rules[ruleposfield]() {
+						goto l41
 					}
 					{
-						position45, tokenIndex45 := position, tokenIndex
-						{
-							position47 := position
-							if !_rules[rulefield]() {
-								goto l46
-							}
-							if !_rules[rulesp]() {
-								goto l46
-							}
-							if buffer[position] != rune('=') {
-								goto l46
-							}
-							position++
-							if !_rules[rulesp]() {
-								goto l46
-							}
-							if !_rules[rulevalue]() {
-								goto l46
-							}
-							if !_rules[rulecomma]() {
-								goto l46
-							}
-							{
-								position48 := position
-								if !_rules[ruletimestampfmt]() {
-									goto l46
-								}
-								add(rulePegText, position48)
-							}
-							{
-								add(ruleAction28, position)
-							}
-							if !_rules[rulecomma]() {
-								goto l46
-							}
-							{
-								position50 := position
-								if !_rules[ruletimestampfmt]() {
-									goto l46
-								}
-								add(rulePegText, position50)
-							}
-							{
-								add(ruleAction29, position)
-							}
-							add(ruletimerange, position47)
-						}
-						goto l45
-					l46:
-						position, tokenIndex = position45, tokenIndex45
-						{
-							position53 := position
-							{
-								add(ruleAction23, position)
-							}
-							if !_rules[rulecondint]() {
-								goto l52
-							}
-							if !_rules[rulecondLT]() {
-								goto l52
-							}
-							{
-								position55 := position
-								{
-									position56 := position
-									if !_rules[rulefieldExpr]() {
-										goto l52
-									}
-									add(rulePegText, position56)
-								}
-								if !_rules[rulesp]() {
-									goto l52
-								}
-								{
-									add(ruleAction27, position)
-								}
-								add(rulecondfield, position55)
-							}
-							if !_rules[rulecondLT]() {
-								goto l52
-							}
-							if !_rules[rulecondint]() {
-								goto l52
-							}
-							{
-								add(ruleAction24, position)
-							}
-							add(ruleconditional, position53)
-						}
-						goto l45
-					l52:
-						position, tokenIndex = position45, tokenIndex45
-						if !_rules[rulearg]() {
+						position43, tokenIndex43 := position, tokenIndex
+						if !_rules[rulecomma]() {
 							goto l43
 						}
+						if !_rules[ruleallargs]() {
+							goto l43
+						}
+						goto l44
+					l43:
+						position, tokenIndex = position43, tokenIndex43
 					}
-				l45:
+				l44:
 					if !_rules[ruleclose]() {
-						goto l43
+						goto l41
 					}
 					{
 						add(ruleAction13, position)
 					}
 					goto l7
-				l43:
+				l41:
+					position, tokenIndex = position7, tokenIndex7
+					if buffer[position] != rune('R') {
+						goto l46
+					}
+					position++
+					if buffer[position] != rune('a') {
+						goto l46
+					}
+					position++
+					if buffer[position] != rune('n') {
+						goto l46
+					}
+					position++
+					if buffer[position] != rune('g') {
+						goto l46
+					}
+					position++
+					if buffer[position] != rune('e') {
+						goto l46
+					}
+					position++
+					{
+						add(ruleAction14, position)
+					}
+					if !_rules[ruleopen]() {
+						goto l46
+					}
+					{
+						position48, tokenIndex48 := position, tokenIndex
+						{
+							position50 := position
+							if !_rules[rulefield]() {
+								goto l49
+							}
+							if !_rules[rulesp]() {
+								goto l49
+							}
+							if buffer[position] != rune('=') {
+								goto l49
+							}
+							position++
+							if !_rules[rulesp]() {
+								goto l49
+							}
+							if !_rules[rulevalue]() {
+								goto l49
+							}
+							if !_rules[rulecomma]() {
+								goto l49
+							}
+							{
+								position51 := position
+								if !_rules[ruletimestampfmt]() {
+									goto l49
+								}
+								add(rulePegText, position51)
+							}
+							{
+								add(ruleAction30, position)
+							}
+							if !_rules[rulecomma]() {
+								goto l49
+							}
+							{
+								position53 := position
+								if !_rules[ruletimestampfmt]() {
+									goto l49
+								}
+								add(rulePegText, position53)
+							}
+							{
+								add(ruleAction31, position)
+							}
+							add(ruletimerange, position50)
+						}
+						goto l48
+					l49:
+						position, tokenIndex = position48, tokenIndex48
+						{
+							position56 := position
+							{
+								add(ruleAction25, position)
+							}
+							if !_rules[rulecondint]() {
+								goto l55
+							}
+							if !_rules[rulecondLT]() {
+								goto l55
+							}
+							{
+								position58 := position
+								{
+									position59 := position
+									if !_rules[rulefieldExpr]() {
+										goto l55
+									}
+									add(rulePegText, position59)
+								}
+								if !_rules[rulesp]() {
+									goto l55
+								}
+								{
+									add(ruleAction29, position)
+								}
+								add(rulecondfield, position58)
+							}
+							if !_rules[rulecondLT]() {
+								goto l55
+							}
+							if !_rules[rulecondint]() {
+								goto l55
+							}
+							{
+								add(ruleAction26, position)
+							}
+							add(ruleconditional, position56)
+						}
+						goto l48
+					l55:
+						position, tokenIndex = position48, tokenIndex48
+						if !_rules[rulearg]() {
+							goto l46
+						}
+					}
+				l48:
+					if !_rules[ruleclose]() {
+						goto l46
+					}
+					{
+						add(ruleAction15, position)
+					}
+					goto l7
+				l46:
 					position, tokenIndex = position7, tokenIndex7
 					{
-						position60 := position
+						position63 := position
 						{
-							position61 := position
+							position64 := position
 							{
-								position62, tokenIndex62 := position, tokenIndex
+								position65, tokenIndex65 := position, tokenIndex
 								if c := buffer[position]; c < rune('a') || c > rune('z') {
-									goto l63
+									goto l66
 								}
 								position++
-								goto l62
-							l63:
-								position, tokenIndex = position62, tokenIndex62
+								goto l65
+							l66:
+								position, tokenIndex = position65, tokenIndex65
 								if c := buffer[position]; c < rune('A') || c > rune('Z') {
 									goto l5
 								}
 								position++
 							}
-						l62:
-						l64:
+						l65:
+						l67:
 							{
-								position65, tokenIndex65 := position, tokenIndex
+								position68, tokenIndex68 := position, tokenIndex
 								{
-									position66, tokenIndex66 := position, tokenIndex
+									position69, tokenIndex69 := position, tokenIndex
 									if c := buffer[position]; c < rune('a') || c > rune('z') {
-										goto l67
+										goto l70
 									}
 									position++
-									goto l66
-								l67:
-									position, tokenIndex = position66, tokenIndex66
+									goto l69
+								l70:
+									position, tokenIndex = position69, tokenIndex69
 									if c := buffer[position]; c < rune('A') || c > rune('Z') {
+										goto l71
+									}
+									position++
+									goto l69
+								l71:
+									position, tokenIndex = position69, tokenIndex69
+									if c := buffer[position]; c < rune('0') || c > rune('9') {
 										goto l68
 									}
 									position++
-									goto l66
-								l68:
-									position, tokenIndex = position66, tokenIndex66
-									if c := buffer[position]; c < rune('0') || c > rune('9') {
-										goto l65
-									}
-									position++
 								}
-							l66:
-								goto l64
-							l65:
-								position, tokenIndex = position65, tokenIndex65
+							l69:
+								goto l67
+							l68:
+								position, tokenIndex = position68, tokenIndex68
 							}
-							add(ruleIDENT, position61)
+							add(ruleIDENT, position64)
 						}
-						add(rulePegText, position60)
+						add(rulePegText, position63)
 					}
 					{
-						add(ruleAction14, position)
+						add(ruleAction16, position)
 					}
 					if !_rules[ruleopen]() {
 						goto l5
@@ -1223,20 +1275,20 @@ func (p *PQL) Init() {
 						goto l5
 					}
 					{
-						position70, tokenIndex70 := position, tokenIndex
+						position73, tokenIndex73 := position, tokenIndex
 						if !_rules[rulecomma]() {
-							goto l70
+							goto l73
 						}
-						goto l71
-					l70:
-						position, tokenIndex = position70, tokenIndex70
+						goto l74
+					l73:
+						position, tokenIndex = position73, tokenIndex73
 					}
-				l71:
+				l74:
 					if !_rules[ruleclose]() {
 						goto l5
 					}
 					{
-						add(ruleAction15, position)
+						add(ruleAction17, position)
 					}
 				}
 			l7:
@@ -1249,1487 +1301,1487 @@ func (p *PQL) Init() {
 		},
 		/* 2 allargs <- <((Call (comma Call)* (comma args)?) / args / sp)> */
 		func() bool {
-			position73, tokenIndex73 := position, tokenIndex
+			position76, tokenIndex76 := position, tokenIndex
 			{
-				position74 := position
+				position77 := position
 				{
-					position75, tokenIndex75 := position, tokenIndex
+					position78, tokenIndex78 := position, tokenIndex
 					if !_rules[ruleCall]() {
-						goto l76
-					}
-				l77:
-					{
-						position78, tokenIndex78 := position, tokenIndex
-						if !_rules[rulecomma]() {
-							goto l78
-						}
-						if !_rules[ruleCall]() {
-							goto l78
-						}
-						goto l77
-					l78:
-						position, tokenIndex = position78, tokenIndex78
-					}
-					{
-						position79, tokenIndex79 := position, tokenIndex
-						if !_rules[rulecomma]() {
-							goto l79
-						}
-						if !_rules[ruleargs]() {
-							goto l79
-						}
-						goto l80
-					l79:
-						position, tokenIndex = position79, tokenIndex79
+						goto l79
 					}
 				l80:
-					goto l75
-				l76:
-					position, tokenIndex = position75, tokenIndex75
-					if !_rules[ruleargs]() {
-						goto l81
+					{
+						position81, tokenIndex81 := position, tokenIndex
+						if !_rules[rulecomma]() {
+							goto l81
+						}
+						if !_rules[ruleCall]() {
+							goto l81
+						}
+						goto l80
+					l81:
+						position, tokenIndex = position81, tokenIndex81
 					}
-					goto l75
-				l81:
-					position, tokenIndex = position75, tokenIndex75
+					{
+						position82, tokenIndex82 := position, tokenIndex
+						if !_rules[rulecomma]() {
+							goto l82
+						}
+						if !_rules[ruleargs]() {
+							goto l82
+						}
+						goto l83
+					l82:
+						position, tokenIndex = position82, tokenIndex82
+					}
+				l83:
+					goto l78
+				l79:
+					position, tokenIndex = position78, tokenIndex78
+					if !_rules[ruleargs]() {
+						goto l84
+					}
+					goto l78
+				l84:
+					position, tokenIndex = position78, tokenIndex78
 					if !_rules[rulesp]() {
-						goto l73
+						goto l76
 					}
 				}
-			l75:
-				add(ruleallargs, position74)
+			l78:
+				add(ruleallargs, position77)
 			}
 			return true
-		l73:
-			position, tokenIndex = position73, tokenIndex73
+		l76:
+			position, tokenIndex = position76, tokenIndex76
 			return false
 		},
 		/* 3 args <- <(arg (comma args)? sp)> */
 		func() bool {
-			position82, tokenIndex82 := position, tokenIndex
+			position85, tokenIndex85 := position, tokenIndex
 			{
-				position83 := position
+				position86 := position
 				if !_rules[rulearg]() {
-					goto l82
+					goto l85
 				}
 				{
-					position84, tokenIndex84 := position, tokenIndex
+					position87, tokenIndex87 := position, tokenIndex
 					if !_rules[rulecomma]() {
-						goto l84
+						goto l87
 					}
 					if !_rules[ruleargs]() {
-						goto l84
+						goto l87
 					}
-					goto l85
-				l84:
-					position, tokenIndex = position84, tokenIndex84
+					goto l88
+				l87:
+					position, tokenIndex = position87, tokenIndex87
 				}
-			l85:
+			l88:
 				if !_rules[rulesp]() {
-					goto l82
+					goto l85
 				}
-				add(ruleargs, position83)
+				add(ruleargs, position86)
 			}
 			return true
-		l82:
-			position, tokenIndex = position82, tokenIndex82
+		l85:
+			position, tokenIndex = position85, tokenIndex85
 			return false
 		},
 		/* 4 arg <- <((field sp '=' sp value) / (field sp COND sp value))> */
 		func() bool {
-			position86, tokenIndex86 := position, tokenIndex
+			position89, tokenIndex89 := position, tokenIndex
 			{
-				position87 := position
+				position90 := position
 				{
-					position88, tokenIndex88 := position, tokenIndex
+					position91, tokenIndex91 := position, tokenIndex
 					if !_rules[rulefield]() {
-						goto l89
+						goto l92
 					}
 					if !_rules[rulesp]() {
-						goto l89
+						goto l92
 					}
 					if buffer[position] != rune('=') {
-						goto l89
+						goto l92
 					}
 					position++
 					if !_rules[rulesp]() {
-						goto l89
+						goto l92
 					}
 					if !_rules[rulevalue]() {
+						goto l92
+					}
+					goto l91
+				l92:
+					position, tokenIndex = position91, tokenIndex91
+					if !_rules[rulefield]() {
 						goto l89
 					}
-					goto l88
-				l89:
-					position, tokenIndex = position88, tokenIndex88
-					if !_rules[rulefield]() {
-						goto l86
-					}
 					if !_rules[rulesp]() {
-						goto l86
+						goto l89
 					}
 					{
-						position90 := position
+						position93 := position
 						{
-							position91, tokenIndex91 := position, tokenIndex
+							position94, tokenIndex94 := position, tokenIndex
 							if buffer[position] != rune('>') {
-								goto l92
+								goto l95
 							}
 							position++
 							if buffer[position] != rune('<') {
-								goto l92
-							}
-							position++
-							{
-								add(ruleAction16, position)
-							}
-							goto l91
-						l92:
-							position, tokenIndex = position91, tokenIndex91
-							if buffer[position] != rune('<') {
-								goto l94
-							}
-							position++
-							if buffer[position] != rune('=') {
-								goto l94
-							}
-							position++
-							{
-								add(ruleAction17, position)
-							}
-							goto l91
-						l94:
-							position, tokenIndex = position91, tokenIndex91
-							if buffer[position] != rune('>') {
-								goto l96
-							}
-							position++
-							if buffer[position] != rune('=') {
-								goto l96
+								goto l95
 							}
 							position++
 							{
 								add(ruleAction18, position)
 							}
-							goto l91
-						l96:
-							position, tokenIndex = position91, tokenIndex91
-							if buffer[position] != rune('=') {
-								goto l98
+							goto l94
+						l95:
+							position, tokenIndex = position94, tokenIndex94
+							if buffer[position] != rune('<') {
+								goto l97
 							}
 							position++
 							if buffer[position] != rune('=') {
-								goto l98
+								goto l97
 							}
 							position++
 							{
 								add(ruleAction19, position)
 							}
-							goto l91
-						l98:
-							position, tokenIndex = position91, tokenIndex91
-							if buffer[position] != rune('!') {
-								goto l100
+							goto l94
+						l97:
+							position, tokenIndex = position94, tokenIndex94
+							if buffer[position] != rune('>') {
+								goto l99
 							}
 							position++
 							if buffer[position] != rune('=') {
-								goto l100
+								goto l99
 							}
 							position++
 							{
 								add(ruleAction20, position)
 							}
-							goto l91
-						l100:
-							position, tokenIndex = position91, tokenIndex91
-							if buffer[position] != rune('<') {
-								goto l102
+							goto l94
+						l99:
+							position, tokenIndex = position94, tokenIndex94
+							if buffer[position] != rune('=') {
+								goto l101
+							}
+							position++
+							if buffer[position] != rune('=') {
+								goto l101
 							}
 							position++
 							{
 								add(ruleAction21, position)
 							}
-							goto l91
-						l102:
-							position, tokenIndex = position91, tokenIndex91
-							if buffer[position] != rune('>') {
-								goto l86
+							goto l94
+						l101:
+							position, tokenIndex = position94, tokenIndex94
+							if buffer[position] != rune('!') {
+								goto l103
+							}
+							position++
+							if buffer[position] != rune('=') {
+								goto l103
 							}
 							position++
 							{
 								add(ruleAction22, position)
 							}
-						}
-					l91:
-						add(ruleCOND, position90)
-					}
-					if !_rules[rulesp]() {
-						goto l86
-					}
-					if !_rules[rulevalue]() {
-						goto l86
-					}
-				}
-			l88:
-				add(rulearg, position87)
-			}
-			return true
-		l86:
-			position, tokenIndex = position86, tokenIndex86
-			return false
-		},
-		/* 5 COND <- <(('>' '<' Action16) / ('<' '=' Action17) / ('>' '=' Action18) / ('=' '=' Action19) / ('!' '=' Action20) / ('<' Action21) / ('>' Action22))> */
-		nil,
-		/* 6 conditional <- <(Action23 condint condLT condfield condLT condint Action24)> */
-		nil,
-		/* 7 condint <- <(<(('-'? [1-9] [0-9]*) / '0')> sp Action25)> */
-		func() bool {
-			position107, tokenIndex107 := position, tokenIndex
-			{
-				position108 := position
-				{
-					position109 := position
-					{
-						position110, tokenIndex110 := position, tokenIndex
-						{
-							position112, tokenIndex112 := position, tokenIndex
-							if buffer[position] != rune('-') {
-								goto l112
+							goto l94
+						l103:
+							position, tokenIndex = position94, tokenIndex94
+							if buffer[position] != rune('<') {
+								goto l105
 							}
 							position++
-							goto l113
-						l112:
-							position, tokenIndex = position112, tokenIndex112
+							{
+								add(ruleAction23, position)
+							}
+							goto l94
+						l105:
+							position, tokenIndex = position94, tokenIndex94
+							if buffer[position] != rune('>') {
+								goto l89
+							}
+							position++
+							{
+								add(ruleAction24, position)
+							}
 						}
-					l113:
-						if c := buffer[position]; c < rune('1') || c > rune('9') {
-							goto l111
-						}
-						position++
-					l114:
+					l94:
+						add(ruleCOND, position93)
+					}
+					if !_rules[rulesp]() {
+						goto l89
+					}
+					if !_rules[rulevalue]() {
+						goto l89
+					}
+				}
+			l91:
+				add(rulearg, position90)
+			}
+			return true
+		l89:
+			position, tokenIndex = position89, tokenIndex89
+			return false
+		},
+		/* 5 COND <- <(('>' '<' Action18) / ('<' '=' Action19) / ('>' '=' Action20) / ('=' '=' Action21) / ('!' '=' Action22) / ('<' Action23) / ('>' Action24))> */
+		nil,
+		/* 6 conditional <- <(Action25 condint condLT condfield condLT condint Action26)> */
+		nil,
+		/* 7 condint <- <(<(('-'? [1-9] [0-9]*) / '0')> sp Action27)> */
+		func() bool {
+			position110, tokenIndex110 := position, tokenIndex
+			{
+				position111 := position
+				{
+					position112 := position
+					{
+						position113, tokenIndex113 := position, tokenIndex
 						{
 							position115, tokenIndex115 := position, tokenIndex
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
+							if buffer[position] != rune('-') {
 								goto l115
 							}
 							position++
-							goto l114
+							goto l116
 						l115:
 							position, tokenIndex = position115, tokenIndex115
 						}
-						goto l110
-					l111:
-						position, tokenIndex = position110, tokenIndex110
+					l116:
+						if c := buffer[position]; c < rune('1') || c > rune('9') {
+							goto l114
+						}
+						position++
+					l117:
+						{
+							position118, tokenIndex118 := position, tokenIndex
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l118
+							}
+							position++
+							goto l117
+						l118:
+							position, tokenIndex = position118, tokenIndex118
+						}
+						goto l113
+					l114:
+						position, tokenIndex = position113, tokenIndex113
 						if buffer[position] != rune('0') {
-							goto l107
+							goto l110
 						}
 						position++
 					}
-				l110:
-					add(rulePegText, position109)
+				l113:
+					add(rulePegText, position112)
 				}
 				if !_rules[rulesp]() {
-					goto l107
+					goto l110
 				}
 				{
-					add(ruleAction25, position)
+					add(ruleAction27, position)
 				}
-				add(rulecondint, position108)
+				add(rulecondint, position111)
 			}
 			return true
-		l107:
-			position, tokenIndex = position107, tokenIndex107
+		l110:
+			position, tokenIndex = position110, tokenIndex110
 			return false
 		},
-		/* 8 condLT <- <(<(('<' '=') / '<')> sp Action26)> */
+		/* 8 condLT <- <(<(('<' '=') / '<')> sp Action28)> */
 		func() bool {
-			position117, tokenIndex117 := position, tokenIndex
+			position120, tokenIndex120 := position, tokenIndex
 			{
-				position118 := position
+				position121 := position
 				{
-					position119 := position
+					position122 := position
 					{
-						position120, tokenIndex120 := position, tokenIndex
+						position123, tokenIndex123 := position, tokenIndex
 						if buffer[position] != rune('<') {
-							goto l121
+							goto l124
 						}
 						position++
 						if buffer[position] != rune('=') {
-							goto l121
+							goto l124
 						}
 						position++
-						goto l120
-					l121:
-						position, tokenIndex = position120, tokenIndex120
+						goto l123
+					l124:
+						position, tokenIndex = position123, tokenIndex123
 						if buffer[position] != rune('<') {
-							goto l117
+							goto l120
 						}
 						position++
 					}
-				l120:
-					add(rulePegText, position119)
+				l123:
+					add(rulePegText, position122)
 				}
 				if !_rules[rulesp]() {
-					goto l117
+					goto l120
 				}
 				{
-					add(ruleAction26, position)
+					add(ruleAction28, position)
 				}
-				add(rulecondLT, position118)
+				add(rulecondLT, position121)
 			}
 			return true
-		l117:
-			position, tokenIndex = position117, tokenIndex117
+		l120:
+			position, tokenIndex = position120, tokenIndex120
 			return false
 		},
-		/* 9 condfield <- <(<fieldExpr> sp Action27)> */
+		/* 9 condfield <- <(<fieldExpr> sp Action29)> */
 		nil,
-		/* 10 timerange <- <(field sp '=' sp value comma <timestampfmt> Action28 comma <timestampfmt> Action29)> */
+		/* 10 timerange <- <(field sp '=' sp value comma <timestampfmt> Action30 comma <timestampfmt> Action31)> */
 		nil,
-		/* 11 value <- <(item / (lbrack Action30 list rbrack Action31))> */
+		/* 11 value <- <(item / (lbrack Action32 list rbrack Action33))> */
 		func() bool {
-			position125, tokenIndex125 := position, tokenIndex
+			position128, tokenIndex128 := position, tokenIndex
 			{
-				position126 := position
+				position129 := position
 				{
-					position127, tokenIndex127 := position, tokenIndex
+					position130, tokenIndex130 := position, tokenIndex
 					if !_rules[ruleitem]() {
-						goto l128
+						goto l131
 					}
-					goto l127
-				l128:
-					position, tokenIndex = position127, tokenIndex127
+					goto l130
+				l131:
+					position, tokenIndex = position130, tokenIndex130
 					{
-						position129 := position
+						position132 := position
 						if buffer[position] != rune('[') {
-							goto l125
+							goto l128
 						}
 						position++
 						if !_rules[rulesp]() {
-							goto l125
+							goto l128
 						}
-						add(rulelbrack, position129)
-					}
-					{
-						add(ruleAction30, position)
-					}
-					if !_rules[rulelist]() {
-						goto l125
-					}
-					{
-						position131 := position
-						if !_rules[rulesp]() {
-							goto l125
-						}
-						if buffer[position] != rune(']') {
-							goto l125
-						}
-						position++
-						if !_rules[rulesp]() {
-							goto l125
-						}
-						add(rulerbrack, position131)
-					}
-					{
-						add(ruleAction31, position)
-					}
-				}
-			l127:
-				add(rulevalue, position126)
-			}
-			return true
-		l125:
-			position, tokenIndex = position125, tokenIndex125
-			return false
-		},
-		/* 12 list <- <(item (comma list)?)> */
-		func() bool {
-			position133, tokenIndex133 := position, tokenIndex
-			{
-				position134 := position
-				if !_rules[ruleitem]() {
-					goto l133
-				}
-				{
-					position135, tokenIndex135 := position, tokenIndex
-					if !_rules[rulecomma]() {
-						goto l135
-					}
-					if !_rules[rulelist]() {
-						goto l135
-					}
-					goto l136
-				l135:
-					position, tokenIndex = position135, tokenIndex135
-				}
-			l136:
-				add(rulelist, position134)
-			}
-			return true
-		l133:
-			position, tokenIndex = position133, tokenIndex133
-			return false
-		},
-		/* 13 item <- <(('n' 'u' 'l' 'l' &(comma / (sp close)) Action32) / ('t' 'r' 'u' 'e' &(comma / (sp close)) Action33) / ('f' 'a' 'l' 's' 'e' &(comma / (sp close)) Action34) / (<('-'? [0-9]+ ('.' [0-9]*)?)> Action35) / (<('-'? '.' [0-9]+)> Action36) / (<([a-z] / [A-Z] / [0-9] / '-' / '_' / ':')+> Action37) / ('"' <doublequotedstring> '"' Action38) / ('\'' <singlequotedstring> '\'' Action39))> */
-		func() bool {
-			position137, tokenIndex137 := position, tokenIndex
-			{
-				position138 := position
-				{
-					position139, tokenIndex139 := position, tokenIndex
-					if buffer[position] != rune('n') {
-						goto l140
-					}
-					position++
-					if buffer[position] != rune('u') {
-						goto l140
-					}
-					position++
-					if buffer[position] != rune('l') {
-						goto l140
-					}
-					position++
-					if buffer[position] != rune('l') {
-						goto l140
-					}
-					position++
-					{
-						position141, tokenIndex141 := position, tokenIndex
-						{
-							position142, tokenIndex142 := position, tokenIndex
-							if !_rules[rulecomma]() {
-								goto l143
-							}
-							goto l142
-						l143:
-							position, tokenIndex = position142, tokenIndex142
-							if !_rules[rulesp]() {
-								goto l140
-							}
-							if !_rules[ruleclose]() {
-								goto l140
-							}
-						}
-					l142:
-						position, tokenIndex = position141, tokenIndex141
+						add(rulelbrack, position132)
 					}
 					{
 						add(ruleAction32, position)
 					}
-					goto l139
-				l140:
-					position, tokenIndex = position139, tokenIndex139
-					if buffer[position] != rune('t') {
-						goto l145
+					if !_rules[rulelist]() {
+						goto l128
 					}
-					position++
-					if buffer[position] != rune('r') {
-						goto l145
-					}
-					position++
-					if buffer[position] != rune('u') {
-						goto l145
-					}
-					position++
-					if buffer[position] != rune('e') {
-						goto l145
-					}
-					position++
 					{
-						position146, tokenIndex146 := position, tokenIndex
-						{
-							position147, tokenIndex147 := position, tokenIndex
-							if !_rules[rulecomma]() {
-								goto l148
-							}
-							goto l147
-						l148:
-							position, tokenIndex = position147, tokenIndex147
-							if !_rules[rulesp]() {
-								goto l145
-							}
-							if !_rules[ruleclose]() {
-								goto l145
-							}
+						position134 := position
+						if !_rules[rulesp]() {
+							goto l128
 						}
-					l147:
-						position, tokenIndex = position146, tokenIndex146
+						if buffer[position] != rune(']') {
+							goto l128
+						}
+						position++
+						if !_rules[rulesp]() {
+							goto l128
+						}
+						add(rulerbrack, position134)
 					}
 					{
 						add(ruleAction33, position)
 					}
+				}
+			l130:
+				add(rulevalue, position129)
+			}
+			return true
+		l128:
+			position, tokenIndex = position128, tokenIndex128
+			return false
+		},
+		/* 12 list <- <(item (comma list)?)> */
+		func() bool {
+			position136, tokenIndex136 := position, tokenIndex
+			{
+				position137 := position
+				if !_rules[ruleitem]() {
+					goto l136
+				}
+				{
+					position138, tokenIndex138 := position, tokenIndex
+					if !_rules[rulecomma]() {
+						goto l138
+					}
+					if !_rules[rulelist]() {
+						goto l138
+					}
 					goto l139
-				l145:
-					position, tokenIndex = position139, tokenIndex139
-					if buffer[position] != rune('f') {
-						goto l150
+				l138:
+					position, tokenIndex = position138, tokenIndex138
+				}
+			l139:
+				add(rulelist, position137)
+			}
+			return true
+		l136:
+			position, tokenIndex = position136, tokenIndex136
+			return false
+		},
+		/* 13 item <- <(('n' 'u' 'l' 'l' &(comma / (sp close)) Action34) / ('t' 'r' 'u' 'e' &(comma / (sp close)) Action35) / ('f' 'a' 'l' 's' 'e' &(comma / (sp close)) Action36) / (<('-'? [0-9]+ ('.' [0-9]*)?)> Action37) / (<('-'? '.' [0-9]+)> Action38) / (<([a-z] / [A-Z] / [0-9] / '-' / '_' / ':')+> Action39) / ('"' <doublequotedstring> '"' Action40) / ('\'' <singlequotedstring> '\'' Action41))> */
+		func() bool {
+			position140, tokenIndex140 := position, tokenIndex
+			{
+				position141 := position
+				{
+					position142, tokenIndex142 := position, tokenIndex
+					if buffer[position] != rune('n') {
+						goto l143
 					}
 					position++
-					if buffer[position] != rune('a') {
-						goto l150
+					if buffer[position] != rune('u') {
+						goto l143
 					}
 					position++
 					if buffer[position] != rune('l') {
-						goto l150
+						goto l143
 					}
 					position++
-					if buffer[position] != rune('s') {
-						goto l150
-					}
-					position++
-					if buffer[position] != rune('e') {
-						goto l150
+					if buffer[position] != rune('l') {
+						goto l143
 					}
 					position++
 					{
-						position151, tokenIndex151 := position, tokenIndex
+						position144, tokenIndex144 := position, tokenIndex
 						{
-							position152, tokenIndex152 := position, tokenIndex
+							position145, tokenIndex145 := position, tokenIndex
 							if !_rules[rulecomma]() {
-								goto l153
+								goto l146
 							}
-							goto l152
-						l153:
-							position, tokenIndex = position152, tokenIndex152
+							goto l145
+						l146:
+							position, tokenIndex = position145, tokenIndex145
 							if !_rules[rulesp]() {
-								goto l150
+								goto l143
 							}
 							if !_rules[ruleclose]() {
-								goto l150
+								goto l143
 							}
 						}
-					l152:
-						position, tokenIndex = position151, tokenIndex151
+					l145:
+						position, tokenIndex = position144, tokenIndex144
 					}
 					{
 						add(ruleAction34, position)
 					}
-					goto l139
-				l150:
-					position, tokenIndex = position139, tokenIndex139
+					goto l142
+				l143:
+					position, tokenIndex = position142, tokenIndex142
+					if buffer[position] != rune('t') {
+						goto l148
+					}
+					position++
+					if buffer[position] != rune('r') {
+						goto l148
+					}
+					position++
+					if buffer[position] != rune('u') {
+						goto l148
+					}
+					position++
+					if buffer[position] != rune('e') {
+						goto l148
+					}
+					position++
 					{
-						position156 := position
+						position149, tokenIndex149 := position, tokenIndex
 						{
-							position157, tokenIndex157 := position, tokenIndex
-							if buffer[position] != rune('-') {
-								goto l157
+							position150, tokenIndex150 := position, tokenIndex
+							if !_rules[rulecomma]() {
+								goto l151
 							}
-							position++
-							goto l158
-						l157:
-							position, tokenIndex = position157, tokenIndex157
-						}
-					l158:
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l155
-						}
-						position++
-					l159:
-						{
-							position160, tokenIndex160 := position, tokenIndex
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l160
+							goto l150
+						l151:
+							position, tokenIndex = position150, tokenIndex150
+							if !_rules[rulesp]() {
+								goto l148
 							}
-							position++
-							goto l159
-						l160:
-							position, tokenIndex = position160, tokenIndex160
-						}
-						{
-							position161, tokenIndex161 := position, tokenIndex
-							if buffer[position] != rune('.') {
-								goto l161
+							if !_rules[ruleclose]() {
+								goto l148
 							}
-							position++
-						l163:
-							{
-								position164, tokenIndex164 := position, tokenIndex
-								if c := buffer[position]; c < rune('0') || c > rune('9') {
-									goto l164
-								}
-								position++
-								goto l163
-							l164:
-								position, tokenIndex = position164, tokenIndex164
-							}
-							goto l162
-						l161:
-							position, tokenIndex = position161, tokenIndex161
 						}
-					l162:
-						add(rulePegText, position156)
+					l150:
+						position, tokenIndex = position149, tokenIndex149
 					}
 					{
 						add(ruleAction35, position)
 					}
-					goto l139
-				l155:
-					position, tokenIndex = position139, tokenIndex139
+					goto l142
+				l148:
+					position, tokenIndex = position142, tokenIndex142
+					if buffer[position] != rune('f') {
+						goto l153
+					}
+					position++
+					if buffer[position] != rune('a') {
+						goto l153
+					}
+					position++
+					if buffer[position] != rune('l') {
+						goto l153
+					}
+					position++
+					if buffer[position] != rune('s') {
+						goto l153
+					}
+					position++
+					if buffer[position] != rune('e') {
+						goto l153
+					}
+					position++
 					{
-						position167 := position
+						position154, tokenIndex154 := position, tokenIndex
 						{
-							position168, tokenIndex168 := position, tokenIndex
-							if buffer[position] != rune('-') {
-								goto l168
+							position155, tokenIndex155 := position, tokenIndex
+							if !_rules[rulecomma]() {
+								goto l156
 							}
-							position++
-							goto l169
-						l168:
-							position, tokenIndex = position168, tokenIndex168
-						}
-					l169:
-						if buffer[position] != rune('.') {
-							goto l166
-						}
-						position++
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l166
-						}
-						position++
-					l170:
-						{
-							position171, tokenIndex171 := position, tokenIndex
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l171
+							goto l155
+						l156:
+							position, tokenIndex = position155, tokenIndex155
+							if !_rules[rulesp]() {
+								goto l153
 							}
-							position++
-							goto l170
-						l171:
-							position, tokenIndex = position171, tokenIndex171
+							if !_rules[ruleclose]() {
+								goto l153
+							}
 						}
-						add(rulePegText, position167)
+					l155:
+						position, tokenIndex = position154, tokenIndex154
 					}
 					{
 						add(ruleAction36, position)
 					}
-					goto l139
-				l166:
-					position, tokenIndex = position139, tokenIndex139
+					goto l142
+				l153:
+					position, tokenIndex = position142, tokenIndex142
 					{
-						position174 := position
+						position159 := position
 						{
-							position177, tokenIndex177 := position, tokenIndex
-							if c := buffer[position]; c < rune('a') || c > rune('z') {
-								goto l178
-							}
-							position++
-							goto l177
-						l178:
-							position, tokenIndex = position177, tokenIndex177
-							if c := buffer[position]; c < rune('A') || c > rune('Z') {
-								goto l179
-							}
-							position++
-							goto l177
-						l179:
-							position, tokenIndex = position177, tokenIndex177
-							if c := buffer[position]; c < rune('0') || c > rune('9') {
-								goto l180
-							}
-							position++
-							goto l177
-						l180:
-							position, tokenIndex = position177, tokenIndex177
+							position160, tokenIndex160 := position, tokenIndex
 							if buffer[position] != rune('-') {
-								goto l181
+								goto l160
 							}
 							position++
-							goto l177
-						l181:
-							position, tokenIndex = position177, tokenIndex177
-							if buffer[position] != rune('_') {
-								goto l182
-							}
-							position++
-							goto l177
-						l182:
-							position, tokenIndex = position177, tokenIndex177
-							if buffer[position] != rune(':') {
-								goto l173
-							}
-							position++
+							goto l161
+						l160:
+							position, tokenIndex = position160, tokenIndex160
 						}
-					l177:
-					l175:
+					l161:
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l158
+						}
+						position++
+					l162:
 						{
-							position176, tokenIndex176 := position, tokenIndex
-							{
-								position183, tokenIndex183 := position, tokenIndex
-								if c := buffer[position]; c < rune('a') || c > rune('z') {
-									goto l184
-								}
-								position++
-								goto l183
-							l184:
-								position, tokenIndex = position183, tokenIndex183
-								if c := buffer[position]; c < rune('A') || c > rune('Z') {
-									goto l185
-								}
-								position++
-								goto l183
-							l185:
-								position, tokenIndex = position183, tokenIndex183
-								if c := buffer[position]; c < rune('0') || c > rune('9') {
-									goto l186
-								}
-								position++
-								goto l183
-							l186:
-								position, tokenIndex = position183, tokenIndex183
-								if buffer[position] != rune('-') {
-									goto l187
-								}
-								position++
-								goto l183
-							l187:
-								position, tokenIndex = position183, tokenIndex183
-								if buffer[position] != rune('_') {
-									goto l188
-								}
-								position++
-								goto l183
-							l188:
-								position, tokenIndex = position183, tokenIndex183
-								if buffer[position] != rune(':') {
-									goto l176
-								}
-								position++
+							position163, tokenIndex163 := position, tokenIndex
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l163
 							}
-						l183:
-							goto l175
-						l176:
-							position, tokenIndex = position176, tokenIndex176
+							position++
+							goto l162
+						l163:
+							position, tokenIndex = position163, tokenIndex163
 						}
-						add(rulePegText, position174)
+						{
+							position164, tokenIndex164 := position, tokenIndex
+							if buffer[position] != rune('.') {
+								goto l164
+							}
+							position++
+						l166:
+							{
+								position167, tokenIndex167 := position, tokenIndex
+								if c := buffer[position]; c < rune('0') || c > rune('9') {
+									goto l167
+								}
+								position++
+								goto l166
+							l167:
+								position, tokenIndex = position167, tokenIndex167
+							}
+							goto l165
+						l164:
+							position, tokenIndex = position164, tokenIndex164
+						}
+					l165:
+						add(rulePegText, position159)
 					}
 					{
 						add(ruleAction37, position)
 					}
-					goto l139
-				l173:
-					position, tokenIndex = position139, tokenIndex139
-					if buffer[position] != rune('"') {
-						goto l190
-					}
-					position++
+					goto l142
+				l158:
+					position, tokenIndex = position142, tokenIndex142
 					{
-						position191 := position
-						if !_rules[ruledoublequotedstring]() {
-							goto l190
+						position170 := position
+						{
+							position171, tokenIndex171 := position, tokenIndex
+							if buffer[position] != rune('-') {
+								goto l171
+							}
+							position++
+							goto l172
+						l171:
+							position, tokenIndex = position171, tokenIndex171
 						}
-						add(rulePegText, position191)
+					l172:
+						if buffer[position] != rune('.') {
+							goto l169
+						}
+						position++
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l169
+						}
+						position++
+					l173:
+						{
+							position174, tokenIndex174 := position, tokenIndex
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l174
+							}
+							position++
+							goto l173
+						l174:
+							position, tokenIndex = position174, tokenIndex174
+						}
+						add(rulePegText, position170)
 					}
-					if buffer[position] != rune('"') {
-						goto l190
-					}
-					position++
 					{
 						add(ruleAction38, position)
 					}
-					goto l139
-				l190:
-					position, tokenIndex = position139, tokenIndex139
-					if buffer[position] != rune('\'') {
-						goto l137
-					}
-					position++
+					goto l142
+				l169:
+					position, tokenIndex = position142, tokenIndex142
 					{
-						position193 := position
-						if !_rules[rulesinglequotedstring]() {
-							goto l137
+						position177 := position
+						{
+							position180, tokenIndex180 := position, tokenIndex
+							if c := buffer[position]; c < rune('a') || c > rune('z') {
+								goto l181
+							}
+							position++
+							goto l180
+						l181:
+							position, tokenIndex = position180, tokenIndex180
+							if c := buffer[position]; c < rune('A') || c > rune('Z') {
+								goto l182
+							}
+							position++
+							goto l180
+						l182:
+							position, tokenIndex = position180, tokenIndex180
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
+								goto l183
+							}
+							position++
+							goto l180
+						l183:
+							position, tokenIndex = position180, tokenIndex180
+							if buffer[position] != rune('-') {
+								goto l184
+							}
+							position++
+							goto l180
+						l184:
+							position, tokenIndex = position180, tokenIndex180
+							if buffer[position] != rune('_') {
+								goto l185
+							}
+							position++
+							goto l180
+						l185:
+							position, tokenIndex = position180, tokenIndex180
+							if buffer[position] != rune(':') {
+								goto l176
+							}
+							position++
 						}
-						add(rulePegText, position193)
+					l180:
+					l178:
+						{
+							position179, tokenIndex179 := position, tokenIndex
+							{
+								position186, tokenIndex186 := position, tokenIndex
+								if c := buffer[position]; c < rune('a') || c > rune('z') {
+									goto l187
+								}
+								position++
+								goto l186
+							l187:
+								position, tokenIndex = position186, tokenIndex186
+								if c := buffer[position]; c < rune('A') || c > rune('Z') {
+									goto l188
+								}
+								position++
+								goto l186
+							l188:
+								position, tokenIndex = position186, tokenIndex186
+								if c := buffer[position]; c < rune('0') || c > rune('9') {
+									goto l189
+								}
+								position++
+								goto l186
+							l189:
+								position, tokenIndex = position186, tokenIndex186
+								if buffer[position] != rune('-') {
+									goto l190
+								}
+								position++
+								goto l186
+							l190:
+								position, tokenIndex = position186, tokenIndex186
+								if buffer[position] != rune('_') {
+									goto l191
+								}
+								position++
+								goto l186
+							l191:
+								position, tokenIndex = position186, tokenIndex186
+								if buffer[position] != rune(':') {
+									goto l179
+								}
+								position++
+							}
+						l186:
+							goto l178
+						l179:
+							position, tokenIndex = position179, tokenIndex179
+						}
+						add(rulePegText, position177)
 					}
-					if buffer[position] != rune('\'') {
-						goto l137
-					}
-					position++
 					{
 						add(ruleAction39, position)
 					}
+					goto l142
+				l176:
+					position, tokenIndex = position142, tokenIndex142
+					if buffer[position] != rune('"') {
+						goto l193
+					}
+					position++
+					{
+						position194 := position
+						if !_rules[ruledoublequotedstring]() {
+							goto l193
+						}
+						add(rulePegText, position194)
+					}
+					if buffer[position] != rune('"') {
+						goto l193
+					}
+					position++
+					{
+						add(ruleAction40, position)
+					}
+					goto l142
+				l193:
+					position, tokenIndex = position142, tokenIndex142
+					if buffer[position] != rune('\'') {
+						goto l140
+					}
+					position++
+					{
+						position196 := position
+						if !_rules[rulesinglequotedstring]() {
+							goto l140
+						}
+						add(rulePegText, position196)
+					}
+					if buffer[position] != rune('\'') {
+						goto l140
+					}
+					position++
+					{
+						add(ruleAction41, position)
+					}
 				}
-			l139:
-				add(ruleitem, position138)
+			l142:
+				add(ruleitem, position141)
 			}
 			return true
-		l137:
-			position, tokenIndex = position137, tokenIndex137
+		l140:
+			position, tokenIndex = position140, tokenIndex140
 			return false
 		},
 		/* 14 doublequotedstring <- <((!('"' / '\\' / '\n') .) / ('\\' 'n') / ('\\' '"') / ('\\' '\'') / ('\\' '\\'))*> */
 		func() bool {
 			{
-				position196 := position
-			l197:
+				position199 := position
+			l200:
 				{
-					position198, tokenIndex198 := position, tokenIndex
+					position201, tokenIndex201 := position, tokenIndex
 					{
-						position199, tokenIndex199 := position, tokenIndex
+						position202, tokenIndex202 := position, tokenIndex
 						{
-							position201, tokenIndex201 := position, tokenIndex
+							position204, tokenIndex204 := position, tokenIndex
 							{
-								position202, tokenIndex202 := position, tokenIndex
+								position205, tokenIndex205 := position, tokenIndex
 								if buffer[position] != rune('"') {
-									goto l203
+									goto l206
 								}
 								position++
-								goto l202
-							l203:
-								position, tokenIndex = position202, tokenIndex202
+								goto l205
+							l206:
+								position, tokenIndex = position205, tokenIndex205
 								if buffer[position] != rune('\\') {
+									goto l207
+								}
+								position++
+								goto l205
+							l207:
+								position, tokenIndex = position205, tokenIndex205
+								if buffer[position] != rune('\n') {
 									goto l204
 								}
 								position++
-								goto l202
-							l204:
-								position, tokenIndex = position202, tokenIndex202
-								if buffer[position] != rune('\n') {
-									goto l201
-								}
-								position++
 							}
-						l202:
-							goto l200
-						l201:
-							position, tokenIndex = position201, tokenIndex201
+						l205:
+							goto l203
+						l204:
+							position, tokenIndex = position204, tokenIndex204
 						}
 						if !matchDot() {
-							goto l200
+							goto l203
 						}
-						goto l199
-					l200:
-						position, tokenIndex = position199, tokenIndex199
+						goto l202
+					l203:
+						position, tokenIndex = position202, tokenIndex202
 						if buffer[position] != rune('\\') {
-							goto l205
+							goto l208
 						}
 						position++
 						if buffer[position] != rune('n') {
-							goto l205
+							goto l208
 						}
 						position++
-						goto l199
-					l205:
-						position, tokenIndex = position199, tokenIndex199
+						goto l202
+					l208:
+						position, tokenIndex = position202, tokenIndex202
 						if buffer[position] != rune('\\') {
-							goto l206
+							goto l209
 						}
 						position++
 						if buffer[position] != rune('"') {
-							goto l206
+							goto l209
 						}
 						position++
-						goto l199
-					l206:
-						position, tokenIndex = position199, tokenIndex199
+						goto l202
+					l209:
+						position, tokenIndex = position202, tokenIndex202
 						if buffer[position] != rune('\\') {
-							goto l207
+							goto l210
 						}
 						position++
 						if buffer[position] != rune('\'') {
-							goto l207
+							goto l210
 						}
 						position++
-						goto l199
-					l207:
-						position, tokenIndex = position199, tokenIndex199
+						goto l202
+					l210:
+						position, tokenIndex = position202, tokenIndex202
 						if buffer[position] != rune('\\') {
-							goto l198
+							goto l201
 						}
 						position++
 						if buffer[position] != rune('\\') {
-							goto l198
+							goto l201
 						}
 						position++
 					}
-				l199:
-					goto l197
-				l198:
-					position, tokenIndex = position198, tokenIndex198
+				l202:
+					goto l200
+				l201:
+					position, tokenIndex = position201, tokenIndex201
 				}
-				add(ruledoublequotedstring, position196)
+				add(ruledoublequotedstring, position199)
 			}
 			return true
 		},
 		/* 15 singlequotedstring <- <((!('\'' / '\\' / '\n') .) / ('\\' 'n') / ('\\' '"') / ('\\' '\'') / ('\\' '\\'))*> */
 		func() bool {
 			{
-				position209 := position
-			l210:
+				position212 := position
+			l213:
 				{
-					position211, tokenIndex211 := position, tokenIndex
+					position214, tokenIndex214 := position, tokenIndex
 					{
-						position212, tokenIndex212 := position, tokenIndex
+						position215, tokenIndex215 := position, tokenIndex
 						{
-							position214, tokenIndex214 := position, tokenIndex
+							position217, tokenIndex217 := position, tokenIndex
 							{
-								position215, tokenIndex215 := position, tokenIndex
+								position218, tokenIndex218 := position, tokenIndex
 								if buffer[position] != rune('\'') {
-									goto l216
+									goto l219
 								}
 								position++
-								goto l215
-							l216:
-								position, tokenIndex = position215, tokenIndex215
+								goto l218
+							l219:
+								position, tokenIndex = position218, tokenIndex218
 								if buffer[position] != rune('\\') {
+									goto l220
+								}
+								position++
+								goto l218
+							l220:
+								position, tokenIndex = position218, tokenIndex218
+								if buffer[position] != rune('\n') {
 									goto l217
 								}
 								position++
-								goto l215
-							l217:
-								position, tokenIndex = position215, tokenIndex215
-								if buffer[position] != rune('\n') {
-									goto l214
-								}
-								position++
 							}
-						l215:
-							goto l213
-						l214:
-							position, tokenIndex = position214, tokenIndex214
+						l218:
+							goto l216
+						l217:
+							position, tokenIndex = position217, tokenIndex217
 						}
 						if !matchDot() {
-							goto l213
+							goto l216
 						}
-						goto l212
-					l213:
-						position, tokenIndex = position212, tokenIndex212
+						goto l215
+					l216:
+						position, tokenIndex = position215, tokenIndex215
 						if buffer[position] != rune('\\') {
-							goto l218
+							goto l221
 						}
 						position++
 						if buffer[position] != rune('n') {
-							goto l218
+							goto l221
 						}
 						position++
-						goto l212
-					l218:
-						position, tokenIndex = position212, tokenIndex212
+						goto l215
+					l221:
+						position, tokenIndex = position215, tokenIndex215
 						if buffer[position] != rune('\\') {
-							goto l219
+							goto l222
 						}
 						position++
 						if buffer[position] != rune('"') {
-							goto l219
+							goto l222
 						}
 						position++
-						goto l212
-					l219:
-						position, tokenIndex = position212, tokenIndex212
+						goto l215
+					l222:
+						position, tokenIndex = position215, tokenIndex215
 						if buffer[position] != rune('\\') {
-							goto l220
+							goto l223
 						}
 						position++
 						if buffer[position] != rune('\'') {
-							goto l220
+							goto l223
 						}
 						position++
-						goto l212
-					l220:
-						position, tokenIndex = position212, tokenIndex212
+						goto l215
+					l223:
+						position, tokenIndex = position215, tokenIndex215
 						if buffer[position] != rune('\\') {
-							goto l211
+							goto l214
 						}
 						position++
 						if buffer[position] != rune('\\') {
-							goto l211
+							goto l214
 						}
 						position++
 					}
-				l212:
-					goto l210
-				l211:
-					position, tokenIndex = position211, tokenIndex211
+				l215:
+					goto l213
+				l214:
+					position, tokenIndex = position214, tokenIndex214
 				}
-				add(rulesinglequotedstring, position209)
+				add(rulesinglequotedstring, position212)
 			}
 			return true
 		},
 		/* 16 fieldExpr <- <(([a-z] / [A-Z]) ([a-z] / [A-Z] / [0-9] / '_' / '-')*)> */
 		func() bool {
-			position221, tokenIndex221 := position, tokenIndex
+			position224, tokenIndex224 := position, tokenIndex
 			{
-				position222 := position
+				position225 := position
 				{
-					position223, tokenIndex223 := position, tokenIndex
+					position226, tokenIndex226 := position, tokenIndex
 					if c := buffer[position]; c < rune('a') || c > rune('z') {
+						goto l227
+					}
+					position++
+					goto l226
+				l227:
+					position, tokenIndex = position226, tokenIndex226
+					if c := buffer[position]; c < rune('A') || c > rune('Z') {
 						goto l224
 					}
 					position++
-					goto l223
-				l224:
-					position, tokenIndex = position223, tokenIndex223
-					if c := buffer[position]; c < rune('A') || c > rune('Z') {
-						goto l221
-					}
-					position++
 				}
-			l223:
-			l225:
+			l226:
+			l228:
 				{
-					position226, tokenIndex226 := position, tokenIndex
+					position229, tokenIndex229 := position, tokenIndex
 					{
-						position227, tokenIndex227 := position, tokenIndex
+						position230, tokenIndex230 := position, tokenIndex
 						if c := buffer[position]; c < rune('a') || c > rune('z') {
-							goto l228
-						}
-						position++
-						goto l227
-					l228:
-						position, tokenIndex = position227, tokenIndex227
-						if c := buffer[position]; c < rune('A') || c > rune('Z') {
-							goto l229
-						}
-						position++
-						goto l227
-					l229:
-						position, tokenIndex = position227, tokenIndex227
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l230
-						}
-						position++
-						goto l227
-					l230:
-						position, tokenIndex = position227, tokenIndex227
-						if buffer[position] != rune('_') {
 							goto l231
 						}
 						position++
-						goto l227
+						goto l230
 					l231:
-						position, tokenIndex = position227, tokenIndex227
+						position, tokenIndex = position230, tokenIndex230
+						if c := buffer[position]; c < rune('A') || c > rune('Z') {
+							goto l232
+						}
+						position++
+						goto l230
+					l232:
+						position, tokenIndex = position230, tokenIndex230
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l233
+						}
+						position++
+						goto l230
+					l233:
+						position, tokenIndex = position230, tokenIndex230
+						if buffer[position] != rune('_') {
+							goto l234
+						}
+						position++
+						goto l230
+					l234:
+						position, tokenIndex = position230, tokenIndex230
 						if buffer[position] != rune('-') {
-							goto l226
+							goto l229
 						}
 						position++
 					}
-				l227:
-					goto l225
-				l226:
-					position, tokenIndex = position226, tokenIndex226
+				l230:
+					goto l228
+				l229:
+					position, tokenIndex = position229, tokenIndex229
 				}
-				add(rulefieldExpr, position222)
+				add(rulefieldExpr, position225)
 			}
 			return true
-		l221:
-			position, tokenIndex = position221, tokenIndex221
+		l224:
+			position, tokenIndex = position224, tokenIndex224
 			return false
 		},
-		/* 17 field <- <(<(fieldExpr / reserved)> Action40)> */
+		/* 17 field <- <(<(fieldExpr / reserved)> Action42)> */
 		func() bool {
-			position232, tokenIndex232 := position, tokenIndex
+			position235, tokenIndex235 := position, tokenIndex
 			{
-				position233 := position
+				position236 := position
 				{
-					position234 := position
+					position237 := position
 					{
-						position235, tokenIndex235 := position, tokenIndex
+						position238, tokenIndex238 := position, tokenIndex
 						if !_rules[rulefieldExpr]() {
-							goto l236
+							goto l239
 						}
-						goto l235
-					l236:
-						position, tokenIndex = position235, tokenIndex235
+						goto l238
+					l239:
+						position, tokenIndex = position238, tokenIndex238
 						{
-							position237 := position
+							position240 := position
 							{
-								position238, tokenIndex238 := position, tokenIndex
+								position241, tokenIndex241 := position, tokenIndex
 								if buffer[position] != rune('_') {
-									goto l239
+									goto l242
 								}
 								position++
 								if buffer[position] != rune('r') {
-									goto l239
+									goto l242
 								}
 								position++
 								if buffer[position] != rune('o') {
-									goto l239
+									goto l242
 								}
 								position++
 								if buffer[position] != rune('w') {
-									goto l239
+									goto l242
 								}
 								position++
-								goto l238
-							l239:
-								position, tokenIndex = position238, tokenIndex238
+								goto l241
+							l242:
+								position, tokenIndex = position241, tokenIndex241
 								if buffer[position] != rune('_') {
-									goto l240
+									goto l243
 								}
 								position++
 								if buffer[position] != rune('c') {
-									goto l240
+									goto l243
 								}
 								position++
 								if buffer[position] != rune('o') {
-									goto l240
+									goto l243
 								}
 								position++
 								if buffer[position] != rune('l') {
-									goto l240
+									goto l243
 								}
 								position++
-								goto l238
-							l240:
-								position, tokenIndex = position238, tokenIndex238
+								goto l241
+							l243:
+								position, tokenIndex = position241, tokenIndex241
 								if buffer[position] != rune('_') {
-									goto l241
+									goto l244
 								}
 								position++
 								if buffer[position] != rune('s') {
-									goto l241
+									goto l244
 								}
 								position++
 								if buffer[position] != rune('t') {
-									goto l241
+									goto l244
 								}
 								position++
 								if buffer[position] != rune('a') {
-									goto l241
+									goto l244
 								}
 								position++
 								if buffer[position] != rune('r') {
-									goto l241
+									goto l244
 								}
 								position++
 								if buffer[position] != rune('t') {
-									goto l241
+									goto l244
 								}
 								position++
-								goto l238
-							l241:
-								position, tokenIndex = position238, tokenIndex238
+								goto l241
+							l244:
+								position, tokenIndex = position241, tokenIndex241
 								if buffer[position] != rune('_') {
-									goto l242
+									goto l245
 								}
 								position++
 								if buffer[position] != rune('e') {
-									goto l242
+									goto l245
 								}
 								position++
 								if buffer[position] != rune('n') {
-									goto l242
+									goto l245
 								}
 								position++
 								if buffer[position] != rune('d') {
-									goto l242
+									goto l245
 								}
 								position++
-								goto l238
-							l242:
-								position, tokenIndex = position238, tokenIndex238
+								goto l241
+							l245:
+								position, tokenIndex = position241, tokenIndex241
 								if buffer[position] != rune('_') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('t') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('i') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('m') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('e') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('s') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('t') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('a') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('m') {
-									goto l243
+									goto l246
 								}
 								position++
 								if buffer[position] != rune('p') {
-									goto l243
+									goto l246
 								}
 								position++
-								goto l238
-							l243:
-								position, tokenIndex = position238, tokenIndex238
+								goto l241
+							l246:
+								position, tokenIndex = position241, tokenIndex241
 								if buffer[position] != rune('_') {
-									goto l232
+									goto l235
 								}
 								position++
 								if buffer[position] != rune('f') {
-									goto l232
+									goto l235
 								}
 								position++
 								if buffer[position] != rune('i') {
-									goto l232
+									goto l235
 								}
 								position++
 								if buffer[position] != rune('e') {
-									goto l232
+									goto l235
 								}
 								position++
 								if buffer[position] != rune('l') {
-									goto l232
+									goto l235
 								}
 								position++
 								if buffer[position] != rune('d') {
-									goto l232
+									goto l235
 								}
 								position++
 							}
-						l238:
-							add(rulereserved, position237)
+						l241:
+							add(rulereserved, position240)
 						}
 					}
-				l235:
-					add(rulePegText, position234)
+				l238:
+					add(rulePegText, position237)
 				}
 				{
-					add(ruleAction40, position)
+					add(ruleAction42, position)
 				}
-				add(rulefield, position233)
+				add(rulefield, position236)
 			}
 			return true
-		l232:
-			position, tokenIndex = position232, tokenIndex232
+		l235:
+			position, tokenIndex = position235, tokenIndex235
 			return false
 		},
 		/* 18 reserved <- <(('_' 'r' 'o' 'w') / ('_' 'c' 'o' 'l') / ('_' 's' 't' 'a' 'r' 't') / ('_' 'e' 'n' 'd') / ('_' 't' 'i' 'm' 'e' 's' 't' 'a' 'm' 'p') / ('_' 'f' 'i' 'e' 'l' 'd'))> */
 		nil,
-		/* 19 posfield <- <(<fieldExpr> Action41)> */
+		/* 19 posfield <- <(<fieldExpr> Action43)> */
 		func() bool {
-			position246, tokenIndex246 := position, tokenIndex
+			position249, tokenIndex249 := position, tokenIndex
 			{
-				position247 := position
+				position250 := position
 				{
-					position248 := position
+					position251 := position
 					if !_rules[rulefieldExpr]() {
-						goto l246
+						goto l249
 					}
-					add(rulePegText, position248)
+					add(rulePegText, position251)
 				}
 				{
-					add(ruleAction41, position)
+					add(ruleAction43, position)
 				}
-				add(ruleposfield, position247)
+				add(ruleposfield, position250)
 			}
 			return true
-		l246:
-			position, tokenIndex = position246, tokenIndex246
+		l249:
+			position, tokenIndex = position249, tokenIndex249
 			return false
 		},
 		/* 20 uint <- <(([1-9] [0-9]*) / '0')> */
 		func() bool {
-			position250, tokenIndex250 := position, tokenIndex
+			position253, tokenIndex253 := position, tokenIndex
 			{
-				position251 := position
+				position254 := position
 				{
-					position252, tokenIndex252 := position, tokenIndex
+					position255, tokenIndex255 := position, tokenIndex
 					if c := buffer[position]; c < rune('1') || c > rune('9') {
+						goto l256
+					}
+					position++
+				l257:
+					{
+						position258, tokenIndex258 := position, tokenIndex
+						if c := buffer[position]; c < rune('0') || c > rune('9') {
+							goto l258
+						}
+						position++
+						goto l257
+					l258:
+						position, tokenIndex = position258, tokenIndex258
+					}
+					goto l255
+				l256:
+					position, tokenIndex = position255, tokenIndex255
+					if buffer[position] != rune('0') {
 						goto l253
 					}
 					position++
-				l254:
-					{
-						position255, tokenIndex255 := position, tokenIndex
-						if c := buffer[position]; c < rune('0') || c > rune('9') {
-							goto l255
-						}
-						position++
-						goto l254
-					l255:
-						position, tokenIndex = position255, tokenIndex255
-					}
-					goto l252
-				l253:
-					position, tokenIndex = position252, tokenIndex252
-					if buffer[position] != rune('0') {
-						goto l250
-					}
-					position++
 				}
-			l252:
-				add(ruleuint, position251)
+			l255:
+				add(ruleuint, position254)
 			}
 			return true
-		l250:
-			position, tokenIndex = position250, tokenIndex250
+		l253:
+			position, tokenIndex = position253, tokenIndex253
 			return false
 		},
-		/* 21 uintrow <- <(<uint> Action42)> */
+		/* 21 uintrow <- <(<uint> Action44)> */
 		nil,
-		/* 22 col <- <((<uint> Action43) / ('\'' <singlequotedstring> '\'' Action44) / ('"' <doublequotedstring> '"' Action45))> */
+		/* 22 col <- <((<uint> Action45) / ('\'' <singlequotedstring> '\'' Action46) / ('"' <doublequotedstring> '"' Action47))> */
 		func() bool {
-			position257, tokenIndex257 := position, tokenIndex
+			position260, tokenIndex260 := position, tokenIndex
 			{
-				position258 := position
+				position261 := position
 				{
-					position259, tokenIndex259 := position, tokenIndex
-					{
-						position261 := position
-						if !_rules[ruleuint]() {
-							goto l260
-						}
-						add(rulePegText, position261)
-					}
-					{
-						add(ruleAction43, position)
-					}
-					goto l259
-				l260:
-					position, tokenIndex = position259, tokenIndex259
-					if buffer[position] != rune('\'') {
-						goto l263
-					}
-					position++
+					position262, tokenIndex262 := position, tokenIndex
 					{
 						position264 := position
-						if !_rules[rulesinglequotedstring]() {
+						if !_rules[ruleuint]() {
 							goto l263
 						}
 						add(rulePegText, position264)
 					}
-					if buffer[position] != rune('\'') {
-						goto l263
-					}
-					position++
-					{
-						add(ruleAction44, position)
-					}
-					goto l259
-				l263:
-					position, tokenIndex = position259, tokenIndex259
-					if buffer[position] != rune('"') {
-						goto l257
-					}
-					position++
-					{
-						position266 := position
-						if !_rules[ruledoublequotedstring]() {
-							goto l257
-						}
-						add(rulePegText, position266)
-					}
-					if buffer[position] != rune('"') {
-						goto l257
-					}
-					position++
 					{
 						add(ruleAction45, position)
 					}
+					goto l262
+				l263:
+					position, tokenIndex = position262, tokenIndex262
+					if buffer[position] != rune('\'') {
+						goto l266
+					}
+					position++
+					{
+						position267 := position
+						if !_rules[rulesinglequotedstring]() {
+							goto l266
+						}
+						add(rulePegText, position267)
+					}
+					if buffer[position] != rune('\'') {
+						goto l266
+					}
+					position++
+					{
+						add(ruleAction46, position)
+					}
+					goto l262
+				l266:
+					position, tokenIndex = position262, tokenIndex262
+					if buffer[position] != rune('"') {
+						goto l260
+					}
+					position++
+					{
+						position269 := position
+						if !_rules[ruledoublequotedstring]() {
+							goto l260
+						}
+						add(rulePegText, position269)
+					}
+					if buffer[position] != rune('"') {
+						goto l260
+					}
+					position++
+					{
+						add(ruleAction47, position)
+					}
 				}
-			l259:
-				add(rulecol, position258)
+			l262:
+				add(rulecol, position261)
 			}
 			return true
-		l257:
-			position, tokenIndex = position257, tokenIndex257
+		l260:
+			position, tokenIndex = position260, tokenIndex260
 			return false
 		},
-		/* 23 row <- <((<uint> Action46) / ('\'' <singlequotedstring> '\'' Action47) / ('"' <doublequotedstring> '"' Action48))> */
+		/* 23 row <- <((<uint> Action48) / ('\'' <singlequotedstring> '\'' Action49) / ('"' <doublequotedstring> '"' Action50))> */
 		nil,
 		/* 24 open <- <('(' sp)> */
 		func() bool {
-			position269, tokenIndex269 := position, tokenIndex
+			position272, tokenIndex272 := position, tokenIndex
 			{
-				position270 := position
+				position273 := position
 				if buffer[position] != rune('(') {
-					goto l269
+					goto l272
 				}
 				position++
 				if !_rules[rulesp]() {
-					goto l269
+					goto l272
 				}
-				add(ruleopen, position270)
+				add(ruleopen, position273)
 			}
 			return true
-		l269:
-			position, tokenIndex = position269, tokenIndex269
+		l272:
+			position, tokenIndex = position272, tokenIndex272
 			return false
 		},
 		/* 25 close <- <(')' sp)> */
 		func() bool {
-			position271, tokenIndex271 := position, tokenIndex
+			position274, tokenIndex274 := position, tokenIndex
 			{
-				position272 := position
+				position275 := position
 				if buffer[position] != rune(')') {
-					goto l271
+					goto l274
 				}
 				position++
 				if !_rules[rulesp]() {
-					goto l271
+					goto l274
 				}
-				add(ruleclose, position272)
+				add(ruleclose, position275)
 			}
 			return true
-		l271:
-			position, tokenIndex = position271, tokenIndex271
+		l274:
+			position, tokenIndex = position274, tokenIndex274
 			return false
 		},
 		/* 26 sp <- <(' ' / '\t' / '\n')*> */
 		func() bool {
 			{
-				position274 := position
-			l275:
+				position277 := position
+			l278:
 				{
-					position276, tokenIndex276 := position, tokenIndex
+					position279, tokenIndex279 := position, tokenIndex
 					{
-						position277, tokenIndex277 := position, tokenIndex
+						position280, tokenIndex280 := position, tokenIndex
 						if buffer[position] != rune(' ') {
-							goto l278
+							goto l281
 						}
 						position++
-						goto l277
-					l278:
-						position, tokenIndex = position277, tokenIndex277
+						goto l280
+					l281:
+						position, tokenIndex = position280, tokenIndex280
 						if buffer[position] != rune('\t') {
+							goto l282
+						}
+						position++
+						goto l280
+					l282:
+						position, tokenIndex = position280, tokenIndex280
+						if buffer[position] != rune('\n') {
 							goto l279
 						}
 						position++
-						goto l277
-					l279:
-						position, tokenIndex = position277, tokenIndex277
-						if buffer[position] != rune('\n') {
-							goto l276
-						}
-						position++
 					}
-				l277:
-					goto l275
-				l276:
-					position, tokenIndex = position276, tokenIndex276
+				l280:
+					goto l278
+				l279:
+					position, tokenIndex = position279, tokenIndex279
 				}
-				add(rulesp, position274)
+				add(rulesp, position277)
 			}
 			return true
 		},
 		/* 27 comma <- <(sp ',' sp)> */
 		func() bool {
-			position280, tokenIndex280 := position, tokenIndex
+			position283, tokenIndex283 := position, tokenIndex
 			{
-				position281 := position
+				position284 := position
 				if !_rules[rulesp]() {
-					goto l280
+					goto l283
 				}
 				if buffer[position] != rune(',') {
-					goto l280
+					goto l283
 				}
 				position++
 				if !_rules[rulesp]() {
-					goto l280
+					goto l283
 				}
-				add(rulecomma, position281)
+				add(rulecomma, position284)
 			}
 			return true
-		l280:
-			position, tokenIndex = position280, tokenIndex280
+		l283:
+			position, tokenIndex = position283, tokenIndex283
 			return false
 		},
 		/* 28 lbrack <- <('[' sp)> */
@@ -2740,139 +2792,139 @@ func (p *PQL) Init() {
 		nil,
 		/* 31 timestampbasicfmt <- <([0-9] [0-9] [0-9] [0-9] '-' ('0' / '1') [0-9] '-' [0-3] [0-9] 'T' [0-9] [0-9] ':' [0-9] [0-9])> */
 		func() bool {
-			position285, tokenIndex285 := position, tokenIndex
+			position288, tokenIndex288 := position, tokenIndex
 			{
-				position286 := position
+				position289 := position
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if buffer[position] != rune('-') {
-					goto l285
+					goto l288
 				}
 				position++
 				{
-					position287, tokenIndex287 := position, tokenIndex
+					position290, tokenIndex290 := position, tokenIndex
 					if buffer[position] != rune('0') {
+						goto l291
+					}
+					position++
+					goto l290
+				l291:
+					position, tokenIndex = position290, tokenIndex290
+					if buffer[position] != rune('1') {
 						goto l288
 					}
 					position++
-					goto l287
-				l288:
-					position, tokenIndex = position287, tokenIndex287
-					if buffer[position] != rune('1') {
-						goto l285
-					}
-					position++
 				}
-			l287:
+			l290:
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if buffer[position] != rune('-') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('3') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if buffer[position] != rune('T') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if buffer[position] != rune(':') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
 				if c := buffer[position]; c < rune('0') || c > rune('9') {
-					goto l285
+					goto l288
 				}
 				position++
-				add(ruletimestampbasicfmt, position286)
+				add(ruletimestampbasicfmt, position289)
 			}
 			return true
-		l285:
-			position, tokenIndex = position285, tokenIndex285
+		l288:
+			position, tokenIndex = position288, tokenIndex288
 			return false
 		},
 		/* 32 timestampfmt <- <(('"' timestampbasicfmt '"') / ('\'' timestampbasicfmt '\'') / timestampbasicfmt)> */
 		func() bool {
-			position289, tokenIndex289 := position, tokenIndex
+			position292, tokenIndex292 := position, tokenIndex
 			{
-				position290 := position
+				position293 := position
 				{
-					position291, tokenIndex291 := position, tokenIndex
+					position294, tokenIndex294 := position, tokenIndex
 					if buffer[position] != rune('"') {
-						goto l292
+						goto l295
 					}
 					position++
 					if !_rules[ruletimestampbasicfmt]() {
-						goto l292
+						goto l295
 					}
 					if buffer[position] != rune('"') {
+						goto l295
+					}
+					position++
+					goto l294
+				l295:
+					position, tokenIndex = position294, tokenIndex294
+					if buffer[position] != rune('\'') {
+						goto l296
+					}
+					position++
+					if !_rules[ruletimestampbasicfmt]() {
+						goto l296
+					}
+					if buffer[position] != rune('\'') {
+						goto l296
+					}
+					position++
+					goto l294
+				l296:
+					position, tokenIndex = position294, tokenIndex294
+					if !_rules[ruletimestampbasicfmt]() {
 						goto l292
-					}
-					position++
-					goto l291
-				l292:
-					position, tokenIndex = position291, tokenIndex291
-					if buffer[position] != rune('\'') {
-						goto l293
-					}
-					position++
-					if !_rules[ruletimestampbasicfmt]() {
-						goto l293
-					}
-					if buffer[position] != rune('\'') {
-						goto l293
-					}
-					position++
-					goto l291
-				l293:
-					position, tokenIndex = position291, tokenIndex291
-					if !_rules[ruletimestampbasicfmt]() {
-						goto l289
 					}
 				}
-			l291:
-				add(ruletimestampfmt, position290)
+			l294:
+				add(ruletimestampfmt, position293)
 			}
 			return true
-		l289:
-			position, tokenIndex = position289, tokenIndex289
+		l292:
+			position, tokenIndex = position292, tokenIndex292
 			return false
 		},
-		/* 33 timestamp <- <(<timestampfmt> Action49)> */
+		/* 33 timestamp <- <(<timestampfmt> Action51)> */
 		nil,
 		/* 35 Action0 <- <{p.startCall("Set")}> */
 		nil,
@@ -2894,86 +2946,90 @@ func (p *PQL) Init() {
 		nil,
 		/* 44 Action9 <- <{p.endCall()}> */
 		nil,
-		/* 45 Action10 <- <{p.startCall("TopN")}> */
+		/* 45 Action10 <- <{p.startCall("Store")}> */
 		nil,
 		/* 46 Action11 <- <{p.endCall()}> */
 		nil,
-		/* 47 Action12 <- <{p.startCall("Range")}> */
+		/* 47 Action12 <- <{p.startCall("TopN")}> */
 		nil,
 		/* 48 Action13 <- <{p.endCall()}> */
 		nil,
+		/* 49 Action14 <- <{p.startCall("Range")}> */
 		nil,
-		/* 50 Action14 <- <{ p.startCall(buffer[begin:end] ) }> */
+		/* 50 Action15 <- <{p.endCall()}> */
 		nil,
-		/* 51 Action15 <- <{ p.endCall() }> */
 		nil,
-		/* 52 Action16 <- <{ p.addBTWN() }> */
+		/* 52 Action16 <- <{ p.startCall(buffer[begin:end] ) }> */
 		nil,
-		/* 53 Action17 <- <{ p.addLTE() }> */
+		/* 53 Action17 <- <{ p.endCall() }> */
 		nil,
-		/* 54 Action18 <- <{ p.addGTE() }> */
+		/* 54 Action18 <- <{ p.addBTWN() }> */
 		nil,
-		/* 55 Action19 <- <{ p.addEQ() }> */
+		/* 55 Action19 <- <{ p.addLTE() }> */
 		nil,
-		/* 56 Action20 <- <{ p.addNEQ() }> */
+		/* 56 Action20 <- <{ p.addGTE() }> */
 		nil,
-		/* 57 Action21 <- <{ p.addLT() }> */
+		/* 57 Action21 <- <{ p.addEQ() }> */
 		nil,
-		/* 58 Action22 <- <{ p.addGT() }> */
+		/* 58 Action22 <- <{ p.addNEQ() }> */
 		nil,
-		/* 59 Action23 <- <{p.startConditional()}> */
+		/* 59 Action23 <- <{ p.addLT() }> */
 		nil,
-		/* 60 Action24 <- <{p.endConditional()}> */
+		/* 60 Action24 <- <{ p.addGT() }> */
 		nil,
-		/* 61 Action25 <- <{p.condAdd(buffer[begin:end])}> */
+		/* 61 Action25 <- <{p.startConditional()}> */
 		nil,
-		/* 62 Action26 <- <{p.condAdd(buffer[begin:end])}> */
+		/* 62 Action26 <- <{p.endConditional()}> */
 		nil,
 		/* 63 Action27 <- <{p.condAdd(buffer[begin:end])}> */
 		nil,
-		/* 64 Action28 <- <{p.addPosStr("_start", buffer[begin:end])}> */
+		/* 64 Action28 <- <{p.condAdd(buffer[begin:end])}> */
 		nil,
-		/* 65 Action29 <- <{p.addPosStr("_end", buffer[begin:end])}> */
+		/* 65 Action29 <- <{p.condAdd(buffer[begin:end])}> */
 		nil,
-		/* 66 Action30 <- <{ p.startList() }> */
+		/* 66 Action30 <- <{p.addPosStr("_start", buffer[begin:end])}> */
 		nil,
-		/* 67 Action31 <- <{ p.endList() }> */
+		/* 67 Action31 <- <{p.addPosStr("_end", buffer[begin:end])}> */
 		nil,
-		/* 68 Action32 <- <{ p.addVal(nil) }> */
+		/* 68 Action32 <- <{ p.startList() }> */
 		nil,
-		/* 69 Action33 <- <{ p.addVal(true) }> */
+		/* 69 Action33 <- <{ p.endList() }> */
 		nil,
-		/* 70 Action34 <- <{ p.addVal(false) }> */
+		/* 70 Action34 <- <{ p.addVal(nil) }> */
 		nil,
-		/* 71 Action35 <- <{ p.addNumVal(buffer[begin:end]) }> */
+		/* 71 Action35 <- <{ p.addVal(true) }> */
 		nil,
-		/* 72 Action36 <- <{ p.addNumVal(buffer[begin:end]) }> */
+		/* 72 Action36 <- <{ p.addVal(false) }> */
 		nil,
-		/* 73 Action37 <- <{ p.addVal(buffer[begin:end]) }> */
+		/* 73 Action37 <- <{ p.addNumVal(buffer[begin:end]) }> */
 		nil,
-		/* 74 Action38 <- <{ p.addVal(buffer[begin:end]) }> */
+		/* 74 Action38 <- <{ p.addNumVal(buffer[begin:end]) }> */
 		nil,
 		/* 75 Action39 <- <{ p.addVal(buffer[begin:end]) }> */
 		nil,
-		/* 76 Action40 <- <{ p.addField(buffer[begin:end]) }> */
+		/* 76 Action40 <- <{ p.addVal(buffer[begin:end]) }> */
 		nil,
-		/* 77 Action41 <- <{ p.addPosStr("_field", buffer[begin:end]) }> */
+		/* 77 Action41 <- <{ p.addVal(buffer[begin:end]) }> */
 		nil,
-		/* 78 Action42 <- <{p.addPosNum("_row", buffer[begin:end])}> */
+		/* 78 Action42 <- <{ p.addField(buffer[begin:end]) }> */
 		nil,
-		/* 79 Action43 <- <{p.addPosNum("_col", buffer[begin:end])}> */
+		/* 79 Action43 <- <{ p.addPosStr("_field", buffer[begin:end]) }> */
 		nil,
-		/* 80 Action44 <- <{p.addPosStr("_col", buffer[begin:end])}> */
+		/* 80 Action44 <- <{p.addPosNum("_row", buffer[begin:end])}> */
 		nil,
-		/* 81 Action45 <- <{p.addPosStr("_col", buffer[begin:end])}> */
+		/* 81 Action45 <- <{p.addPosNum("_col", buffer[begin:end])}> */
 		nil,
-		/* 82 Action46 <- <{p.addPosNum("_row", buffer[begin:end])}> */
+		/* 82 Action46 <- <{p.addPosStr("_col", buffer[begin:end])}> */
 		nil,
-		/* 83 Action47 <- <{p.addPosStr("_row", buffer[begin:end])}> */
+		/* 83 Action47 <- <{p.addPosStr("_col", buffer[begin:end])}> */
 		nil,
-		/* 84 Action48 <- <{p.addPosStr("_row", buffer[begin:end])}> */
+		/* 84 Action48 <- <{p.addPosNum("_row", buffer[begin:end])}> */
 		nil,
-		/* 85 Action49 <- <{p.addPosStr("_timestamp", buffer[begin:end])}> */
+		/* 85 Action49 <- <{p.addPosStr("_row", buffer[begin:end])}> */
+		nil,
+		/* 86 Action50 <- <{p.addPosStr("_row", buffer[begin:end])}> */
+		nil,
+		/* 87 Action51 <- <{p.addPosStr("_timestamp", buffer[begin:end])}> */
 		nil,
 	}
 	p.rules = _rules


### PR DESCRIPTION
## Overview

This PR implements `Store(<row_query>, <fieldname>=10)`. Currently, it's only supported on `set` fields. It's not clear to me yet how we would support this on `mutex` and `bool` fields. And I don't think it makes sense to store a `row` result into `int` or `time` fields (although I suppose if `Store()` took an optional timestamp, it could apply the row to all time quantums).

Also, the PQL function is `Store()`, but internally everything is `SetRow()` because it seemed like a complement to `ClearRow()`.

Fixes #637 (at least the first phase of it)

TODO:
- [x] Docs
- [x] Decide if we want to support `time` fields.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
