### PR TITLE
prevent closing os.Stderr (used in verbose test logging)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -364,7 +364,10 @@ func (m *Command) Close() error {
 		eg.Go(m.gossipMemberSet.Close)
 	}
 	if closer, ok := m.logOutput.(io.Closer); ok {
-		eg.Go(closer.Close)
+		// If closer is os.Stdout or os.Stderr, don't close it.
+		if closer != os.Stdout && closer != os.Stderr {
+			eg.Go(closer.Close)
+		}
 	}
 	err := eg.Wait()
 	return errors.Wrap(err, "closing everything")


### PR DESCRIPTION
## Overview

When running tests with the `-v` verbose flag, `logOutput` was getting set to `os.Stderr`. In some test that used `test.command.Reopen()`, this was causing `os.Stderr` (or `/dev/stderr`) to be closed, which caused problems later.

This PR just prevents closing `logOutput` when it is `os.Stderr`

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
