### PR TITLE
fixes a bug on upper end of bsi range queries

### DIFF
--- a/pql/ast.go
+++ b/pql/ast.go
@@ -91,8 +91,8 @@ func (q *Query) endConditional() {
 	if q.conditional[1] == "<" {
 		low++
 	}
-	if q.conditional[3] == "<=" {
-		high++
+	if q.conditional[3] == "<" {
+		high--
 	}
 
 	elem := q.lastCallStackElem()

--- a/pql/pqlpeg_test.go
+++ b/pql/pqlpeg_test.go
@@ -501,7 +501,7 @@ func TestPQLDeepEquality(t *testing.T) {
 				Args: map[string]interface{}{
 					"a": &Condition{
 						Op:    BETWEEN,
-						Value: []interface{}{int64(4), int64(9)},
+						Value: []interface{}{int64(4), int64(8)},
 					},
 				},
 			}},
@@ -513,7 +513,7 @@ func TestPQLDeepEquality(t *testing.T) {
 				Args: map[string]interface{}{
 					"a": &Condition{
 						Op:    BETWEEN,
-						Value: []interface{}{int64(5), int64(9)},
+						Value: []interface{}{int64(5), int64(8)},
 					},
 				},
 			}},
@@ -525,7 +525,7 @@ func TestPQLDeepEquality(t *testing.T) {
 				Args: map[string]interface{}{
 					"a": &Condition{
 						Op:    BETWEEN,
-						Value: []interface{}{int64(4), int64(10)},
+						Value: []interface{}{int64(4), int64(9)},
 					},
 				},
 			}},
@@ -537,7 +537,7 @@ func TestPQLDeepEquality(t *testing.T) {
 				Args: map[string]interface{}{
 					"a": &Condition{
 						Op:    BETWEEN,
-						Value: []interface{}{int64(5), int64(10)},
+						Value: []interface{}{int64(5), int64(9)},
 					},
 				},
 			}},
@@ -640,7 +640,7 @@ func TestPQLDeepEquality(t *testing.T) {
 						Args: map[string]interface{}{
 							"a": &Condition{
 								Op:    BETWEEN,
-								Value: []interface{}{int64(5), int64(9)},
+								Value: []interface{}{int64(5), int64(8)},
 							},
 						},
 					},


### PR DESCRIPTION
## Overview

This PR addresses the issues described in #1819. I believe this was caused by the previous `BETWEEN` logic handling ranges as `[x, y)`, where the upper end was not inclusive. Now that the inclusivity is explicitly designated by `<=` and `>=` it's clear how to handle the range bounds.

Fixes #1819

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
