### PR TITLE
Implement fast roaring bitmap union (Part 1)

### DIFF
--- a/enterprise/b/containers_btree.go
+++ b/enterprise/b/containers_btree.go
@@ -177,6 +177,15 @@ func (btc *bTreeContainers) Iterator(key uint64) (citer roaring.ContainerIterato
 	}, found
 }
 
+func (btc *bTreeContainers) Repair() {
+	e, _ := btc.tree.Seek(0)
+	_, c, err := e.Next()
+	for err != io.EOF {
+		c.Repair()
+		_, c, err = e.Next()
+	}
+}
+
 type btcIterator struct {
 	e   *enumerator
 	key uint64

--- a/http/handler.go
+++ b/http/handler.go
@@ -24,8 +24,8 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	_ "net/http/pprof"
-	"net/url" // Imported for its side-effect of registering pprof endpoints with the server.
+	_ "net/http/pprof" // Imported for its side-effect of registering pprof endpoints with the server.
+	"net/url"
 	"reflect"
 	"runtime/debug"
 	"strconv"

--- a/roaring/containers.go
+++ b/roaring/containers.go
@@ -156,7 +156,7 @@ func (sc *sliceContainers) Iterator(key uint64) (citer ContainerIterator, found 
 	return &sliceIterator{e: sc, i: i}, found
 }
 
-func (sc *sliceContainers) Repair() {
+func (sc *sliceContainers) RepairBitmaps() {
 	for _, c := range sc.containers {
 		if c.isBitmap() {
 			c.bitmapRepair()

--- a/roaring/containers.go
+++ b/roaring/containers.go
@@ -156,11 +156,9 @@ func (sc *sliceContainers) Iterator(key uint64) (citer ContainerIterator, found 
 	return &sliceIterator{e: sc, i: i}, found
 }
 
-func (sc *sliceContainers) repairBitmaps() {
+func (sc *sliceContainers) Repair() {
 	for _, c := range sc.containers {
-		if c.isBitmap() {
-			c.bitmapRepair()
-		}
+		c.Repair()
 	}
 }
 

--- a/roaring/containers.go
+++ b/roaring/containers.go
@@ -156,6 +156,14 @@ func (sc *sliceContainers) Iterator(key uint64) (citer ContainerIterator, found 
 	return &sliceIterator{e: sc, i: i}, found
 }
 
+func (sc *sliceContainers) Repair() {
+	for _, c := range sc.containers {
+		if c.isBitmap() {
+			c.bitmapRepair()
+		}
+	}
+}
+
 type sliceIterator struct {
 	e     *sliceContainers
 	i     int

--- a/roaring/containers.go
+++ b/roaring/containers.go
@@ -156,7 +156,7 @@ func (sc *sliceContainers) Iterator(key uint64) (citer ContainerIterator, found 
 	return &sliceIterator{e: sc, i: i}, found
 }
 
-func (sc *sliceContainers) RepairBitmaps() {
+func (sc *sliceContainers) repairBitmaps() {
 	for _, c := range sc.containers {
 		if c.isBitmap() {
 			c.bitmapRepair()

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -601,12 +601,14 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 				continue
 			}
 
-			iKey, iContainer := iIter.iter.Value()
-
-			// Summary statistics about all the containers in the other bitmaps
-			// that share the same key so we can make smarter union strategy
-			// decisions later.
-			summaryStats := otherIters[i:].calculateSummaryStats(iKey)
+			var (
+				iKey, iContainer = iIter.iter.Value()
+				// Summary statistics about all the containers in the other bitmaps
+				// that share the same key so we can make smarter union strategy
+				// decisions later. Note that we slice to [i:] not [i+1:] because we
+				// want to include the current containers information in the stats.
+				summaryStats = otherIters[i:].calculateSummaryStats(iKey)
+			)
 
 			if summaryStats.isOnlyContainerWithKey {
 				// TODO(rartoul): We can avoid these clones if we can determine

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -478,7 +478,11 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 //     1. Detect that bitmaps A, B, and C all have containers for key 0.
 //     2. Estimate the resulting cardinality of the union of all their containers to be
 //        400 + 500 + 3500 > ArrayMaxSize and decide upfront to use a bitset for the target
-//        container.
+//        container. Note that this is just an approximation of the final cardinality and can
+//        be off by a wide margin if there is a lot of overlap between containers, but that is
+//        fine, we'll still get the same result at the end, we'll just be more biased towards
+//        using bitmap containers will still being able to use array containers when all the
+//        cardinalities are small.
 //     3. Union the containers from bitmaps A, B, and C into the new bitset container directly
 //        using fast bitwise operations.
 //

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -605,8 +605,8 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 
 	// Performing the popcount() operation with every union is wasteful because
 	// its likely the value will be invalidated by the next union operation. As
-	// a result, when we're performing all our in-place unions, we don't repair
-	// the value of n (container cardinality), and then at the very end we perform
+	// a result, when we're performing all our in-place unions we allow the value of
+	// n (container cardinality) to fall out of sync, and then at the very end we perform
 	// a "Repair" to recalculate all the container values. That way we never popcount()
 	// an entire bitmap container more than once per bulk union operation.
 	target.Containers.Repair()

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -513,8 +513,9 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // outer loop over again and the process repeats until we've iterated through every container in every bitmap
 // and unioned everything into a single target bitmap.
 //
-// The diagram below shows the iteration state of four different maps as the algorithm progresses. The diagrams should be
-// interpreted from left -> right, top -> bottom. The ^ symbol represents the bitmaps current container iteration position,
+// The diagram below shows the iteration state of four different bitmaps as the algorithm progresses them.
+// The diagrams should BE interpreted from left -> right, top -> bottom. The X's represent a container in
+// the bitmap at a specific key,  ^ symbol represents the bitmaps current container iteration position,
 // and the - symbol represents a container that is at the current iteration position, but has been marked as "handled".
 //
 //          ----------------------------      |      ----------------------------      |      ----------------------------

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -454,7 +454,7 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // participate in the union. This significantly reduces allocations. In addition,
 // because we perform the unions one container at a time accross all the bitmaps, we
 // can calculate summary statistics that allow us to make more efficient decisions
-// up front. For example, imagine trying to combine a union accross the following three
+// up front. For example, imagine trying to perform a union accross the following three
 // bitsets:
 //
 //     1. Bitmap A: Single array container at key 0 with 400 values in it.

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -424,15 +424,6 @@ type wrapperIter struct {
 // be left unchanged, but target will be modified in place. Used to share
 // the union logic between the copy-on-write and in-place functions.
 func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
-	numArrayIntoBitmap := 0
-	numRunIntoBitmap := 0
-	numBitmapIntoBitmap := 0
-	// defer func() {
-	// 	fmt.Println("numArrayIntoBitmap: ", numArrayIntoBitmap)
-	// 	fmt.Println("numRunIntoBitmap: ", numRunIntoBitmap)
-	// 	fmt.Println("numBitmapIntoBitmap: ", numBitmapIntoBitmap)
-	// }()
-
 	otherIters := make([]wrapperIter, 0, len(others)+1)
 	bIter, _ := b.Containers.Iterator(0)
 	next := bIter.Next()
@@ -537,13 +528,10 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 
 					if iKey == jKey {
 						if jContainer.isArray() {
-							numArrayIntoBitmap++
 							unionBitmapArrayInPlace(container, jContainer)
 						} else if jContainer.isRun() {
-							numRunIntoBitmap++
 							unionBitmapRunInPlace(container, jContainer)
 						} else {
-							numBitmapIntoBitmap++
 							unionBitmapBitmapInPlace(container, jContainer)
 						}
 						otherIters[j].handled = true

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -656,7 +656,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 					}
 				}
 
-				// Once we've acquire a bitmap container (either by reusing the existing one
+				// Once we've acquired a bitmap container (either by reusing the existing one
 				// or allocating a new one) then the last step is to iterate through all the
 				// other containers to see which ones have the same key, and union all of them
 				// into the target bitmap container.

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -509,7 +509,7 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // key together, perform the union, mark the unioned containers as "handled" and then move on to the next
 // batch of containers that share the same key.
 //
-// We repeat this process until every single bitmaps current container has been "handled". Then  we start the
+// We repeat this process until every single bitmaps current container has been "handled". Then we start the
 // outer loop over again and the process repeats until we've iterated through every container in every bitmap
 // and unioned everything into a single target bitmap.
 //

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -468,7 +468,6 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 	hasNext := true
 	for hasNext {
 		// Loop until every iters current value has been handled.
-		// for {
 		for i, iIter := range otherIters {
 			if !iIter.hasNext || iIter.handled {
 				continue

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -592,6 +592,10 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 						otherIters[j].handled = true
 					}
 				}
+
+				// Now that we've calculated a container is that a union of all the containers
+				// with the same key across all the bitmaps, we store it in the list of containers
+				// for the target.
 				target.Containers.Put(iKey, container)
 			}
 		}

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -504,7 +504,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 					// Use a bitmap
 					buf := make([]uint64, bitmapN)
 					ob := buf[:bitmapN]
-					output := &Container{
+					container := &Container{
 						bitmap:        ob,
 						n:             n,
 						containerType: containerBitmap,
@@ -514,6 +514,13 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 						jKey, jContainer := jIter.iter.Value()
 
 						if iKey == jKey {
+							if jContainer.isArray() {
+								unionBitmapArrayInPlace(container, jContainer)
+							} else if jContainer.isRun() {
+								unionBitmapRunInPlace(container, jContainer)
+							} else {
+								unionBitmapBitmapInPlace(container, jContainer)
+							}
 						}
 					}
 				}

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -517,7 +517,7 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // interpreted from left -> right, top -> bottom. The ^ symbol represents the bitmaps current container iteration position,
 // and the - symbol represents a container that is at the current iteration position, but has been marked as "handled".
 //
-//          ----------------------------      |      ----------------------------      |     ----------------------------
+//          ----------------------------      |      ----------------------------      |      ----------------------------
 // Bitmap 1 |___X____________X__________|     |      |___X____________X__________|     |      |___X____________X__________|
 //              ^                             |          _                             |
 //          ----------------------------      |      ----------------------------      |      ----------------------------

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -599,7 +599,12 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 		hasNext = otherIters.next()
 	}
 
-	// Repair bitmaps after the fact
+	// Performing the popcount() operation with every union is wasteful because
+	// its likely the value will be invalidated by the next union operation. As
+	// a result, when we're performing all our in-place unions, we don't repair
+	// the value of n (container cardinality), and then at the very end we perform
+	// a "Repair" to recalculate all the container values. That way we never popcount()
+	// an entire bitmap container more than once per bulk union operation.
 	target.Containers.Repair()
 }
 

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2703,10 +2703,7 @@ func unionArrayBitmap(a, b *Container) *Container {
 // of a will need to be repaired after the fact.
 func unionBitmapArrayInPlace(a, b *Container) {
 	for _, v := range b.array {
-		if !a.bitmapContains(v) {
-			a.bitmap[v/64] |= (1 << uint64(v%64))
-			a.n++
-		}
+		a.bitmap[v/64] |= (1 << uint64(v%64))
 	}
 }
 

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -506,8 +506,8 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // and for each container with a specific key that we encounter, we scan forward to see if any of the
 // other bitmaps have a container for the same key. If so, we calculate some summary statistics and
 // then use that information to make a decision about how to union all of the containers with the same
-// key together, perform the union, and then move on to the next batch of containers that share the same
-// key.
+// key together, perform the union, mark the unioned containers as "handled" and then move on to the next
+// batch of containers that share the same key.
 //
 // We repeat this process until every single bitmaps current container has been "handled". Then  we start the
 // outer loop over again and the process repeats until we've iterated through every container in every bitmap

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -699,7 +699,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 
 	// Performing the popcount() operation with every union is wasteful because
 	// its likely the value will be invalidated by the next union operation. As
-	// a result, when we're performing all our in-place unions we allow the value of
+	// a result, when we're performing all of our in-place unions we allow the value of
 	// n (container cardinality) to fall out of sync, and then at the very end we perform
 	// a "Repair" to recalculate all the container values. That way we never popcount()
 	// an entire bitmap container more than once per bulk union operation.

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2860,10 +2860,10 @@ func unionBitmapBitmapInPlace(a, b *Container) {
 	// TODO(rartoul): Can probably make this a few x faster using
 	// SIMD instructions.
 	for i := 0; i < bitmapN; i += 4 {
-		ab[i] = ab[i] | bb[i]
-		ab[i+1] = ab[i+1] | bb[i+1]
-		ab[i+2] = ab[i+2] | bb[i+2]
-		ab[i+3] = ab[i+3] | bb[i+3]
+		ab[i] |= bb[i]
+		ab[i+1] |= bb[i+1]
+		ab[i+2] |= bb[i+2]
+		ab[i+3] |= bb[i+3]
 	}
 }
 

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -485,7 +485,7 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // In the naive approach, we had to allocate two containers, whereas in the optimized approach
 // we only had to allocate one container, and we also had to perform less union operations. This
 // example is simplistic, but the impact in terms of CPU cycles and memory allocations achieved
-// by using the optimized alogorithm when working with a large number of large bitmaps is huge.
+// by using the optimized alogorithm when unioning many large bitmaps can be huge.
 //
 // An additional optimization that this function makes is that it recognizes that even when
 // CPU support is present, performing the popcount() operation isn't free. Imagine a scenario

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -413,9 +413,9 @@ func (b *Bitmap) UnionInPlace(others ...*Bitmap) {
 	b.unionIntoTarget(b, others...)
 }
 
-// unionIntoTarget stores the union of b and other into target. b and other will
-// be left unchanged, but target will be modified in place. Used to share
-// the union logic between the copy-on-write and in-place functions.
+// unionIntoTarget stores the union of b and others into target. b and others will
+// be left unchanged (unless one of them is also target), but target will be modified
+// in place.
 //
 // This function performs an n-way union of n bitmaps. It performs this in an
 // optimized manner looping through all the bitmaps and performing unions one

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -27,8 +27,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func statshit() {}
-
 const (
 	// magicNumber is an identifier, in bytes 0-1 of the file.
 	magicNumber = uint32(12348)

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -448,9 +448,9 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // containers for each union operation for a given container key, only one
 // new container needs to be allocated (or re-used) regardless of how many bitmaps
 // participate in the union. This significantly reduces allocations. In addition,
-// because we perform the unions one container at a time accross all the bitmaps, we
+// because we perform the unions one container at a time across all the bitmaps, we
 // can calculate summary statistics that allow us to make more efficient decisions
-// up front. For example, imagine trying to perform a union accross the following three
+// up front. For example, imagine trying to perform a union across the following three
 // bitsets:
 //
 //     1. Bitmap A: Single array container at key 0 with 400 values in it.

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -3966,6 +3966,9 @@ func readWithRuns(b *Bitmap, data []byte, pos int, keyN uint32) {
 	}
 }
 
+// handledIter and handledIters are wrappers around Bitmap Container iterators
+// and assist with the unionIntoTarget algorithm by abstracting away some tedious
+// operations.
 type handledIter struct {
 	iter    ContainerIterator
 	hasNext bool

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -519,7 +519,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 				// else {
 				// Use a bitmap
 				container := target.Containers.Get(iKey)
-				if container == nil {
+				if container == nil || container.containerType != containerBitmap {
 					buf := make([]uint64, bitmapN)
 					ob := buf[:bitmapN]
 					container = &Container{

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -502,7 +502,7 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // At every "tick" of the outermost loop, we increment our pointer into the bitmaps list of containers
 // by 1 (if we haven't reached the end of the containers for that bitmap.)
 //
-// We then loop through all of the "current" values of the current container for all of the bitmaps
+// We then loop through all of the "current" values(containers) for all of the bitmaps
 // and for each container with a specific key that we encounter, we scan forward to see if any of the
 // other bitmaps have a container for the same key. If so, we calculate some summary statistics and
 // then use that information to make a decision about how to union all of the containers with the same

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -398,6 +398,7 @@ func (b *Bitmap) Intersect(other *Bitmap) *Bitmap {
 // Union returns the bitwise union of b and other.
 func (b *Bitmap) Union(others ...*Bitmap) *Bitmap {
 	output := NewBitmap()
+	output.UnionInPlace(b)
 	output.UnionInPlace(others...)
 	return output
 }

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -494,7 +494,7 @@ func (b *Bitmap) unionIntoTargetSingle(target *Bitmap, other *Bitmap) {
 // An additional optimization that this function makes is that it recognizes that even when
 // CPU support is present, performing the popcount() operation isn't free. Imagine a scenario
 // where 10 bitset containers are being unioned together one after the next. If every
-// bitset<->bitset union operation needs to keep the containers cardinality up to date, then
+// bitset<->bitset union operation needs to keep the containers' cardinality up to date, then
 // the algorithm will waste a lot of time performing intermediary popcount() operations that
 // will immediately be invalidated by the next union operation. As a result, we allow the cardinality
 // of containers to degrade when we perform the in-place union operations, and then when the algorithm

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -98,10 +98,6 @@ type Containers interface {
 
 	Count() uint64
 
-	// RepairBitmaps will repair cardinality(n) values on bitmap containers after
-	// in-place operations.
-	RepairBitmaps()
-
 	//Reset will clear the containers collection to allow for recycling during snapshot
 	Reset()
 }
@@ -692,7 +688,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 	// n (container cardinality) to fall out of sync, and then at the very end we perform
 	// a "Repair" to recalculate all the container values. That way we never popcount()
 	// an entire bitmap container more than once per bulk union operation.
-	target.Containers.RepairBitmaps()
+	target.Containers.(*sliceContainers).repairBitmaps()
 }
 
 // Difference returns the difference of b and other.

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -659,8 +659,9 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 				// Once we've acquired a bitmap container (either by reusing the existing one
 				// or allocating a new one) then the last step is to iterate through all the
 				// other containers to see which ones have the same key, and union all of them
-				// into the target bitmap container.
-				for j, jIter := range bitmapIters {
+				// into the target bitmap container. Only need to loop starting from i because
+				// anything previous to that has already been handled.
+				for j, jIter := range bitmapIters[i:] {
 					jKey, jContainer := jIter.iter.Value()
 
 					if iKey == jKey {

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -98,8 +98,9 @@ type Containers interface {
 
 	Count() uint64
 
-	// Repair will n values after in-place operations.
-	Repair()
+	// RepairBitmaps will repair cardinality(n) values on bitmap containers after
+	// in-place operations.
+	RepairBitmaps()
 
 	//Reset will clear the containers collection to allow for recycling during snapshot
 	Reset()
@@ -672,7 +673,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 	// n (container cardinality) to fall out of sync, and then at the very end we perform
 	// a "Repair" to recalculate all the container values. That way we never popcount()
 	// an entire bitmap container more than once per bulk union operation.
-	target.Containers.Repair()
+	target.Containers.RepairBitmaps()
 }
 
 // Difference returns the difference of b and other.

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -563,8 +563,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 	// a wasteful self union.
 	if b != target {
 		bIter, _ := b.Containers.Iterator(0)
-		next := bIter.Next()
-		if next {
+		if bIter.Next() {
 			bitmapIters = append(bitmapIters, handledIter{
 				iter:    bIter,
 				hasNext: true,
@@ -575,8 +574,7 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 
 	for _, other := range others {
 		otherIter, _ := other.Containers.Iterator(0)
-		next := otherIter.Next()
-		if next {
+		if otherIter.Next() {
 			bitmapIters = append(bitmapIters, handledIter{
 				iter:    otherIter,
 				hasNext: true,

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -4028,20 +4028,17 @@ func (w handledIters) calculateSummaryStats(key uint64) containerUnionSummarySta
 	summary := containerUnionSummaryStats{}
 
 	for _, iter := range w {
-		if summary.hasMaxRange {
-			// If we already know that we're going to use a max range RLE container,
-			// then there is no reason to continue calculating statistics.
-			continue
-		}
-
 		// Calculate key-level statistics here
 		currKey, currContainer := iter.iter.Value()
 
 		if key == currKey {
 			summary.isOnlyContainerWithKey = false
 			summary.n += currContainer.n
-			if !summary.hasMaxRange {
-				summary.hasMaxRange = (currContainer.n == maxContainerVal+1)
+
+			if currContainer.n == maxContainerVal+1 {
+				summary.hasMaxRange = true
+				summary.n = maxContainerVal + 1
+				return summary
 			}
 		}
 	}

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -98,7 +98,7 @@ type Containers interface {
 
 	Count() uint64
 
-	// Reset will clear the containers collection to allow for recycling during snapshot
+	// Reset clears the containers collection to allow for recycling during snapshot
 	Reset()
 
 	// Repair will repair the cardinality of any containers whose cardinality were corrupted

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2094,8 +2094,14 @@ func (c *Container) check() error {
 
 func (c *Container) bitmapRepair() {
 	n := int32(0)
-	for i := 0; i < bitmapN; i++ {
+	// Manually unroll loop to make it a little faster.
+	// TODO(rartoul): Can probably make this a few x faster using
+	// SIMD instructions.
+	for i := 0; i < bitmapN; i += 4 {
 		n += int32(popcount(c.bitmap[i]))
+		n += int32(popcount(c.bitmap[i+1]))
+		n += int32(popcount(c.bitmap[i+2]))
+		n += int32(popcount(c.bitmap[i+3]))
 	}
 	c.n = n
 }
@@ -2852,8 +2858,14 @@ func unionBitmapBitmapInPlace(a, b *Container) {
 		bb = b.bitmap[:bitmapN]
 	)
 
-	for i := 0; i < bitmapN; i++ {
+	// Manually unroll loop to make it a little faster.
+	// TODO(rartoul): Can probably make this a few x faster using
+	// SIMD instructions.
+	for i := 0; i < bitmapN; i += 4 {
 		ab[i] = ab[i] | bb[i]
+		ab[i+1] = ab[i+1] | bb[i+1]
+		ab[i+2] = ab[i+2] | bb[i+2]
+		ab[i+3] = ab[i+3] | bb[i+3]
 	}
 }
 

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -407,9 +407,6 @@ func (b *Bitmap) Union(others ...*Bitmap) *Bitmap {
 // b in place.
 func (b *Bitmap) UnionInPlace(others ...*Bitmap) {
 	b.unionIntoTarget(b, others...)
-	// for _, other := range others {
-	// 	b.unionIntoTarget(other, b)
-	// }
 }
 
 type wrapperIter struct {
@@ -504,12 +501,15 @@ func (b *Bitmap) unionIntoTarget(target *Bitmap, others ...*Bitmap) {
 				// }
 				// else {
 				// Use a bitmap
-				buf := make([]uint64, bitmapN)
-				ob := buf[:bitmapN]
-				container := &Container{
-					bitmap:        ob,
-					n:             0,
-					containerType: containerBitmap,
+				container := target.Containers.Get(iKey)
+				if container == nil {
+					buf := make([]uint64, bitmapN)
+					ob := buf[:bitmapN]
+					container = &Container{
+						bitmap:        ob,
+						n:             0,
+						containerType: containerBitmap,
+					}
 				}
 
 				for _, jIter := range otherIters {

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -2471,38 +2471,6 @@ func unionArrayArray(a, b *Container) *Container {
 	return output
 }
 
-// func unionArrayArrayInPlace(a, b *Container) *Container {
-// 	statsHit("union/ArrayArray")
-// 	output := a
-// 	na, nb := len(a.array), len(b.array)
-// 	for i, j := 0, 0; ; {
-// 		if i >= na && j >= nb {
-// 			break
-// 		} else if i < na && j >= nb {
-// 			output.add(a.array[i])
-// 			i++
-// 			continue
-// 		} else if i >= na && j < nb {
-// 			output.add(b.array[j])
-// 			j++
-// 			continue
-// 		}
-
-// 		va, vb := a.array[i], b.array[j]
-// 		if va < vb {
-// 			output.add(va)
-// 			i++
-// 		} else if va > vb {
-// 			output.add(vb)
-// 			j++
-// 		} else {
-// 			output.add(va)
-// 			i, j = i+1, j+1
-// 		}
-// 	}
-// 	return output
-// }
-
 // unionArrayRun optimistically assumes that the result will be a run container,
 // and converts to a bitmap or array container afterwards if necessary.
 func unionArrayRun(a, b *Container) *Container {
@@ -2764,9 +2732,7 @@ func unionArrayBitmap(a, b *Container) *Container {
 // of a will need to be repaired after the fact.
 func unionBitmapArrayInPlace(a, b *Container) {
 	for _, v := range b.array {
-		// a.bitmap[v>>6] |= (1 << uint64(v%64))
-		i := v >> 6
-		a.bitmap[i] = a.bitmap[i] | (uint64(1) << (v % 64))
+		a.bitmap[v>>6] |= (uint64(1) << (v % 64))
 	}
 }
 

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -395,7 +395,7 @@ func (b *Bitmap) Intersect(other *Bitmap) *Bitmap {
 	return output
 }
 
-// Union returns the bitwise union of b and other as a new bitmap.
+// Union returns the bitwise union of b and others as a new bitmap.
 func (b *Bitmap) Union(others ...*Bitmap) *Bitmap {
 	output := NewBitmap()
 	if len(others) == 1 {

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -3267,6 +3267,27 @@ func TestUnmarshalOfficialRoaring(t *testing.T) {
 
 }
 
+func BenchmarkUnionBitmapBitmapInPlace(b *testing.B) {
+	b1 := newTestBitmapContainer()
+	b2 := newTestBitmapContainer()
+	for n := 0; n < b.N; n++ {
+		unionBitmapBitmapInPlace(b1, b2)
+	}
+}
+
+func newTestBitmapContainer() *Container {
+	var (
+		buf       = make([]uint64, bitmapN)
+		ob        = buf[:bitmapN]
+		container = &Container{
+			bitmap:        ob,
+			n:             0,
+			containerType: containerBitmap,
+		}
+	)
+	return container
+}
+
 /*
 // This function exercises an arcane edge case in dead code.
 // It doesn't need to be run right now.

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -3275,6 +3275,13 @@ func BenchmarkUnionBitmapBitmapInPlace(b *testing.B) {
 	}
 }
 
+func BenchmarkBitmapRepair(b *testing.B) {
+	b1 := newTestBitmapContainer()
+	for n := 0; n < b.N; n++ {
+		b1.bitmapRepair()
+	}
+}
+
 func newTestBitmapContainer() *Container {
 	var (
 		buf       = make([]uint64, bitmapN)

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -411,14 +411,10 @@ func TestBitmap_UnionInPlace1(t *testing.T) {
 
 	result.UnionInPlace(bm0, bm1)
 	if n := result.Count(); n != 2682675 {
-		// for _, val := range result.Slice() {
-		// 	fmt.Println(val)
-		// }
 		t.Fatalf("unexpected n: %d", n)
 	}
 
 	bm := testBM()
-	fmt.Println("bm.Count(): ", bm.Count())
 	result = roaring.NewBitmap()
 	result.UnionInPlace(bm, bm0)
 	if n := result.Count(); n != 75009 {

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -1424,12 +1424,12 @@ func BenchmarkUnion(b *testing.B) {
 	}
 }
 
-// func BenchmarkUnionBulk(b *testing.B) {
-// 	// a1, a2, b, r1, r2 *roaring.Bitmap
-// 	data := getBenchData(b)
-// 	yolo := roaring.NewBitmap()
-// 	for n := 0; n < b.N; n++ {
-// 		yolo.
-// 			BulkUnion(data.a1, data.a2, data.b, data.r1, data.r2)
-// 	}
-// }
+func BenchmarkUnionBulk(b *testing.B) {
+	// a1, a2, b, r1, r2 *roaring.Bitmap
+	data := getBenchData(b)
+	yolo := roaring.NewBitmap()
+	for n := 0; n < b.N; n++ {
+		yolo.
+			UnionInPlace(data.a1, data.a2, data.b, data.r1, data.r2)
+	}
+}

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -1413,7 +1413,6 @@ func BenchmarkSliceDescending(b *testing.B) {
 }
 
 func BenchmarkUnion(b *testing.B) {
-	// a1, a2, b, r1, r2 *roaring.Bitmap
 	data := getBenchData(b)
 	for n := 0; n < b.N; n++ {
 		data.a1.
@@ -1425,11 +1424,10 @@ func BenchmarkUnion(b *testing.B) {
 }
 
 func BenchmarkUnionBulk(b *testing.B) {
-	// a1, a2, b, r1, r2 *roaring.Bitmap
 	data := getBenchData(b)
-	yolo := roaring.NewBitmap()
+	bm := roaring.NewBitmap()
 	for n := 0; n < b.N; n++ {
-		yolo.
+		bm.
 			UnionInPlace(data.a1, data.a2, data.b, data.r1, data.r2)
 	}
 }

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -411,10 +411,14 @@ func TestBitmap_UnionInPlace1(t *testing.T) {
 
 	result.UnionInPlace(bm0, bm1)
 	if n := result.Count(); n != 2682675 {
+		// for _, val := range result.Slice() {
+		// 	fmt.Println(val)
+		// }
 		t.Fatalf("unexpected n: %d", n)
 	}
 
 	bm := testBM()
+	fmt.Println("bm.Count(): ", bm.Count())
 	result = roaring.NewBitmap()
 	result.UnionInPlace(bm, bm0)
 	if n := result.Count(); n != 75009 {

--- a/roaring/roaring_test.go
+++ b/roaring/roaring_test.go
@@ -396,7 +396,44 @@ func TestBitmap_Union1(t *testing.T) {
 	if n := result.Count(); n != 75007 {
 		t.Fatalf("unexpected n: %d", n)
 	}
+}
 
+func TestBitmap_UnionInPlace1(t *testing.T) {
+	var (
+		bm0    = roaring.NewFileBitmap(0, 2683177)
+		bm1    = roaring.NewFileBitmap()
+		result = roaring.NewBitmap()
+	)
+	for i := uint64(628); i < 2683301; i++ {
+		bm1.Add(i)
+	}
+	bm1.Add(4000000)
+
+	result.UnionInPlace(bm0, bm1)
+	if n := result.Count(); n != 2682675 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+
+	bm := testBM()
+	result = roaring.NewBitmap()
+	result.UnionInPlace(bm, bm0)
+	if n := result.Count(); n != 75009 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+
+	result = roaring.NewBitmap()
+	result.UnionInPlace(bm, bm)
+	if n := result.Count(); n != 75007 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+
+	// Make sure the bitmaps weren't mutated.
+	if n := bm0.Count(); n != 2 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+	if n := bm1.Count(); n != 2682674 {
+		t.Fatalf("unexpected n: %d", n)
+	}
 }
 
 func TestBitmap_Intersection_Empty(t *testing.T) {
@@ -544,9 +581,33 @@ func TestBitmap_Union(t *testing.T) {
 	bm0 := roaring.NewFileBitmap(0, 1000001, 1000002, 1000003)
 	bm1 := roaring.NewFileBitmap(0, 50000, 1000001, 1000002)
 	result := bm0.Union(bm1)
+
 	if n := result.Count(); n != 5 {
 		t.Fatalf("unexpected n: %d", n)
 	}
+}
+
+func TestBitmap_UnionInPlace(t *testing.T) {
+	var (
+		bm0    = roaring.NewFileBitmap(0, 1000001, 1000002, 1000003)
+		bm1    = roaring.NewFileBitmap(0, 50000, 1000001, 1000002)
+		result = roaring.NewBitmap()
+	)
+	result.UnionInPlace(bm0, bm1)
+
+	// Make sure the union worked.
+	if n := result.Count(); n != 5 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+
+	// Make sure the other bitmaps weren't mutated.
+	if n := bm0.Count(); n != 4 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+	if n := bm1.Count(); n != 4 {
+		t.Fatalf("unexpected n: %d", n)
+	}
+
 }
 
 func TestBitmap_Xor(t *testing.T) {
@@ -1350,3 +1411,25 @@ func BenchmarkSliceDescending(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkUnion(b *testing.B) {
+	// a1, a2, b, r1, r2 *roaring.Bitmap
+	data := getBenchData(b)
+	for n := 0; n < b.N; n++ {
+		data.a1.
+			Union(data.a2).
+			Union(data.b).
+			Union(data.r1).
+			Union(data.r2)
+	}
+}
+
+// func BenchmarkUnionBulk(b *testing.B) {
+// 	// a1, a2, b, r1, r2 *roaring.Bitmap
+// 	data := getBenchData(b)
+// 	yolo := roaring.NewBitmap()
+// 	for n := 0; n < b.N; n++ {
+// 		yolo.
+// 			BulkUnion(data.a1, data.a2, data.b, data.r1, data.r2)
+// 	}
+// }


### PR DESCRIPTION
## Overview

This pull partially addresses #1765 by providing a much faster and less allocation heavy implementation of the union operation.

## Pull request checklist

- [X] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [X] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [X] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [X] I have resolved any merge conflicts.
- [X] I have included tests that cover my changes.
- [X] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
