### PR TITLE
support advertise address and listen on 0.0.0.0

### DIFF
--- a/ctl/server.go
+++ b/ctl/server.go
@@ -26,6 +26,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags := cmd.Flags()
 	flags.StringVarP(&srv.Config.DataDir, "data-dir", "d", srv.Config.DataDir, "Directory to store pilosa data files.")
 	flags.StringVarP(&srv.Config.Bind, "bind", "b", srv.Config.Bind, "Default URI on which pilosa should listen.")
+	flags.StringVar(&srv.Config.Advertise, "advertise", srv.Config.Advertise, "Address to advertise externally.")
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
 	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Enable verbose logging")
@@ -49,6 +50,9 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 
 	// Gossip
 	flags.StringVarP(&srv.Config.Gossip.Port, "gossip.port", "", srv.Config.Gossip.Port, "Port to which pilosa should bind for internal state sharing.")
+	flags.StringVarP(&srv.Config.Gossip.AdvertiseHost, "gossip.advertise-host", "", srv.Config.Gossip.AdvertiseHost, "Host on which memberlist should advertise.")
+	flags.StringVarP(&srv.Config.Gossip.AdvertisePort, "gossip.advertise-port", "", srv.Config.Gossip.AdvertisePort, "Port on which memberlist should advertise.")
+
 	flags.StringSliceVarP(&srv.Config.Gossip.Seeds, "gossip.seeds", "", srv.Config.Gossip.Seeds, "Host with which to seed the gossip membership.")
 	flags.StringVarP(&srv.Config.Gossip.Key, "gossip.key", "", srv.Config.Gossip.Key, "The path to file of the encryption key for gossip. The contents of the file should be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.")
 	flags.DurationVarP((*time.Duration)(&srv.Config.Gossip.StreamTimeout), "gossip.stream-timeout", "", (time.Duration)(srv.Config.Gossip.StreamTimeout), "Timeout for establishing a stream connection with a remote node for a full state sync.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -61,7 +61,7 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
 
 #### Bind
 
-* Description: host:port on which the Pilosa server will listen for requests. Host defaults to localhost and port to 10101. If `bind` is set to `0.0.0.0` then Pilosa will listen on all addresses.
+* Description: host:port on which the Pilosa server will listen for requests. Host defaults to localhost and port to 10101. If `bind` is set to `0.0.0.0` then Pilosa will listen on all available interfaces.
 * Flag: `--bind="localhost:10101"`
 * Env: `PILOSA_BIND="localhost:10101"`
 * Config:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,17 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
 
 ### All Options
 
+#### Advertise
+
+* Description: Address advertised by the server to other nodes in the cluster and to clients via the `/status` endpoint. Host defaults to the IP address represented by `bind` and port to 10101. If `bind` is set to `0.0.0.0` and `advertise` is not specified, then Pilosa will try to determine a reasonable, external IP address to use for `advertise`.
+* Flag: `--advertise="192.168.1.100:10101"`
+* Env: `PILOSA_BIND="192.168.1.100:10101"`
+* Config:
+
+    ```toml
+    advertise = 192.168.1.100:10101
+    ```
+
 #### Anti Entropy Interval
 
 * Description: Interval at which the cluster will run its anti-entropy routine which ensures that all replicas of each fragment are in sync.
@@ -50,7 +61,7 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
 
 #### Bind
 
-* Description: host:port on which the Pilosa server will listen for requests. Host defaults to localhost and port to 10101.
+* Description: host:port on which the Pilosa server will listen for requests. Host defaults to localhost and port to 10101. If `bind` is set to `0.0.0.0` then Pilosa will listen on all addresses.
 * Flag: `--bind="localhost:10101"`
 * Env: `PILOSA_BIND="localhost:10101"`
 * Config:
@@ -113,6 +124,30 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
 
     ```toml
     max-writes-per-request = 5000
+    ```
+
+#### Gossip Advertise Host
+
+* Description: Host on which memberlist should advertise. Defaults to `advertise` host.
+* Flag: `--gossip.advertise-host=192.168.1.100`
+* Env: `PILOSA_GOSSIP_ADVERTISE_HOST=192.168.1.100
+* Config:
+
+    ```toml
+    [gossip]
+      advertise-host = 192.168.1.100
+    ```
+
+#### Gossip Advertise Port
+
+* Description: Port on which memberlist should advertise. Defaults to `advertise` port.
+* Flag: `--gossip.advertise-port=15001`
+* Env: `PILOSA_GOSSIP_ADVERTISE_PORT=15001`
+* Config:
+
+    ```toml
+    [gossip]
+      advertise-port = 15001
     ```
 
 #### Gossip Port

--- a/http/client.go
+++ b/http/client.go
@@ -1015,7 +1015,7 @@ func (c *InternalClient) executeRequest(req *http.Request) (*http.Response, erro
 		if resp != nil {
 			resp.Body.Close()
 		}
-		return nil, errors.Wrap(err, "executing request")
+		return nil, errors.Wrap(err, "getting response")
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer resp.Body.Close()

--- a/pilosa.go
+++ b/pilosa.go
@@ -166,7 +166,6 @@ func stringSlicesAreEqual(a, b []string) bool {
 func AddressWithDefaults(addr string) (*URI, error) {
 	if addr == "" {
 		return defaultURI(), nil
-	} else {
-		return NewURIFromAddress(addr)
 	}
+	return NewURIFromAddress(addr)
 }

--- a/server/config_internal_test.go
+++ b/server/config_internal_test.go
@@ -1,0 +1,153 @@
+// Copyright 2017 Pilosa Corp.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"net"
+	"os"
+	"strings"
+	"testing"
+)
+
+type addrs struct{ bind, advertise string }
+
+func TestConfig_validateAddrs(t *testing.T) {
+
+	// Prepare some reference strings that will be checked in the
+	// test below.
+	outboundAddr := outboundIP().String()
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostAddr, err := lookupAddr(context.Background(), net.DefaultResolver, hostname)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(hostAddr, ":") {
+		hostAddr = "[" + hostAddr + "]"
+	}
+
+	tests := []struct {
+		expErr string
+		in     addrs
+		exp    addrs
+	}{
+		// Default values; addresses set empty.
+		{"",
+			addrs{"", ""},
+			addrs{":10101", ":10101"}},
+		{"",
+			addrs{":", ""},
+			addrs{":10101", ":10101"}},
+		{"",
+			addrs{"", ":"},
+			addrs{":10101", ":10101"}},
+		{"",
+			addrs{":", ":"},
+			addrs{":10101", ":10101"}},
+		// Listener :port.
+		{"",
+			addrs{":1234", ""},
+			addrs{":1234", ":1234"}},
+		// Listener with host:port.
+		{"",
+			addrs{hostAddr + ":10101", ""},
+			addrs{hostAddr + ":10101", hostAddr + ":10101"}},
+		// Listener with host:.
+		{"",
+			addrs{hostAddr + ":", ""},
+			addrs{hostAddr + ":10101", hostAddr + ":10101"}},
+		// Listener with scheme:.
+		{"",
+			addrs{"http://" + hostAddr + ":", ""},
+			addrs{"http://" + hostAddr + ":10101", "http://" + hostAddr + ":10101"}},
+		// Listener with localhost:port.
+		{"",
+			addrs{"localhost:1234", ""},
+			addrs{"localhost:1234", "localhost:1234"}},
+		// Listener with localhost:.
+		{"",
+			addrs{"localhost:", ""},
+			addrs{"localhost:10101", "localhost:10101"}},
+		// Listener and advertise addresses.
+		{"",
+			addrs{hostAddr + ":1234", hostAddr + ":"},
+			addrs{hostAddr + ":1234", hostAddr + ":1234"}},
+		// Explicit port number in advertise addr.
+		{"",
+			addrs{hostAddr + ":1234", hostAddr + ":7890"},
+			addrs{hostAddr + ":1234", hostAddr + ":7890"}},
+		// Use a non-numeric port number.
+		{"",
+			addrs{":postgresql", ""},
+			addrs{":5432", ":5432"}},
+		// Advertise port 0 means reuse listen port.
+		{"",
+			addrs{":1234", ":0"},
+			addrs{":1234", ":1234"}},
+		// Listen on all interfaces. Determine advertise address.
+		{"",
+			addrs{"0.0.0.0:1234", ""},
+			addrs{"0.0.0.0:1234", outboundAddr + ":1234"}},
+		// Expected errors.
+
+		// Missing port number.
+		{"missing port in address",
+			addrs{"localhost", ""},
+			addrs{}},
+		{"missing port in address",
+			addrs{":1234", "localhost"},
+			addrs{}},
+		// Invalid port number.
+		{"invalid port",
+			addrs{"localhost:-1234", ""},
+			addrs{}},
+		{"validating advertise address",
+			addrs{"localhost:foo", ""},
+			addrs{}},
+		{"no such host",
+			addrs{"333.333.333.333:1234", ""},
+			addrs{}},
+	}
+
+	for i, test := range tests {
+		c := NewConfig()
+
+		c.Bind = test.in.bind
+		c.Advertise = test.in.advertise
+
+		err := c.validateAddrs(context.Background())
+
+		if err != nil && test.expErr == "" {
+			t.Fatal(err)
+		} else if err == nil && test.expErr != "" {
+			t.Fatalf("test %d: expected error string to contain %s, but got no error", i, test.expErr)
+		} else if err != nil && test.expErr != "" {
+			if strings.Contains(err.Error(), test.expErr) {
+				continue
+			} else {
+				t.Fatalf("test %d: expected error string to contain %s, but got %s", i, test.expErr, err.Error())
+			}
+		}
+
+		if c.Bind != test.exp.bind {
+			t.Fatalf("test %d: bind address: expected %s, but got %s", i, test.exp.bind, c.Bind)
+		} else if c.Advertise != test.exp.advertise {
+			t.Fatalf("test %d: advertise address: expected %s, but got %s", i, test.exp.advertise, c.Advertise)
+		}
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -468,7 +468,6 @@ func TestClusteringNodesReplica1(t *testing.T) {
 	// Create new main with the same config.
 	config := cluster[2].Command.Config
 	config.Translation.MapSize = 100000
-	// config.Bind = cluster[2].API.Node().URI.HostPort()
 
 	// this isn't necessary, but makes the test run way faster
 	config.Gossip.Port = strconv.Itoa(int(cluster[2].Command.GossipTransport().URI.Port))


### PR DESCRIPTION
## Overview

This PR adds support for advertise address by using a new config
option `advertise-addr`, or by defaulting its value to that
specified in `listen-addr`. Also replaces `bind` with `listen-addr`.

Also adds support for listening on 0.0.0.0 by trying to determine
the preferred outbound IP to use for the advertise address.

Fixes #1735

TODO:
- [x] Update the docs if the changes here are agreed upon

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
