### PR TITLE
fix bug where cluster goes into RESIZING instead of NORMAL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,20 +68,24 @@ release: check-clean
 	$(MAKE) release-build GOOS=linux GOARCH=386
 	$(MAKE) release-build GOOS=linux GOARCH=386 ENTERPRISE=1
 
+
+# try (e.g.) internal/clustertests/docker-compose-replication2.yml
+DOCKER_COMPOSE=internal/clustertests/docker-compose.yml
+
 # Run cluster integration tests using docker. Requires docker daemon to be
 # running. This will catch changes to internal/clustertests/*.go, but if you
 # make changes to Pilosa, you'll want to run clustertests-build to rebuild the
 # pilosa image.
 clustertests:
-	docker-compose -f internal/clustertests/docker-compose.yml down
-	docker-compose -f internal/clustertests/docker-compose.yml build client1
-	docker-compose -f internal/clustertests/docker-compose.yml up --exit-code-from=client1
+	docker-compose -f $(DOCKER_COMPOSE) down
+	docker-compose -f $(DOCKER_COMPOSE) build client1
+	docker-compose -f $(DOCKER_COMPOSE) up --exit-code-from=client1
 
 
 # Like clustertests, but rebuilds all images.
 clustertests-build:
-	docker-compose -f internal/clustertests/docker-compose.yml down
-	docker-compose -f internal/clustertests/docker-compose.yml up --exit-code-from=client1 --build
+	docker-compose -f $(DOCKER_COMPOSE) down
+	docker-compose -f $(DOCKER_COMPOSE) up --exit-code-from=client1 --build
 
 # Create prerelease builds
 prerelease: vendor

--- a/cluster.go
+++ b/cluster.go
@@ -983,7 +983,7 @@ func (c *cluster) markAsJoined() {
 
 // needTopologyAgreement is unprotected.
 func (c *cluster) needTopologyAgreement() bool {
-	return c.state == ClusterStateStarting && !stringSlicesAreEqual(c.Topology.nodeIDs, c.nodeIDs())
+	return (c.state == ClusterStateStarting || c.state == ClusterStateDegraded) && !stringSlicesAreEqual(c.Topology.nodeIDs, c.nodeIDs())
 }
 
 // haveTopologyAgreement is unprotected.

--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -333,15 +333,30 @@ func newEventReceiver(logger *log.Logger, papi *pilosa.API) *eventReceiver {
 }
 
 func (g *eventReceiver) NotifyJoin(n *memberlist.Node) {
-	g.ch <- memberlist.NodeEvent{Event: memberlist.NodeJoin, Node: n}
+	// copy node to avoid data race
+	n2 := *n
+	n2.Meta = make([]byte, len(n.Meta))
+	copy(n2.Meta, n.Meta)
+
+	g.ch <- memberlist.NodeEvent{Event: memberlist.NodeJoin, Node: &n2}
 }
 
 func (g *eventReceiver) NotifyLeave(n *memberlist.Node) {
-	g.ch <- memberlist.NodeEvent{Event: memberlist.NodeLeave, Node: n}
+	// copy node to avoid data race
+	n2 := *n
+	n2.Meta = make([]byte, len(n.Meta))
+	copy(n2.Meta, n.Meta)
+
+	g.ch <- memberlist.NodeEvent{Event: memberlist.NodeLeave, Node: &n2}
 }
 
 func (g *eventReceiver) NotifyUpdate(n *memberlist.Node) {
-	g.ch <- memberlist.NodeEvent{Event: memberlist.NodeUpdate, Node: n}
+	// copy node to avoid data race
+	n2 := *n
+	n2.Meta = make([]byte, len(n.Meta))
+	copy(n2.Meta, n.Meta)
+
+	g.ch <- memberlist.NodeEvent{Event: memberlist.NodeUpdate, Node: &n2}
 }
 
 func (g *eventReceiver) listen() {

--- a/internal/clustertests/docker-compose-replication2.yml
+++ b/internal/clustertests/docker-compose-replication2.yml
@@ -1,0 +1,58 @@
+version: '2'
+services: 
+  pilosa1:
+    build:
+      context: ../..
+      dockerfile: Dockerfile-clustertests
+    image: ptest
+    ports:
+      - "33455:10101"
+    environment:
+      - PILOSA_CLUSTER_COORDINATOR=true
+      - PILOSA_GOSSIP_SEEDS=pilosa1:14000
+      - PILOSA_CLUSTER_REPLICAS=2
+    networks:
+      - pilosanet
+    command:
+      - "/pilosa server --bind pilosa1:10101"
+  pilosa2:
+    build:
+      context: ../..
+      dockerfile: Dockerfile-clustertests
+    image: ptest
+    ports:
+      - "33456:10101"
+    environment:
+      - PILOSA_GOSSIP_SEEDS=pilosa1:14000
+      - PILOSA_CLUSTER_REPLICAS=2
+    networks:
+      - pilosanet
+    command:
+      - "/pilosa server --bind pilosa2:10101"
+  pilosa3:
+    build:
+      context: ../..
+      dockerfile: Dockerfile-clustertests
+    image: ptest
+    ports:
+      - "33457:10101"
+    environment:
+      - PILOSA_GOSSIP_SEEDS=pilosa1:14000,pilosa2:14000
+      - PILOSA_CLUSTER_REPLICAS=2
+    networks:
+      - pilosanet
+    command:
+      - "/pilosa server --bind pilosa3:10101"
+  client1:
+    build:
+      context: .
+    environment:
+      - ENABLE_PILOSA_CLUSTER_TESTS=1
+    networks:
+      - pilosanet
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - "go test -v -count=1 github.com/pilosa/pilosa/internal/clustertests"
+networks: 
+  pilosanet:


### PR DESCRIPTION
running
"make clustertests
DOCKER_COMPOSE=internal/clustertests/docker-compose-replication2.yml"

shows this issue (just remove the change in cluster.go).

Also removed two unrelated lines of code that appear to be doing absolutely nothing.

Fixes #1776 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
