### PR TITLE
add `clear` functional option for imports

### DIFF
--- a/api.go
+++ b/api.go
@@ -256,10 +256,20 @@ func (api *API) Field(_ context.Context, indexName, fieldName string) (*Field, e
 // (shard*ShardWidth)+(i%ShardWidth). That is to say that "data" represents all
 // of the rows in this shard of this field concatenated together in one long
 // bitmap.
-func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, shard uint64, remote bool, data []byte) (err error) {
+func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, shard uint64, remote bool, data []byte, opts ...ImportOption) (err error) {
 	if err = api.validate(apiField); err != nil {
 		return errors.Wrap(err, "validating api method")
 	}
+
+	// Set up import options.
+	options := &ImportOptions{}
+	for _, opt := range opts {
+		err := opt(options)
+		if err != nil {
+			return errors.Wrap(err, "applying option")
+		}
+	}
+
 	nodes := api.cluster.shardNodes(indexName, shard)
 	var eg errgroup.Group
 
@@ -280,14 +290,14 @@ func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, 
 			d2 := make([]byte, len(data))
 			copy(d2, data)
 			eg.Go(func() error {
-				return field.importRoaring(d2, shard)
+				return field.importRoaring(d2, shard, options.Clear)
 			})
 			go func(node *Node) {
 			}(node)
 		} else if !remote { // if remote == true we don't forward to other nodes
 			// forward it on
 			eg.Go(func() error {
-				return api.server.defaultClient.ImportRoaring(ctx, &node.URI, indexName, fieldName, shard, true, data)
+				return api.server.defaultClient.ImportRoaring(ctx, &node.URI, indexName, fieldName, shard, true, data, opts...)
 			})
 		}
 	}

--- a/api.go
+++ b/api.go
@@ -239,6 +239,17 @@ func (api *API) Field(_ context.Context, indexName, fieldName string) (*Field, e
 	return field, nil
 }
 
+func setUpImportOptions(opts ...ImportOption) (*ImportOptions, error) {
+	options := &ImportOptions{}
+	for _, opt := range opts {
+		err := opt(options)
+		if err != nil {
+			return nil, errors.Wrap(err, "applying option")
+		}
+	}
+	return options, nil
+}
+
 // ImportRoaring is a low level interface for importing data to Pilosa when
 // extremely high throughput is desired. The data must be encoded in a
 // particular way which may be unintuitive (discussed below). The data is merged
@@ -262,12 +273,9 @@ func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, 
 	}
 
 	// Set up import options.
