### PR TITLE
ensure ClearRow() arguments get translated

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -1693,6 +1693,9 @@ func (e *executor) executeClearRow(ctx context.Context, index string, c *pql.Cal
 	}
 
 	result, err := e.mapReduce(ctx, index, shards, c, opt, mapFn, reduceFn)
+	if err != nil {
+		return false, errors.Wrap(err, "mapreducing clearrow")
+	}
 	return result.(bool), err
 }
 
@@ -2368,7 +2371,7 @@ func (e *executor) translateCalls(ctx context.Context, index string, idx *Index,
 func (e *executor) translateCall(index string, idx *Index, c *pql.Call) error {
 	var colKey, rowKey, fieldName string
 	switch c.Name {
-	case "Set", "Clear", "Row", "Range", "SetColumnAttrs":
+	case "Set", "Clear", "Row", "Range", "SetColumnAttrs", "ClearRow":
 		// Positional args in new PQL syntax require special handling here.
 		colKey = "_" + columnLabel
 		fieldName, _ = c.FieldArg()

--- a/executor_test.go
+++ b/executor_test.go
@@ -2887,6 +2887,19 @@ func TestExecutor_Execute_ClearRow(t *testing.T) {
 			t.Fatalf("topn wrong results: %v", res.Results)
 		}
 	})
+
+	// Ensure that ClearRow returns false when the row to clear needs translation.
+	t.Run("WithKeys", func(t *testing.T) {
+		wq := ""
+		rq := []string{
+			`ClearRow(f="bar")`,
+		}
+
+		responses := runCallTest(t, wq, rq, &pilosa.IndexOptions{}, pilosa.OptFieldKeys())
+		if res := responses[0].Results[0].(bool); res {
+			t.Fatalf("unexpected result: %+v", res)
+		}
+	})
 }
 
 // Ensure a row can be set.


### PR DESCRIPTION
## Overview

This PR ensures that `ClearRow()` queries pass through the call translator.

Fixes #1847 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
