### PR TITLE
Fixes #1702

### DIFF
--- a/field.go
+++ b/field.go
@@ -1254,10 +1254,14 @@ func encodeFieldOptions(o *FieldOptions) *internal.FieldOptions {
 	if o == nil {
 		return nil
 	}
+	var cacheSize uint32
+	if o.CacheType != CacheTypeNone {
+		cacheSize = o.CacheSize
+	}
 	return &internal.FieldOptions{
 		Type:        o.Type,
 		CacheType:   o.CacheType,
-		CacheSize:   o.CacheSize,
+		CacheSize:   cacheSize,
 		Min:         o.Min,
 		Max:         o.Max,
 		TimeQuantum: string(o.TimeQuantum),
@@ -1267,16 +1271,20 @@ func encodeFieldOptions(o *FieldOptions) *internal.FieldOptions {
 
 func (o *FieldOptions) MarshalJSON() ([]byte, error) {
 	switch o.Type {
-	case FieldTypeSet:
+	case FieldTypeSet, FieldTypeMutex:
+		var cacheSize uint32
+		if o.CacheType != CacheTypeNone {
+			cacheSize = o.CacheSize
+		}
 		return json.Marshal(struct {
 			Type      string `json:"type"`
 			CacheType string `json:"cacheType"`
-			CacheSize uint32 `json:"cacheSize"`
+			CacheSize uint32 `json:"cacheSize,omitempty"`
 			Keys      bool   `json:"keys"`
 		}{
 			o.Type,
 			o.CacheType,
-			o.CacheSize,
+			cacheSize,
 			o.Keys,
 		})
 	case FieldTypeInt:
@@ -1299,18 +1307,6 @@ func (o *FieldOptions) MarshalJSON() ([]byte, error) {
 		}{
 			o.Type,
 			o.TimeQuantum,
-			o.Keys,
-		})
-	case FieldTypeMutex:
-		return json.Marshal(struct {
-			Type      string `json:"type"`
-			CacheType string `json:"cacheType"`
-			CacheSize uint32 `json:"cacheSize"`
-			Keys      bool   `json:"keys"`
-		}{
-			o.Type,
-			o.CacheType,
-			o.CacheSize,
 			o.Keys,
 		})
 	case FieldTypeBool:


### PR DESCRIPTION
## Overview

Omits returning the `cacheSize` field when `fieldOptions.CacheSize == 0` and/or `fieldOptions.CacheType == "none"`.
I think we should not omit that field though, just return 0.

Fixes #1702 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