-	options := &ImportOptions{}
-	for _, opt := range opts {
-		err := opt(options)
-		if err != nil {
-			return errors.Wrap(err, "applying option")
-		}
+	options, err := setUpImportOptions(opts...)
+	if err != nil {
+		return errors.Wrap(err, "setting up import options")
 	}
 
 	nodes := api.cluster.shardNodes(indexName, shard)
@@ -685,7 +693,7 @@ type ImportOptions struct {
 	Clear bool
 }
 
-// ImportOption is a functional option type for API.Import
+// ImportOption is a functional option type for API.Import.
 type ImportOption func(*ImportOptions) error
 
 func OptImportOptionsClear(c bool) ImportOption {
@@ -702,12 +710,9 @@ func (api *API) Import(_ context.Context, req *ImportRequest, opts ...ImportOpti
 	}
 
 	// Set up import options.
-	options := &ImportOptions{}
-	for _, opt := range opts {
-		err := opt(options)
-		if err != nil {
-			return errors.Wrap(err, "applying option")
-		}
+	options, err := setUpImportOptions(opts...)
+	if err != nil {
+		return errors.Wrap(err, "setting up import options")
 	}
 
 	index := api.holder.Index(req.Index)
@@ -773,12 +778,9 @@ func (api *API) ImportValue(_ context.Context, req *ImportValueRequest, opts ...
 	}
 
 	// Set up import options.
-	options := &ImportOptions{}
-	for _, opt := range opts {
-		err := opt(options)
-		if err != nil {
-			return errors.Wrap(err, "applying option")
-		}
+	options, err := setUpImportOptions(opts...)
+	if err != nil {
+		return errors.Wrap(err, "setting up import options")
 	}
 
 	index := api.holder.Index(req.Index)

--- a/client.go
+++ b/client.go
@@ -42,8 +42,8 @@ type InternalClient interface {
 	EnsureIndex(ctx context.Context, name string, options IndexOptions) error
 	EnsureField(ctx context.Context, indexName string, fieldName string) error
 	EnsureFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error
-	ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue) error
-	ImportValueK(ctx context.Context, index, field string, vals []FieldValue) error
+	ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue, opts ...ImportOption) error
+	ImportValueK(ctx context.Context, index, field string, vals []FieldValue, opts ...ImportOption) error
 	ExportCSV(ctx context.Context, index, field string, shard uint64, w io.Writer) error
 	CreateField(ctx context.Context, index, field string) error
 	CreateFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error
@@ -121,10 +121,10 @@ func (n nopInternalClient) EnsureField(ctx context.Context, indexName string, fi
 func (n nopInternalClient) EnsureFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error {
 	return nil
 }
-func (n nopInternalClient) ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue) error {
+func (n nopInternalClient) ImportValue(ctx context.Context, index, field string, shard uint64, vals []FieldValue, opts ...ImportOption) error {
 	return nil
 }
-func (n nopInternalClient) ImportValueK(ctx context.Context, index, field string, vals []FieldValue) error {
+func (n nopInternalClient) ImportValueK(ctx context.Context, index, field string, vals []FieldValue, opts ...ImportOption) error {
 	return nil
 }
 func (n nopInternalClient) ExportCSV(ctx context.Context, index, field string, shard uint64, w io.Writer) error {

--- a/client.go
+++ b/client.go
@@ -53,7 +53,7 @@ type InternalClient interface {
 	RowAttrDiff(ctx context.Context, uri *URI, index, field string, blks []AttrBlock) (map[uint64]map[string]interface{}, error)
 	SendMessage(ctx context.Context, uri *URI, msg []byte) error
 	RetrieveShardFromURI(ctx context.Context, index, field string, shard uint64, uri URI) (io.ReadCloser, error)
-	ImportRoaring(ctx context.Context, uri *URI, index, field string, shard uint64, remote bool, data []byte) error
+	ImportRoaring(ctx context.Context, uri *URI, index, field string, shard uint64, remote bool, data []byte, opts ...ImportOption) error
 }
 
 //===============
@@ -109,7 +109,7 @@ func (n nopInternalClient) Import(ctx context.Context, index, field string, shar
 func (n nopInternalClient) ImportK(ctx context.Context, index, field string, bits []Bit, opts ...ImportOption) error {
 	return nil
 }
-func (n nopInternalClient) ImportRoaring(ctx context.Context, uri *URI, index, field string, shard uint64, remote bool, data []byte) error {
+func (n nopInternalClient) ImportRoaring(ctx context.Context, uri *URI, index, field string, shard uint64, remote bool, data []byte, opts ...ImportOption) error {
 	return nil
 }
 func (n nopInternalClient) EnsureIndex(ctx context.Context, name string, options IndexOptions) error {

--- a/client.go
+++ b/client.go
@@ -37,8 +37,8 @@ type InternalClient interface {
 	Nodes(ctx context.Context) ([]*Node, error)
 	Query(ctx context.Context, index string, queryRequest *QueryRequest) (*QueryResponse, error)
 	QueryNode(ctx context.Context, uri *URI, index string, queryRequest *QueryRequest) (*QueryResponse, error)
-	Import(ctx context.Context, index, field string, shard uint64, bits []Bit) error
-	ImportK(ctx context.Context, index, field string, bits []Bit) error
+	Import(ctx context.Context, index, field string, shard uint64, bits []Bit, opts ...ImportOption) error
+	ImportK(ctx context.Context, index, field string, bits []Bit, opts ...ImportOption) error
 	EnsureIndex(ctx context.Context, name string, options IndexOptions) error
 	EnsureField(ctx context.Context, indexName string, fieldName string) error
 	EnsureFieldWithOptions(ctx context.Context, index, field string, opt FieldOptions) error
@@ -103,10 +103,10 @@ func (n nopInternalClient) Query(ctx context.Context, index string, queryRequest
 func (n nopInternalClient) QueryNode(ctx context.Context, uri *URI, index string, queryRequest *QueryRequest) (*QueryResponse, error) {
 	return nil, nil
 }
-func (n nopInternalClient) Import(ctx context.Context, index, field string, shard uint64, bits []Bit) error {
+func (n nopInternalClient) Import(ctx context.Context, index, field string, shard uint64, bits []Bit, opts ...ImportOption) error {
 	return nil
 }
-func (n nopInternalClient) ImportK(ctx context.Context, index, field string, bits []Bit) error {
+func (n nopInternalClient) ImportK(ctx context.Context, index, field string, bits []Bit, opts ...ImportOption) error {
 	return nil
 }
 func (n nopInternalClient) ImportRoaring(ctx context.Context, uri *URI, index, field string, shard uint64, remote bool, data []byte) error {

--- a/cmd/import.go
+++ b/cmd/import.go
@@ -63,6 +63,7 @@ omitted. If it is present then its format should be YYYY-MM-DDTHH:MM.
 	flags.IntVarP(&Importer.BufferSize, "buffer-size", "s", 10000000, "Number of bits to buffer/sort before importing.")
 	flags.BoolVarP(&Importer.Sort, "sort", "", false, "Enables sorting before import.")
 	flags.BoolVarP(&Importer.CreateSchema, "create", "e", false, "Create the schema if it does not exist before import.")
+	flags.BoolVarP(&Importer.Clear, "clear", "", false, "Clear the data provided in the import.")
 	ctl.SetTLSConfig(flags, &Importer.TLS.CertificatePath, &Importer.TLS.CertificateKeyPath, &Importer.TLS.SkipVerify)
 
 	return importCmd

--- a/cmd/import_test.go
+++ b/cmd/import_test.go
@@ -95,6 +95,17 @@ field = "f1"
 				return v.Error()
 			},
 		},
+		{
+			args: []string{"import", "--index", "i1", "--field", "f1", "--clear", "true"},
+			env:  map[string]string{},
+			validation: func() error {
+				v := validator{}
+				v.Check(cmd.Importer.Index, "i1")
+				v.Check(cmd.Importer.Field, "f1")
+				v.Check(cmd.Importer.Clear, true)
+				return v.Error()
+			},
+		},
 	}
 	executeDry(t, tests)
 }

--- a/ctl/import.go
+++ b/ctl/import.go
@@ -49,6 +49,9 @@ type ImportCommand struct { // nolint: maligned
 	// CreateSchema ensures the schema exists before import
 	CreateSchema bool
 
+	// Clear clears the import data as opposed to setting it.
+	Clear bool
+
 	// Filenames to import from.
 	Paths []string `json:"paths"`
 
@@ -255,7 +258,7 @@ func (cmd *ImportCommand) importBits(ctx context.Context, useColumnKeys, useRowK
 	// If keys are used, all bits are sent to the primary translate store (i.e. coordinator).
 	if useColumnKeys || useRowKeys {
 		logger.Printf("importing keys: n=%d", len(bits))
-		if err := cmd.client.ImportK(ctx, cmd.Index, cmd.Field, bits); err != nil {
+		if err := cmd.client.ImportK(ctx, cmd.Index, cmd.Field, bits, pilosa.OptImportOptionsClear(cmd.Clear)); err != nil {
 			return errors.Wrap(err, "importing keys")
 		}
 		return nil
@@ -272,7 +275,7 @@ func (cmd *ImportCommand) importBits(ctx context.Context, useColumnKeys, useRowK
 		}
 
 		logger.Printf("importing shard: %d, n=%d", shard, len(chunk))
-		if err := cmd.client.Import(ctx, cmd.Index, cmd.Field, shard, chunk); err != nil {
+		if err := cmd.client.Import(ctx, cmd.Index, cmd.Field, shard, chunk, pilosa.OptImportOptionsClear(cmd.Clear)); err != nil {
 			return errors.Wrap(err, "importing")
 		}
 	}

--- a/ctl/import.go
+++ b/ctl/import.go
@@ -380,7 +380,7 @@ func (cmd *ImportCommand) importValues(ctx context.Context, useColumnKeys bool, 
 		}
 
 		logger.Printf("importing shard: %d, n=%d", shard, len(vals))
-		if err := cmd.client.ImportValue(ctx, cmd.Index, cmd.Field, shard, vals); err != nil {
+		if err := cmd.client.ImportValue(ctx, cmd.Index, cmd.Field, shard, vals, pilosa.OptImportOptionsClear(cmd.Clear)); err != nil {
 			return errors.Wrap(err, "importing values")
 		}
 	}

--- a/ctl/import_test.go
+++ b/ctl/import_test.go
@@ -103,29 +103,58 @@ func TestImportCommand_Basic(t *testing.T) {
 
 // Ensure that the ImportValue path runs.
 func TestImportCommand_RunValue(t *testing.T) {
-	buf := bytes.Buffer{}
-	stdin, stdout, stderr := GetIO(buf)
-	cm := NewImportCommand(stdin, stdout, stderr)
-	file, err := ioutil.TempFile("", "import-value.csv")
-	file.Write([]byte("1,2\n3,4\n5,6"))
-	ctx := context.Background()
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("set", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		stdin, stdout, stderr := GetIO(buf)
+		cm := NewImportCommand(stdin, stdout, stderr)
+		file, err := ioutil.TempFile("", "import-value.csv")
+		file.Write([]byte("1,2\n3,4\n5,6"))
+		ctx := context.Background()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	cmd := test.MustRunCluster(t, 1)[0]
-	cm.Host = cmd.API.Node().URI.HostPort()
+		cmd := test.MustRunCluster(t, 1)[0]
+		cm.Host = cmd.API.Node().URI.HostPort()
 
-	http.DefaultClient.Do(MustNewHTTPRequest("POST", "http://"+cm.Host+"/index/i", strings.NewReader("")))
-	http.DefaultClient.Do(MustNewHTTPRequest("POST", "http://"+cm.Host+"/index/i/field/f", strings.NewReader(`{"options":{"type": "int", "min": 0, "max": 100}}`)))
+		http.DefaultClient.Do(MustNewHTTPRequest("POST", "http://"+cm.Host+"/index/i", strings.NewReader("")))
+		http.DefaultClient.Do(MustNewHTTPRequest("POST", "http://"+cm.Host+"/index/i/field/f", strings.NewReader(`{"options":{"type": "int", "min": 0, "max": 100}}`)))
 
-	cm.Index = "i"
-	cm.Field = "f"
-	cm.Paths = []string{file.Name()}
-	err = cm.Run(ctx)
-	if err != nil {
-		t.Fatalf("Import Run with values doesn't work: %s", err)
-	}
+		cm.Index = "i"
+		cm.Field = "f"
+		cm.Paths = []string{file.Name()}
+		err = cm.Run(ctx)
+		if err != nil {
+			t.Fatalf("Import Run with values doesn't work: %s", err)
+		}
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		stdin, stdout, stderr := GetIO(buf)
+		cm := NewImportCommand(stdin, stdout, stderr)
+		file, err := ioutil.TempFile("", "import-value.csv")
+		file.Write([]byte("1,2\n3,4\n5,6"))
+		ctx := context.Background()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := test.MustRunCluster(t, 1)[0]
+		cm.Host = cmd.API.Node().URI.HostPort()
+
+		http.DefaultClient.Do(MustNewHTTPRequest("POST", "http://"+cm.Host+"/index/i", strings.NewReader("")))
+		http.DefaultClient.Do(MustNewHTTPRequest("POST", "http://"+cm.Host+"/index/i/field/f", strings.NewReader(`{"options":{"type": "int", "min": 0, "max": 100}}`)))
+
+		cm.Index = "i"
+		cm.Field = "f"
+		cm.Paths = []string{file.Name()}
+		cm.Clear = true
+		err = cm.Run(ctx)
+		if err != nil {
+			t.Fatalf("Import Run with values doesn't work: %s", err)
+		}
+	})
 }
 
 // Ensure that import with keys runs.

--- a/ctl/import_test.go
+++ b/ctl/import_test.go
@@ -50,28 +50,55 @@ func TestImportCommand_Validation(t *testing.T) {
 	}
 }
 
-func TestImportCommand_Run(t *testing.T) {
-	buf := bytes.Buffer{}
-	stdin, stdout, stderr := GetIO(buf)
-	cm := NewImportCommand(stdin, stdout, stderr)
-	file, err := ioutil.TempFile("", "import.csv")
-	file.Write([]byte("1,2\n3,4\n5,6"))
-	ctx := context.Background()
-	if err != nil {
-		t.Fatal(err)
-	}
+func TestImportCommand_Basic(t *testing.T) {
+	t.Run("set", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		stdin, stdout, stderr := GetIO(buf)
+		cm := NewImportCommand(stdin, stdout, stderr)
+		file, err := ioutil.TempFile("", "import.csv")
+		file.Write([]byte("1,2\n3,4\n5,6"))
+		ctx := context.Background()
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	cmd := test.MustRunCluster(t, 1)[0]
-	cm.Host = cmd.API.Node().URI.HostPort()
+		cmd := test.MustRunCluster(t, 1)[0]
+		cm.Host = cmd.API.Node().URI.HostPort()
 
-	cm.Index = "i"
-	cm.Field = "f"
-	cm.CreateSchema = true
-	cm.Paths = []string{file.Name()}
-	err = cm.Run(ctx)
-	if err != nil {
-		t.Fatalf("Import Run doesn't work: %s", err)
-	}
+		cm.Index = "i"
+		cm.Field = "f"
+		cm.CreateSchema = true
+		cm.Paths = []string{file.Name()}
+		err = cm.Run(ctx)
+		if err != nil {
+			t.Fatalf("Import Run doesn't work: %s", err)
+		}
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		buf := bytes.Buffer{}
+		stdin, stdout, stderr := GetIO(buf)
+		cm := NewImportCommand(stdin, stdout, stderr)
+		file, err := ioutil.TempFile("", "import.csv")
+		file.Write([]byte("1,2\n3,4\n5,6"))
+		ctx := context.Background()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cmd := test.MustRunCluster(t, 1)[0]
+		cm.Host = cmd.API.Node().URI.HostPort()
+
+		cm.Index = "i"
+		cm.Field = "f"
+		cm.CreateSchema = true
+		cm.Clear = true
+		cm.Paths = []string{file.Name()}
+		err = cm.Run(ctx)
+		if err != nil {
+			t.Fatalf("Import Run clear doesn't work: %s", err)
+		}
+	})
 }
 
 // Ensure that the ImportValue path runs.

--- a/docs/administration.md
+++ b/docs/administration.md
@@ -82,6 +82,18 @@ For example, importing a file with the following contents will result in columns
     <p>Note that you must first create a field. View <a href="../api-reference/#create-field">Create Field</a> for more details. The `-e` flag can create the necessary schema when using a field of type "set".</p>
 </div>
 
+#### Clearing Data via Import
+
+By using the `--clear` flag with the import command, Pilosa will clear the values provided in the import payload.
+
+For example, importing a file with the following contents along with the `--clear` flag will result in data being cleared from row 0, column 9; row 1, columns 2 and 8; and row 3, column 12. Clearing a value that doesn't exists is allowed.
+```
+0,9
+1,2
+1,8
+3,12
+```
+
 #### Exporting
 
 Exporting data to csv can be performed on a live instance of Pilosa. You need to specify the index and the field. The API also expects the shard number, but the `pilosa export` sub command will export all shards within a field. The data will be in csv format `Row,Column` and sorted by column.

--- a/field.go
+++ b/field.go
@@ -1126,7 +1126,7 @@ func (f *Field) Import(rowIDs, columnIDs []uint64, timestamps []*time.Time, opts
 }
 
 // importValue bulk imports range-encoded value data.
-func (f *Field) importValue(columnIDs []uint64, values []int64) error {
+func (f *Field) importValue(columnIDs []uint64, values []int64, options *ImportOptions) error {
 	viewName := viewBSIGroupPrefix + f.name
 	// Get the bsiGroup so we know bitDepth.
 	bsig := f.bsiGroup(f.name)
@@ -1174,7 +1174,7 @@ func (f *Field) importValue(columnIDs []uint64, values []int64) error {
 			baseValues[i] = uint64(value - bsig.Min)
 		}
 
-		if err := frag.importValue(data.ColumnIDs, baseValues, bsig.BitDepth()); err != nil {
+		if err := frag.importValue(data.ColumnIDs, baseValues, bsig.BitDepth(), options.Clear); err != nil {
 			return err
 		}
 	}

--- a/field.go
+++ b/field.go
@@ -1182,7 +1182,7 @@ func (f *Field) importValue(columnIDs []uint64, values []int64, options *ImportO
 	return nil
 }
 
-func (f *Field) importRoaring(data []byte, shard uint64) error {
+func (f *Field) importRoaring(data []byte, shard uint64, clear bool) error {
 	viewName := viewStandard
 
 	view, err := f.createViewIfNotExists(viewName)
@@ -1195,7 +1195,7 @@ func (f *Field) importRoaring(data []byte, shard uint64) error {
 		return errors.Wrap(err, "creating fragment")
 	}
 
-	if err := frag.importRoaring(data); err != nil {
+	if err := frag.importRoaring(data, clear); err != nil {
 		return err
 	}
 

--- a/fragment.go
+++ b/fragment.go
@@ -1651,7 +1651,7 @@ func (f *fragment) importValue(columnIDs, values []uint64, bitDepth uint, clear 
 // importRoaring imports from the official roaring data format defined at
 // https://github.com/RoaringBitmap/RoaringFormatSpec or from pilosa's version
 // of the roaring format. The cache is updated to reflect the new data.
-func (f *fragment) importRoaring(data []byte) error {
+func (f *fragment) importRoaring(data []byte, clear bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	bm := roaring.NewBitmap()
@@ -1679,8 +1679,12 @@ func (f *fragment) importRoaring(data []byte) error {
 		lastRow = vRow
 	}
 
-	if f.storage.Count() > 0 {
-		bm = f.storage.Union(bm)
+	if clear {
+		bm = f.storage.Difference(bm)
+	} else {
+		if f.storage.Count() > 0 {
+			bm = f.storage.Union(bm)
+		}
 	}
 
 	for _, rowID := range rowSet {

--- a/fragment.go
+++ b/fragment.go
@@ -612,8 +612,17 @@ func (f *fragment) value(columnID uint64, bitDepth uint) (value uint64, exists b
 	return value, true, nil
 }
 
+// clearValue uses a column of bits to clear a multi-bit value.
+func (f *fragment) clearValue(columnID uint64, bitDepth uint, value uint64) (changed bool, err error) {
+	return f.setValueBase(columnID, bitDepth, value, true)
+}
+
 // setValue uses a column of bits to set a multi-bit value.
 func (f *fragment) setValue(columnID uint64, bitDepth uint, value uint64) (changed bool, err error) {
+	return f.setValueBase(columnID, bitDepth, value, false)
+}
+
+func (f *fragment) setValueBase(columnID uint64, bitDepth uint, value uint64, clear bool) (changed bool, err error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -633,19 +642,26 @@ func (f *fragment) setValue(columnID uint64, bitDepth uint, value uint64) (chang
 		}
 	}
 
-	// Mark value as set.
-	if c, err := f.unprotectedSetBit(uint64(bitDepth), columnID); err != nil {
-		return changed, errors.Wrap(err, "marking not-null")
-	} else if c {
-		changed = true
+	// Mark value as set (or cleared).
+	if clear {
+		if c, err := f.unprotectedClearBit(uint64(bitDepth), columnID); err != nil {
+			return changed, errors.Wrap(err, "clearing not-null")
+		} else if c {
+			changed = true
+		}
+	} else {
+		if c, err := f.unprotectedSetBit(uint64(bitDepth), columnID); err != nil {
+			return changed, errors.Wrap(err, "marking not-null")
+		} else if c {
+			changed = true
+		}
 	}
 
 	return changed, nil
 }
 
 // importSetValue is a more efficient SetValue just for imports.
-func (f *fragment) importSetValue(columnID uint64, bitDepth uint, value uint64) (changed bool, err error) { // nolint: unparam
-
+func (f *fragment) importSetValue(columnID uint64, bitDepth uint, value uint64, clear bool) (changed bool, err error) { // nolint: unparam
 	for i := uint(0); i < bitDepth; i++ {
 		if value&(1<<i) != 0 {
 			bit, err := f.pos(uint64(i), columnID)
@@ -673,12 +689,20 @@ func (f *fragment) importSetValue(columnID uint64, bitDepth uint, value uint64) 
 	// Mark value as set.
 	p, err := f.pos(uint64(bitDepth), columnID)
 	if err != nil {
-		return changed, errors.Wrap(err, "marking not-null")
+		return changed, errors.Wrap(err, "getting not-null pos")
 	}
-	if c, err := f.storage.Add(p); err != nil {
-		return changed, errors.Wrap(err, "adding to storage")
-	} else if c {
-		changed = true
+	if clear {
+		if c, err := f.storage.Remove(p); err != nil {
+			return changed, errors.Wrap(err, "removing not-null from storage")
+		} else if c {
+			changed = true
+		}
+	} else {
+		if c, err := f.storage.Add(p); err != nil {
+			return changed, errors.Wrap(err, "adding not-null to storage")
+		} else if c {
+			changed = true
+		}
 	}
 
 	return changed, nil
@@ -688,12 +712,11 @@ func (f *fragment) importSetValue(columnID uint64, bitDepth uint, value uint64) 
 // A bitmap can be passed in to optionally filter the computed columns.
 func (f *fragment) sum(filter *Row, bitDepth uint) (sum, count uint64, err error) {
 	// Compute count based on the existence row.
-	row := f.row(uint64(bitDepth))
+	consider := f.row(uint64(bitDepth))
 	if filter != nil {
-		count = row.intersectionCount(filter)
-	} else {
-		count = row.Count()
+		consider = consider.Intersect(filter)
 	}
+	count = consider.Count()
 
 	// Compute the sum based on the bit count of each row multiplied by the
 	// place value of each row. For example, 10 bits in the 1's place plus
@@ -705,11 +728,7 @@ func (f *fragment) sum(filter *Row, bitDepth uint) (sum, count uint64, err error
 	var cnt uint64
 	for i := uint(0); i < bitDepth; i++ {
 		row := f.row(uint64(i))
-		if filter != nil {
-			cnt = row.intersectionCount(filter)
-		} else {
-			cnt = row.Count()
-		}
+		cnt = row.intersectionCount(consider)
 		sum += (1 << i) * cnt
 	}
 
@@ -1425,7 +1444,7 @@ func (f *fragment) bulkImport(rowIDs, columnIDs []uint64, options *ImportOptions
 	}
 
 	if f.mutexVector != nil && !options.Clear {
-		return f.bulkImportMutex(rowIDs, columnIDs, options)
+		return f.bulkImportMutex(rowIDs, columnIDs)
 	}
 	return f.bulkImportStandard(rowIDs, columnIDs, options)
 }
@@ -1508,7 +1527,7 @@ func (f *fragment) bulkImportStandard(rowIDs, columnIDs []uint64, options *Impor
 // mutex restrictions. Because the mutex requirements must be checked
 // against storage, this method must acquire a write lock on the fragment
 // during the entire process, and it handles every bit independently.
-func (f *fragment) bulkImportMutex(rowIDs, columnIDs []uint64, options *ImportOptions) error {
+func (f *fragment) bulkImportMutex(rowIDs, columnIDs []uint64) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
@@ -1597,7 +1616,7 @@ func (f *fragment) bulkImportMutex(rowIDs, columnIDs []uint64, options *ImportOp
 }
 
 // importValue bulk imports a set of range-encoded values.
-func (f *fragment) importValue(columnIDs, values []uint64, bitDepth uint) error {
+func (f *fragment) importValue(columnIDs, values []uint64, bitDepth uint, clear bool) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	// Verify that there are an equal number of column ids and values.
@@ -1612,7 +1631,7 @@ func (f *fragment) importValue(columnIDs, values []uint64, bitDepth uint) error 
 		for i := range columnIDs {
 			columnID, value := columnIDs[i], values[i]
 
-			_, err := f.importSetValue(columnID, bitDepth, value)
+			_, err := f.importSetValue(columnID, bitDepth, value, clear)
 			if err != nil {
 				return errors.Wrap(err, "setting")
 			}

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -1900,7 +1900,7 @@ func TestFragment_RoaringImport(t *testing.T) {
 				if err != nil {
 					t.Fatalf("writing to buffer: %v", err)
 				}
-				f.importRoaring(buf.Bytes())
+				f.importRoaring(buf.Bytes(), false)
 				exp := calcExpected(test[:num+1]...)
 				for row, expCols := range exp {
 					cols := f.row(uint64(row)).Columns()
@@ -1972,7 +1972,7 @@ func TestFragment_RoaringImportTopN(t *testing.T) {
 			if err != nil {
 				t.Fatalf("writing to buffer: %v", err)
 			}
-			f.importRoaring(buf.Bytes())
+			f.importRoaring(buf.Bytes(), false)
 			rows, cols := toRowsCols(test.roaring)
 			expPairs = calcTop(append(test.rowIDs, rows...), append(test.colIDs, cols...))
 			pairs, err = f.top(topOptions{})

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -228,6 +228,34 @@ func TestFragment_SetValue(t *testing.T) {
 		}
 	})
 
+	t.Run("Clear", func(t *testing.T) {
+		f := mustOpenFragment("i", "f", viewStandard, 0, "")
+		defer f.Close()
+
+		// Set value.
+		if changed, err := f.setValue(100, 16, 3829); err != nil {
+			t.Fatal(err)
+		} else if !changed {
+			t.Fatal("expected change")
+		}
+
+		// Clear value should overwrite all bits, and set not-null to 0.
+		if changed, err := f.clearValue(100, 16, 2028); err != nil {
+			t.Fatal(err)
+		} else if !changed {
+			t.Fatal("expected change")
+		}
+
+		// Read value.
+		if value, exists, err := f.value(100, 16); err != nil {
+			t.Fatal(err)
+		} else if value != 0 {
+			t.Fatalf("unexpected value: %d", value)
+		} else if exists {
+			t.Fatal("expected to not exist")
+		}
+	})
+
 	t.Run("NotExists", func(t *testing.T) {
 		f := mustOpenFragment("i", "f", viewStandard, 0, "")
 		defer f.Close()

--- a/http/client.go
+++ b/http/client.go
@@ -433,10 +433,11 @@ func (c *InternalClient) importNode(ctx context.Context, node *pilosa.Node, inde
 	path := fmt.Sprintf("/index/%s/field/%s/import", index, field)
 	u := nodePathToURL(node, path)
 
-	url := u.String()
+	vals := url.Values{}
 	if opts.Clear {
-		url += "?clear=true"
+		vals.Set("clear", "true")
 	}
+	url := fmt.Sprintf("%s?%s", u.String(), vals.Encode())
 
 	req, err := http.NewRequest("POST", url, bytes.NewReader(buf))
 	if err != nil {
@@ -588,10 +589,12 @@ func (c *InternalClient) ImportRoaring(ctx context.Context, uri *pilosa.URI, ind
 		}
 	}
 
-	url := fmt.Sprintf("%s/index/%s/field/%s/import-roaring/%d?remote=%v", uri, index, field, shard, remote)
+	vals := url.Values{}
+	vals.Set("remote", strconv.FormatBool(remote))
 	if options.Clear {
-		url += "&clear=true"
+		vals.Set("clear", "true")
 	}
+	url := fmt.Sprintf("%s/index/%s/field/%s/import-roaring/%d?%s", uri, index, field, shard, vals.Encode())
 
 	// Generate HTTP request.
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(data))

--- a/http/client_test.go
+++ b/http/client_test.go
@@ -640,7 +640,7 @@ func TestClient_ImportKeys(t *testing.T) {
 			t.Fatalf("unexpected values: got sum=%v, count=%v; expected sum=50, cnt=3", sum, cnt)
 		}
 
-		// Verify Range
+		// Verify Range.
 		queryRequest := &pilosa.QueryRequest{
 			Query:  fmt.Sprintf(`Range(%s>10)`, fldName),
 			Remote: false,
@@ -671,7 +671,7 @@ func TestClient_ImportKeys(t *testing.T) {
 			t.Fatalf("unexpected values: got sum=%v, count=%v; expected sum=30, cnt=2", sum, cnt)
 		}
 
-		// Verify Range
+		// Verify Range.
 		queryRequest = &pilosa.QueryRequest{
 			Query:  fmt.Sprintf(`Range(%s>10)`, fldName),
 			Remote: false,

--- a/http/handler.go
+++ b/http/handler.go
@@ -1511,6 +1511,9 @@ func (h *Handler) handlePostImportRoaring(w http.ResponseWriter, r *http.Request
 		remote = true
 	}
 
+	// If the clear flag is true, treat the import as clear bits.
+	doClear := q.Get("clear") == "true"
+
 	// Read entire body.
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {
@@ -1527,7 +1530,7 @@ func (h *Handler) handlePostImportRoaring(w http.ResponseWriter, r *http.Request
 
 	resp := &pilosa.ImportResponse{}
 	// TODO give meaningful stats for import
-	err = h.api.ImportRoaring(r.Context(), urlVars["index"], urlVars["field"], shard, remote, body)
+	err = h.api.ImportRoaring(r.Context(), urlVars["index"], urlVars["field"], shard, remote, body, pilosa.OptImportOptionsClear(doClear))
 	if err != nil {
 		resp.Err = err.Error()
 		if _, ok := err.(pilosa.BadRequestError); ok {

--- a/http/handler.go
+++ b/http/handler.go
@@ -1030,7 +1030,7 @@ func (h *Handler) handlePostImport(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := h.api.ImportValue(r.Context(), req); err != nil {
+		if err := h.api.ImportValue(r.Context(), req, pilosa.OptImportOptionsClear(doClear)); err != nil {
 			switch errors.Cause(err) {
 			case pilosa.ErrClusterDoesNotOwnShard:
 				http.Error(w, err.Error(), http.StatusPreconditionFailed)


### PR DESCRIPTION
## Overview

This PR adds functional options to all exposed Import-related api methods. Providing `OptImportOptionsClear(true)` to an `Import()` method will treat the payload as clear-bits.

Fixes #1657 

TODO:
- [x] We don't currently support any type of `clearValue` for `int` fields. The `setValue` import requires a `column`, `value`, but for `clearValue` it doesn't really make sense to require the value for clears. In that case you just need the `column`. Is that a reasonable way to handle it?
- [x] documentation
- [x] update `ImportRoaring` to support clear


## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
