### PR TITLE
Simplify "require-*" logic in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build check-clean clean cover cover-viz default docker docker-build docker-test generate generate-protoc generate-pql gometalinter install install-build-deps install-dep install-gometalinter install-protoc install-protoc-gen-gofast install-peg prerelease prerelease-upload release release-build require-dep require-gometalinter require-protoc require-protoc-gen-gofast require-peg test
+.PHONY: build check-clean clean cover cover-viz default docker docker-build docker-test generate generate-protoc generate-pql gometalinter install install-build-deps install-dep install-gometalinter install-protoc install-protoc-gen-gofast install-peg prerelease prerelease-upload release release-build test
 
 CLONE_URL=github.com/pilosa/pilosa
 VERSION := $(shell git describe --tags 2> /dev/null || echo unknown)
@@ -150,26 +150,10 @@ gometalinter: require-gometalinter
 ######################
 
 # Verifies that needed build dependency is installed. Errors out if not installed.
-define require
-	$(if $(shell command -v $1 2>/dev/null),
-		$(info Verified build dependency "$1" is installed.),
-		$(error Build dependency "$1" not installed. To install, run `make install-$1` or `make install-build-deps`))
-endef
-
-require-dep:
-	$(call require,dep)
-
-require-protoc-gen-gofast:
-	$(call require,protoc-gen-gofast)
-
-require-protoc:
-	$(call require,protoc)
-
-require-peg:
-	$(call require,peg)
-
-require-gometalinter:
-	$(call require,gometalinter)
+require-%:
+	$(if $(shell command -v $* 2>/dev/null),\
+		$(info Verified build dependency "$*" is installed.),\
+		$(error Build dependency "$*" not installed. To install, try `make install-$*`))
 
 install-build-deps: install-dep install-protoc-gen-gofast install-protoc install-stringer install-peg
 


### PR DESCRIPTION
## Overview

This  removes redundant `require-X` code in the Makefile by utilizing the `%` magic char.

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
