### PR TITLE
Drop now-superfluous methodNotAllowedHandler

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -260,18 +260,8 @@ func newRouter(handler *Handler) *mux.Router {
 	router.HandleFunc("/internal/shards/max", handler.handleGetShardsMax).Methods("GET").Name("GetShardsMax") // TODO: deprecate, but it's being used by the client
 	router.HandleFunc("/internal/translate/data", handler.handleGetTranslateData).Methods("GET").Name("GetTranslateData")
 
-	// TODO: Apply MethodNotAllowed statuses to all endpoints.
-	// Ideally this would be automatic, as described in this (wontfix) ticket:
-	// https://github.com/gorilla/mux/issues/6
-	// For now we just do it for the most commonly used handler, /query
-	router.HandleFunc("/index/{index}/query", handler.methodNotAllowedHandler).Methods("GET")
-
 	router.Use(handler.queryArgValidator)
 	return router
-}
-
-func (h *Handler) methodNotAllowedHandler(w http.ResponseWriter, _ *http.Request) {
-	http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 }
 
 // ServeHTTP handles an HTTP request.


### PR DESCRIPTION
Long ago, the maintainers of gorilla/mux concluded that
it was a "wontfix" to return StatusMethodNotAllowed instead
of StatusNotFound for a method mismatch. Pilosa had a
workaround for this for the most common case (GET requests
to /index/{index}/query), and a TODO to address the other
cases.

While browsing the go-pilosa client code, I noticed that there
is a test for roaring import support which relies on getting
StatusMethodNotAllowed.  But how can this work, if gorilla/mux
doesn't do that?

Answer: They started doing it in mid-2017, apparently:
	https://github.com/gorilla/mux/issues/271

Dropping this code changes the exact text of the message
produced for that one case, but not the status code,
and makes the behavior less confusing.

## Overview

Remove superfluous code. No issue #. No doc change since the sum total of difference in behavior is that the 405 for index/foo/query no longer has a body, and nothing was checking the body. (It also no longer has the Content-Type-Options "nosniff", I guess? I don't think that matters.)

## Pull request checklist

- [X] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [X] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [X] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [X] I have resolved any merge conflicts.
- [X] I have included tests that cover my changes.
- [X] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
