### PR TITLE
revert client Timeout addition

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -1504,15 +1504,7 @@ func GetHTTPClient(t *tls.Config) *http.Client {
 	if t != nil {
 		transport.TLSClientConfig = t
 	}
-	return &http.Client{
-		Transport: transport,
-		// Internal queries will time out after 2h 7m by default. This is
-		// reduced from the old default of no timeout, so it was thought we
-		// should keep it fairly high, but it could probably be reduced in most
-		// cases. It is set to an odd number in the hopes that it will be
-		// recognizable in stats/traces/logs when this limit is being hit.
-		Timeout: 127 * time.Minute,
-	}
+	return &http.Client{Transport: transport}
 }
 
 // handlPostRoaringImport


### PR DESCRIPTION
suspect that this is somehow causing "cannot assign requested address" bugs for
some users. removing since it wasn't a necessary part of the deadlock fix, but
just seemed like a prudent thing to have.


## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
