### PR TITLE
Fixes #1660

### DIFF
--- a/api.go
+++ b/api.go
@@ -327,7 +327,7 @@ func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, 
 	}
 
 	// only set fields are supported
-	if field.Type() != "set" {
+	if field.Type() != FieldTypeSet {
 		return NewBadRequestError(errors.New("roaring import is only supported for set fields"))
 	}
 

--- a/http/handler.go
+++ b/http/handler.go
@@ -1473,11 +1473,16 @@ func (h *Handler) handlePostImportRoaring(w http.ResponseWriter, r *http.Request
 		return
 	}
 
+	resp := &pilosa.ImportResponse{}
 	// TODO give meaningful stats for import
 	err = h.api.ImportRoaring(r.Context(), urlVars["index"], urlVars["field"], shard, remote, body)
-	resp := &pilosa.ImportResponse{}
 	if err != nil {
 		resp.Err = err.Error()
+		if _, ok := err.(pilosa.BadRequestError); ok {
+			w.WriteHeader(http.StatusBadRequest)
+		} else {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
 	}
 	// Marshal response object.
 	buf, err := h.api.Serializer.Marshal(resp)

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -104,6 +104,22 @@ func TestHandler_Endpoints(t *testing.T) {
 
 	})
 
+	t.Run("ImportRoaringFieldTypeFail", func(t *testing.T) {
+		// Roaring import into a non-set field should fail.
+		if _, err := i0.CreateFieldIfNotExists("int-field", pilosa.OptFieldTypeInt(0, 1)); err != nil {
+			t.Fatal(err)
+		}
+		w := httptest.NewRecorder()
+		roaringData, _ := hex.DecodeString("3B3001000100000900010000000100010009000100")
+		req := test.MustNewHTTPRequest("POST", "/index/i0/field/int-field/import-roaring/0", bytes.NewBuffer(roaringData))
+		req.Header.Set("Content-Type", "application/x-binary")
+		h.ServeHTTP(w, req)
+		if w.Code != gohttp.StatusBadRequest {
+			t.Fatalf("unexpected status code: %d", w.Code)
+		}
+
+	})
+
 	t.Run("Status", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		h.ServeHTTP(w, test.MustNewHTTPRequest("GET", "/status", nil))


### PR DESCRIPTION
## Overview

Checks the field type on roaring import; if it's not a set field, returns an error.

Fixes #1660 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
