### PR TITLE
CircleCI: Add race detector to parallel build. Default to Go 1.11.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 defaults: &defaults
   working_directory: /go/src/github.com/pilosa/pilosa
   docker:
-    - image: circleci/golang:1.10
+    - image: circleci/golang:1.11
 fast-checkout: &fast-checkout
   attach_workspace:
     at: .
@@ -30,20 +30,28 @@ jobs:
       - run: gometalinter --install
       - run: go get github.com/remyoudompheng/go-misc/deadcode
       - run: make gometalinter
-  test-golang-1.10: &base-test
+  test-golang-1.11: &base-test
     <<: *defaults
     steps:
       - *fast-checkout
       - run: sudo apt-get install lsof
       - run: make test
-  test-golang-1.11-rc:
-    <<: *base-test
-    docker:
-      - image: circleci/golang:1.11-rc
-  test-golang-1.10-386:
+  test-golang-1.11-race:
+    <<: *defaults
+    steps:
+      - *fast-checkout
+      - run: sudo apt-get install lsof
+      - run:
+          command: make test TESTFLAGS="-race -timeout=30m"
+          no_output_timeout: 30m
+  test-golang-1.11-386:
     <<: *base-test
     environment:
       GOARCH: 386
+  test-golang-1.10:
+    <<: *base-test
+    docker:
+      - image: circleci/golang:1.10
   cluster-tests:
     <<: *defaults
     steps:
@@ -96,13 +104,16 @@ workflows:
       - linter:
           requires:
             - build
+      - test-golang-1.11:
+          requires:
+            - build
+      - test-golang-1.11-race:
+          requires:
+            - build
+      - test-golang-1.11-386:
+          requires:
+            - build
       - test-golang-1.10:
-          requires:
-            - build
-      - test-golang-1.11-rc:
-          requires:
-            - build
-      - test-golang-1.10-386:
           requires:
             - build
       - cluster-tests:
@@ -111,11 +122,11 @@ workflows:
       - prerelease:
           requires:
             - linter
-            - test-golang-1.10
+            - test-golang-1.11
       - release:
           requires:
             - linter
-            - test-golang-1.10
+            - test-golang-1.11
           filters:
             tags:
               only: /^v.*/
@@ -127,4 +138,4 @@ workflows:
       - dockerhub-upload:
           requires:
             - linter
-            - test-golang-1.10
+            - test-golang-1.11


### PR DESCRIPTION
## Overview

This makes all builds default to Go 1.11 and adds the race detector to a parallel build pipeline. PRs will only depend on the non-race-detector build, allowing the race detector to finish in parallel with our workflow.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
