### PR TITLE
WIP: implements float support in a custom bsi field

### DIFF
--- a/field_test.go
+++ b/field_test.go
@@ -16,6 +16,8 @@ package pilosa_test
 
 import (
 	"io/ioutil"
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -23,6 +25,108 @@ import (
 	"github.com/pilosa/pilosa/roaring"
 	"github.com/pilosa/pilosa/test"
 )
+
+// Ensure a field can set & read a bsiGroup float.
+func TestField_SetFloat(t *testing.T) {
+	t.Run("OK", func(t *testing.T) {
+		idx := test.MustOpenIndex()
+		defer idx.Close()
+
+		f, err := idx.CreateField("f", pilosa.OptFieldTypeFloat())
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		tests := []struct {
+			flt float64
+			err string
+		}{
+			{flt: 7.0e+0},
+			{flt: -1.120e+308},
+			{flt: 1.120e-292},
+			{flt: math.NaN(), err: "float provided is NaN"},
+			{flt: math.Inf(0), err: "float provided is infinity"},
+
+			// The following came from ftoa.go tests: https://gist.github.com/rsc/1057873
+			{flt: math.Ldexp(8511030020275656, -342)},
+			{flt: math.Ldexp(5201988407066741, -824)},
+			{flt: math.Ldexp(6406892948269899, +237)},
+			{flt: math.Ldexp(8431154198732492, +72)},
+			{flt: math.Ldexp(6475049196144587, +99)},
+			{flt: math.Ldexp(8274307542972842, +726)},
+			{flt: math.Ldexp(5381065484265332, -456)},
+			{flt: math.Ldexp(6761728585499734, -1057)},
+			{flt: math.Ldexp(7976538478610756, +376)},
+			{flt: math.Ldexp(5982403858958067, +377)},
+			{flt: math.Ldexp(5536995190630837, +93)},
+			{flt: math.Ldexp(7225450889282194, +710)},
+			{flt: math.Ldexp(7225450889282194, +709)},
+			{flt: math.Ldexp(8703372741147379, +117)},
+			{flt: math.Ldexp(8944262675275217, -1001)},
+			{flt: math.Ldexp(7459803696087692, -707)},
+			{flt: math.Ldexp(6080469016670379, -381)},
+			{flt: math.Ldexp(8385515147034757, +721)},
+			{flt: math.Ldexp(7514216811389786, -828)},
+			{flt: math.Ldexp(8397297803260511, -345)},
+			{flt: math.Ldexp(6733459239310543, +202)},
+			{flt: math.Ldexp(8091450587292794, -473)},
+			{flt: math.Ldexp(6567258882077402, +952)},
+			{flt: math.Ldexp(6712731423444934, +535)},
+			{flt: math.Ldexp(6712731423444934, +534)},
+			{flt: math.Ldexp(5298405411573037, -957)},
+			{flt: math.Ldexp(5137311167659507, -144)},
+			{flt: math.Ldexp(6722280709661868, +363)},
+			{flt: math.Ldexp(5344436398034927, -169)},
+			{flt: math.Ldexp(8369123604277281, -853)},
+			{flt: math.Ldexp(8995822108487663, -780)},
+			{flt: math.Ldexp(8942832835564782, -383)},
+			{flt: math.Ldexp(8942832835564782, -384)},
+			{flt: math.Ldexp(8942832835564782, -385)},
+			{flt: math.Ldexp(6965949469487146, -249)},
+			{flt: math.Ldexp(6965949469487146, -250)},
+			{flt: math.Ldexp(6965949469487146, -251)},
+			{flt: math.Ldexp(7487252720986826, +548)},
+			{flt: math.Ldexp(5592117679628511, +164)},
+			{flt: math.Ldexp(8887055249355788, +665)},
+			{flt: math.Ldexp(6994187472632449, +690)},
+			{flt: math.Ldexp(8797576579012143, +588)},
+			{flt: math.Ldexp(7363326733505337, +272)},
+			{flt: math.Ldexp(8549497411294502, -448)},
+			{flt: 12345000},
+		}
+		for i, test := range tests {
+			// Set float value on field.
+			changed, err := f.SetFloat(100, test.flt)
+			if test.err != "" {
+				if !strings.Contains(err.Error(), test.err) {
+					t.Errorf("test %d expected error: %s, but got: %s", i, test.err, err)
+				}
+				continue
+			}
+			if err != nil {
+				t.Fatal(err)
+			} else if !changed {
+				t.Errorf("test %d expected change", i)
+			}
+
+			// Read value.
+			if value, exists, err := f.Float(100); err != nil {
+				t.Fatal(err)
+			} else if value != test.flt {
+				t.Errorf("test %d expected value: %v, but got: %v", i, test.flt, value)
+			} else if !exists {
+				t.Errorf("test %d expected value to exist", i)
+			}
+
+			// Setting value should return no change.
+			if changed, err := f.SetFloat(100, test.flt); err != nil {
+				t.Fatal(err)
+			} else if changed {
+				t.Errorf("test %d expected no change", i)
+			}
+		}
+	})
+}
 
 // Ensure a field can set & read a bsiGroup value.
 func TestField_SetValue(t *testing.T) {

--- a/view.go
+++ b/view.go
@@ -327,6 +327,16 @@ func (v *view) value(columnID uint64, bitDepth uint) (value uint64, exists bool,
 	return frag.value(columnID, bitDepth)
 }
 
+// float uses a column of bits to read a multi-bit float value.
+func (v *view) float(columnID uint64) (value uint64, shift uint, neg bool, exists bool, err error) {
+	shard := columnID / ShardWidth
+	frag, err := v.CreateFragmentIfNotExists(shard)
+	if err != nil {
+		return value, shift, neg, exists, err
+	}
+	return frag.float(columnID)
+}
+
 // setValue uses a column of bits to set a multi-bit value.
 func (v *view) setValue(columnID uint64, bitDepth uint, value uint64) (changed bool, err error) {
 	shard := columnID / ShardWidth
@@ -335,6 +345,16 @@ func (v *view) setValue(columnID uint64, bitDepth uint, value uint64) (changed b
 		return changed, err
 	}
 	return frag.setValue(columnID, bitDepth, value)
+}
+
+// setFloat uses a column of bits to set a multi-bit float value.
+func (v *view) setFloat(columnID uint64, shiftDepth uint, value uint64, negative bool) (changed bool, err error) {
+	shard := columnID / ShardWidth
+	frag, err := v.CreateFragmentIfNotExists(shard)
+	if err != nil {
+		return changed, err
+	}
+	return frag.setFloat(columnID, shiftDepth, value, negative)
 }
 
 // sum returns the sum & count of a field.


### PR DESCRIPTION
## Overview

So far I have just implemented set/clear/get float at the fragment, and set/get float at the field levels in order to see how it performs. Also included are a few tests and a benchmark. I'm just putting this PR up for anyone to take a look at the implementation so far.

Fixes #1762 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
