### PR TITLE
propogate updates to node details (not just additions and deletions)

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -70,7 +70,7 @@ type Node struct {
 }
 
 func (n Node) String() string {
-	return fmt.Sprintf("Node:%s:%s:%s", n.URI, n.State, n.ID[:6])
+	return fmt.Sprintf("Node:%s:%s:%s", n.URI, n.State, n.ID)
 }
 
 // Nodes represents a list of nodes.
@@ -364,6 +364,7 @@ func (c *cluster) addNode(node *Node) error {
 	if !c.Topology.addID(node.ID) {
 		return nil
 	}
+	c.Topology.nodeStates[node.ID] = node.State
 
 	// save topology
 	return c.saveTopology()
@@ -588,6 +589,12 @@ func (c *cluster) nodePositionByID(nodeID string) int {
 func (c *cluster) addNodeBasicSorted(node *Node) bool {
 	n := c.unprotectedNodeByID(node.ID)
 	if n != nil {
+		if n.State != node.State || n.IsCoordinator != node.IsCoordinator || n.URI != node.URI {
+			n.State = node.State
+			n.IsCoordinator = node.IsCoordinator
+			n.URI = node.URI
+			return true
+		}
 		return false
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -678,6 +678,15 @@ func TestClusterQueriesAfterRestart(t *testing.T) {
 	defer cluster.Close()
 	cmd1 := cluster[1]
 
+	for _, com := range cluster {
+		nodes := com.API.Hosts(context.Background())
+		for _, n := range nodes {
+			if n.State != "READY" {
+				t.Fatalf("unexpected node state after upping cluster: %v", nodes)
+			}
+		}
+	}
+
 	cmd1.MustCreateIndex(t, "testidx", pilosa.IndexOptions{})
 	cmd1.MustCreateField(t, "testidx", "testfield", pilosa.OptFieldTypeSet(pilosa.CacheTypeRanked, 10))
 


### PR DESCRIPTION
to all nodes in cluster, not just coordinator

## Overview

Fixes the issue @tgruben was seeing where some nodes in the cluster would report in their status that other nodes were down even when the coordinator reported that everything was up.

Fixes #

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
