### PR TITLE
prevent omitting zero ids on columnattrs

### DIFF
--- a/pilosa.go
+++ b/pilosa.go
@@ -15,6 +15,7 @@
 package pilosa
 
 import (
+	"encoding/json"
 	"errors"
 	"regexp"
 )
@@ -121,9 +122,28 @@ var nameRegexp = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,63}$`)
 // ColumnAttrSet represents a set of attributes for a vertical column in an index.
 // Can have a set of attributes attached to it.
 type ColumnAttrSet struct {
-	ID    uint64                 `json:"id,omitempty"`
+	ID    uint64                 `json:"id"`
 	Key   string                 `json:"key,omitempty"`
 	Attrs map[string]interface{} `json:"attrs,omitempty"`
+}
+
+func (cas ColumnAttrSet) MarshalJSON() ([]byte, error) {
+	if cas.Key != "" {
+		return json.Marshal(struct {
+			Key   string                 `json:"key,omitempty"`
+			Attrs map[string]interface{} `json:"attrs,omitempty"`
+		}{
+			Key:   cas.Key,
+			Attrs: cas.Attrs,
+		})
+	}
+	return json.Marshal(struct {
+		ID    uint64                 `json:"id"`
+		Attrs map[string]interface{} `json:"attrs,omitempty"`
+	}{
+		ID:    cas.ID,
+		Attrs: cas.Attrs,
+	})
 }
 
 // TimeFormat is the go-style time format used to parse string dates.


### PR DESCRIPTION
## Overview

This PR fixes a bug that was introduced in #1677 with an `omitempty` json tag which would omit a valid zero value.

Fixes #1682 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
