### PR TITLE
convert the anti-entropy logic to use `ImportRoaring` instead of `QueryNode`

### DIFF
--- a/api.go
+++ b/api.go
@@ -333,8 +333,6 @@ func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, 
 				}
 				return err
 			})
-			go func(node *Node) {
-			}(node)
 		} else if !remote { // if remote == true we don't forward to other nodes
 			// forward it on
 			eg.Go(func() error {

--- a/holder_test.go
+++ b/holder_test.go
@@ -391,19 +391,18 @@ func TestHolderSyncer_TimeQuantum(t *testing.T) {
 	hldr0 := &test.Holder{Holder: c[0].Server.Holder()}
 	hldr1 := &test.Holder{Holder: c[1].Server.Holder()}
 
-	// Set data on the local holder.
+	// Set data on the local holder for node0.
 	t1 := time.Date(2018, 8, 1, 12, 30, 0, 0, time.UTC)
 	t2 := time.Date(2018, 8, 2, 12, 30, 0, 0, time.UTC)
 	hldr0.SetBitTime("i", "f", 0, 1, &t1)
 	hldr0.SetBitTime("i", "f", 0, 2, &t2)
 
+	// Set data on node1
+	hldr0.SetBitTime("i", "f", 0, 22, &t2)
+
 	err = c[0].Server.SyncData()
 	if err != nil {
 		t.Fatalf("syncing node 0: %v", err)
-	}
-	err = c[1].Server.SyncData()
-	if err != nil {
-		t.Fatalf("syncing node 1: %v", err)
 	}
 
 	// Verify data is the same on both nodes.
@@ -411,7 +410,7 @@ func TestHolderSyncer_TimeQuantum(t *testing.T) {
 		if a := hldr.RowTime("i", "f", 0, t1, quantum).Columns(); !reflect.DeepEqual(a, []uint64{1}) {
 			t.Errorf("unexpected columns(%d/0): %+v", i, a)
 		}
-		if a := hldr.RowTime("i", "f", 0, t2, quantum).Columns(); !reflect.DeepEqual(a, []uint64{2}) {
+		if a := hldr.RowTime("i", "f", 0, t2, quantum).Columns(); !reflect.DeepEqual(a, []uint64{2, 22}) {
 			t.Errorf("unexpected columns(%d/0): %+v", i, a)
 		}
 	}


### PR DESCRIPTION
## Overview

Anti-entropy was sending (potentially) large batches of `Set()` and `Clear()` calls via PQL. This PR converts that logic to build a roaring bitmap and use the `ImportRoaring` api method instead.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
