### PR TITLE
Add base system, curl and jq for debug and checks.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,11 @@ COPY . /go/src/github.com/pilosa/pilosa/
 RUN cd /go/src/github.com/pilosa/pilosa \
     && CGO_ENABLED=0 make install-dep install FLAGS="-a"
 
-FROM scratch
+FROM alpine:3.8
 
 LABEL maintainer "dev@pilosa.com"
+
+RUN apk add --no-cache curl jq
 
 COPY --from=builder /go/bin/pilosa /pilosa
 


### PR DESCRIPTION
## Overview

Small image is very cool but not when it lacks minimal debug/check tooling. For e.g. in Kubernetes it would avoid having  excessive sidecar and init containers.

Fixes #1706

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [o] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [o] I have included tests that cover my changes.
- [x] All new and existing tests pass.