### PR TITLE
reverse the order of items in the github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 For bugs, please provide the following:
 
-### Unxpected behavior
+### What's going wrong?
 
-### Expected behavior
+### What was expected?
 
 ### Steps to reproduce the behavior
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,8 +1,8 @@
 For bugs, please provide the following:
 
-### Expected behavior
+### Unxpected behavior
 
-### Actual behavior
+### Expected behavior
 
 ### Steps to reproduce the behavior
 


### PR DESCRIPTION
## Overview

Personally, I would prefer the erroneous behavior experienced due to a bug be the first thing described in the issue. This PR reverses the order of items in the issue template to support that. I'm not sure about what the labels should be, but here's a suggestion.
