### PR TITLE
raise an error on Rows() query against a time field with noStandardView: true

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -1138,6 +1138,14 @@ func (e *executor) executeRowsShard(_ context.Context, index string, c *pql.Call
 	if f == nil {
 		return nil, ErrFieldNotFound
 	}
+
+	// Rows query does not currently support a `time` field that has
+	// `noStandardView: true`.
+	// TODO https://github.com/pilosa/pilosa/issues/1783
+	if f.Type() == FieldTypeTime && f.options.NoStandardView {
+		return nil, errors.New("Rows() query on time field with no standard view is not supported")
+	}
+
 	frag := e.Holder.fragment(index, fieldName, viewStandard, shard)
 	if frag == nil {
 		return make(RowIDs, 0), nil

--- a/executor.go
+++ b/executor.go
@@ -1143,7 +1143,7 @@ func (e *executor) executeRowsShard(_ context.Context, index string, c *pql.Call
 	// `noStandardView: true`.
 	// TODO https://github.com/pilosa/pilosa/issues/1783
 	if f.Type() == FieldTypeTime && f.options.NoStandardView {
-		return nil, errors.New("Rows() query on time field with no standard view is not supported")
+		return nil, errors.New("Rows() query on time field with no standard view is not currently supported")
 	}
 
 	frag := e.Holder.fragment(index, fieldName, viewStandard, shard)

--- a/executor_test.go
+++ b/executor_test.go
@@ -3059,6 +3059,17 @@ func TestExecutor_Execute_Rows(t *testing.T) {
 	}
 }
 
+func TestExecutor_Execute_RowsTime(t *testing.T) {
+	c := test.MustRunCluster(t, 1)
+	defer c.Close()
+	c.CreateField(t, "i", pilosa.IndexOptions{}, "t", pilosa.OptFieldTypeTime(pilosa.TimeQuantum("YMD"), true))
+
+	exp := "executing: Rows() query on time field with no standard view is not supported"
+	if _, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Rows(field=t)`}); err == nil || err.Error() != exp {
+		t.Fatalf("expected error: %s", exp)
+	}
+}
+
 func TestExecutor_Execute_Query_Error(t *testing.T) {
 	c := test.MustRunCluster(t, 1)
 	defer c.Close()

--- a/executor_test.go
+++ b/executor_test.go
@@ -3064,7 +3064,7 @@ func TestExecutor_Execute_RowsTime(t *testing.T) {
 	defer c.Close()
 	c.CreateField(t, "i", pilosa.IndexOptions{}, "t", pilosa.OptFieldTypeTime(pilosa.TimeQuantum("YMD"), true))
 
-	exp := "executing: Rows() query on time field with no standard view is not supported"
+	exp := "executing: Rows() query on time field with no standard view is not currently supported"
 	if _, err := c[0].API.Query(context.Background(), &pilosa.QueryRequest{Index: "i", Query: `Rows(field=t)`}); err == nil || err.Error() != exp {
 		t.Fatalf("expected error: %s", exp)
 	}


### PR DESCRIPTION
## Overview

This PR temporarily addresses the issue described in #1783 until an actual solution for that issue is available. 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
