### PR TITLE
WIP: Advertise URI

### DIFF
--- a/ctl/server.go
+++ b/ctl/server.go
@@ -26,6 +26,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags := cmd.Flags()
 	flags.StringVarP(&srv.Config.DataDir, "data-dir", "d", srv.Config.DataDir, "Directory to store pilosa data files.")
 	flags.StringVarP(&srv.Config.Bind, "bind", "b", srv.Config.Bind, "Default URI on which pilosa should listen.")
+	flags.StringVarP(&srv.Config.Advertise, "advertise", "a", "", "Address to broadcast to other hosts and clients to be contacted on.")
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
 	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Enable verbose logging")

--- a/ctl/server.go
+++ b/ctl/server.go
@@ -49,7 +49,11 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.IntVarP(&srv.Config.Translation.MapSize, "translation.map-size", "", srv.Config.Translation.MapSize, "Size in bytes of mmap to allocate for key translation.")
 
 	// Gossip
+	flags.StringVarP(&srv.Config.Gossip.Host, "gossip.host", "", "", "Host to which pilosa should bind for internal state sharing and cluster membership.")
 	flags.StringVarP(&srv.Config.Gossip.Port, "gossip.port", "", srv.Config.Gossip.Port, "Port to which pilosa should bind for internal state sharing.")
+	flags.StringVarP(&srv.Config.Gossip.AdvertisePort, "gossip.advertise-port", "", srv.Config.Gossip.AdvertisePort, "Port on which memberlist should advertise.")
+	flags.StringVarP(&srv.Config.Gossip.AdvertiseHost, "gossip.advertise-host", "", srv.Config.Gossip.AdvertiseHost, "Host on which memberlist should advertise.")
+
 	flags.StringSliceVarP(&srv.Config.Gossip.Seeds, "gossip.seeds", "", srv.Config.Gossip.Seeds, "Host with which to seed the gossip membership.")
 	flags.StringVarP(&srv.Config.Gossip.Key, "gossip.key", "", srv.Config.Gossip.Key, "The path to file of the encryption key for gossip. The contents of the file should be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.")
 	flags.DurationVarP((*time.Duration)(&srv.Config.Gossip.StreamTimeout), "gossip.stream-timeout", "", (time.Duration)(srv.Config.Gossip.StreamTimeout), "Timeout for establishing a stream connection with a remote node for a full state sync.")

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -465,7 +465,7 @@ type Config struct {
 	// AdvertiseHost is the hostname or IP other nodes should use to connect to
 	// this host. If left blank, the value for Host will be used. This is useful
 	// in some proxy and NAT scenarios.
-	AdvertiseHost string `toml:"advertise-host`
+	AdvertiseHost string `toml:"advertise-host"`
 	// AdvertisePort is the port other nodes will use to connect to this one.
 	// Behaves like AdvertiseHost.
 	AdvertisePort string   `toml:"advertise-port"`

--- a/server/config.go
+++ b/server/config.go
@@ -36,8 +36,14 @@ type Config struct {
 	// DataDir is the directory where Pilosa stores both indexed data and
 	// running state such as cluster topology information.
 	DataDir string `toml:"data-dir"`
+
 	// Bind is the host:port on which Pilosa will listen.
 	Bind string `toml:"bind"`
+
+	// Advertise is the host:port that this node will report as its address to
+	// others. If left blank (the default), this will be set to the bind address
+	// once it is listening.
+	Advertise string `toml:"advertise"`
 
 	// MaxWritesPerRequest limits the number of mutating commands that can be in
 	// a single request to the server. This includes Set, Clear,

--- a/server/server.go
+++ b/server/server.go
@@ -248,6 +248,11 @@ func (m *Command) SetupServer() error {
 		uri.SetPort(uint16(m.ln.Addr().(*net.TCPAddr).Port))
 	}
 
+	advertURI, err := pilosa.NewURIFromAddressWithDefault(m.Config.Advertise, uri)
+	if err != nil {
+		return errors.Wrapf(err, "processing avertise address '%s'", m.Config.Advertise)
+	}
+
 	c := http.GetHTTPClient(TLSConfig)
 
 	// Primary store configuration is handled automatically now.
@@ -276,6 +281,7 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerGCNotifier(gcnotify.NewActiveGCNotifier()),
 		pilosa.OptServerStatsClient(statsClient),
 		pilosa.OptServerURI(uri),
+		pilosa.OptServerAdvertiseURI(advertURI),
 		pilosa.OptServerInternalClient(http.NewInternalClientFromURI(uri, c)),
 		pilosa.OptServerPrimaryTranslateStoreFunc(http.NewTranslateStore),
 		pilosa.OptServerClusterDisabled(m.Config.Cluster.Disabled, m.Config.Cluster.Hosts),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -405,7 +405,6 @@ func TestClusteringNodesReplica1(t *testing.T) {
 	// Create new main with the same config.
 	config := cluster[2].Command.Config
 	config.Translation.MapSize = 100000
-	// config.Bind = cluster[2].API.Node().URI.HostPort()
 
 	// this isn't necessary, but makes the test run way faster
 	config.Gossip.Port = strconv.Itoa(int(cluster[2].Command.GossipTransport().URI.Port))

--- a/uri.go
+++ b/uri.go
@@ -82,6 +82,10 @@ func NewURIFromAddress(address string) (*URI, error) {
 	return parseAddress(address)
 }
 
+func NewURIFromAddressWithDefault(address string, base *URI) (*URI, error) {
+	return parseAddressWithDefault(address, base)
+}
+
 // setScheme sets the scheme of this URI.
 func (u *URI) setScheme(scheme string) error {
 	m := schemeRegexp.FindStringSubmatch(scheme)
@@ -154,20 +158,20 @@ func (u URI) Type() string {
 	return "URI"
 }
 
-func parseAddress(address string) (uri *URI, err error) {
+func parseAddressWithDefault(address string, def *URI) (uri *URI, err error) {
 	m := addressRegexp.FindStringSubmatch(address)
 	if m == nil {
 		return nil, errors.New("invalid address")
 	}
-	scheme := "http"
+	scheme := def.Scheme
 	if m[2] != "" {
 		scheme = m[2]
 	}
-	host := "localhost"
+	host := def.Host
 	if m[3] != "" {
 		host = m[3]
 	}
-	var port = 10101
+	var port = int(def.Port)
 	if m[5] != "" {
 		port, err = strconv.Atoi(m[5])
 		if err != nil {
@@ -183,6 +187,11 @@ func parseAddress(address string) (uri *URI, err error) {
 		Port:   uint16(port),
 	}
 	return uri, nil
+}
+
+func parseAddress(address string) (uri *URI, err error) {
+	u, err := parseAddressWithDefault(address, defaultURI())
+	return u, err
 }
 
 // MarshalJSON marshals URI into a JSON-encoded byte slice.


### PR DESCRIPTION
## Overview

Adds the ability to have separate bind and advertise URIs in Pilosa. It's unclear to me how useful this will be at this juncture, because all the nodes in the cluster need to be able to connect via the advertise URI, not just external clients. Need to look back at the issues to see if this will actually address anything. Also needs some tests.

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
