### PR TITLE
add from/to range arguments to Rows() call

### DIFF
--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -836,8 +836,7 @@ result of the previous request will start from the next available row.
 
 If the field is of type `time`, the `from` and `to` arguments can be provided
 to restrict the result to a specific time span. If `from` and `to` are
-not provided, the field must be configured with `noStandardView` set to
-`false`.
+not provided, the full range of existing data will be queried.
 
 **Result Type:** Object with `"rows" or "keys" and an array of integers or strings respectively.`
 

--- a/docs/query-language.md
+++ b/docs/query-language.md
@@ -812,10 +812,12 @@ Options(Row(f1=10), shards=[0, 2])
 {"attrs":{},"columns":[100, 2097152]}
 ```
 
+#### Rows
+
 **Spec:**
 
 ```
-Rows(<FIELD>, previous=<UINT|STRING>, limit=<UINT>, column=<UINT|STRING>)
+Rows(<FIELD>, previous=<UINT|STRING>, limit=<UINT>, column=<UINT|STRING>, from=<TIMESTAMP>, to=<TIMESTAMP>)
 ```
 
 **Description:**
@@ -832,6 +834,10 @@ is given, the number of rowIDs returned will be less than or equal to
 result sets. Results are always ordered, so setting `previous` as the last
 result of the previous request will start from the next available row.
 
+If the field is of type `time`, the `from` and `to` arguments can be provided
+to restrict the result to a specific time span. If `from` and `to` are
+not provided, the field must be configured with `noStandardView` set to
+`false`.
 
 **Result Type:** Object with `"rows" or "keys" and an array of integers or strings respectively.`
 

--- a/executor.go
+++ b/executor.go
@@ -1198,28 +1198,28 @@ func (e *executor) executeRowsShard(_ context.Context, index string, fieldName s
 
 			// If min/max are empty, there were no time views.
 			if min == "" || max == "" {
-				views = []string{}
-			} else {
-				// Convert min/max from string to time.Time.
-				minTime, err := timeOfView(min, false)
-				if err != nil {
-					return rowIDs, errors.Wrapf(err, "getting min time from view: %s", min)
-				}
-				if fromTime.IsZero() || fromTime.Before(minTime) {
-					fromTime = minTime
-				}
-
-				maxTime, err := timeOfView(max, true)
-				if err != nil {
-					return rowIDs, errors.Wrapf(err, "getting max time from view: %s", max)
-				}
-				if toTime.IsZero() || toTime.After(maxTime) {
-					toTime = maxTime
-				}
-
-				// Determine the views based on the specified time range.
-				views = viewsByTimeRange(viewStandard, fromTime, toTime, q)
+				return rowIDs, nil
 			}
+
+			// Convert min/max from string to time.Time.
+			minTime, err := timeOfView(min, false)
+			if err != nil {
+				return rowIDs, errors.Wrapf(err, "getting min time from view: %s", min)
+			}
+			if fromTime.IsZero() || fromTime.Before(minTime) {
+				fromTime = minTime
+			}
+
+			maxTime, err := timeOfView(max, true)
+			if err != nil {
+				return rowIDs, errors.Wrapf(err, "getting max time from view: %s", max)
+			}
+			if toTime.IsZero() || toTime.After(maxTime) {
+				toTime = maxTime
+			}
+
+			// Determine the views based on the specified time range.
+			views = viewsByTimeRange(viewStandard, fromTime, toTime, q)
 		}
 	}
 

--- a/executor.go
+++ b/executor.go
@@ -1165,31 +1165,17 @@ func (e *executor) executeRowsShard(_ context.Context, index string, fieldName s
 
 		// Parse "from" time, if set.
 		var fromTime time.Time
-		if _, ok := c.Args["from"]; ok {
-			switch v := c.Args["from"].(type) {
-			case string:
-				if fromTime, err = time.Parse(TimeFormat, v); err != nil {
-					return nil, errors.New("cannot parse Row() 'from' time")
-				}
-			case int64:
-				fromTime = time.Unix(v, 0).UTC()
-			default:
-				return nil, errors.New("Row() 'from' arg must be a timestamp")
+		if v, ok := c.Args["from"]; ok {
+			if fromTime, err = parseTime(v); err != nil {
+				return nil, errors.Wrap(err, "determining from time")
 			}
 		}
 
 		// Parse "to" time, if set.
 		var toTime time.Time
-		if _, ok := c.Args["to"]; ok {
-			switch v := c.Args["to"].(type) {
-			case string:
-				if toTime, err = time.Parse(TimeFormat, v); err != nil {
-					return nil, errors.New("cannot parse Row() 'to' time")
-				}
-			case int64:
-				toTime = time.Unix(v, 0).UTC()
-			default:
-				return nil, errors.New("Row() 'to' arg must be a timestamp")
+		if v, ok := c.Args["to"]; ok {
+			if toTime, err = parseTime(v); err != nil {
+				return nil, errors.Wrap(err, "determining to time")
 			}
 		}
 
@@ -1284,31 +1270,17 @@ func (e *executor) executeRowShard(ctx context.Context, index string, c *pql.Cal
 
 	// Parse "from" time, if set.
 	var fromTime time.Time
-	if _, ok := c.Args["from"]; ok {
-		switch v := c.Args["from"].(type) {
-		case string:
-			if fromTime, err = time.Parse(TimeFormat, v); err != nil {
-				return nil, errors.New("cannot parse Row() 'from' time")
-			}
-		case int64:
-			fromTime = time.Unix(v, 0).UTC()
-		default:
-			return nil, errors.New("Row() 'from' arg must be a timestamp")
+	if v, ok := c.Args["from"]; ok {
+		if fromTime, err = parseTime(v); err != nil {
+			return nil, errors.Wrap(err, "determining from time")
 		}
 	}
 
 	// Parse "to" time, if set.
 	var toTime time.Time
-	if _, ok := c.Args["to"]; ok {
-		switch v := c.Args["to"].(type) {
-		case string:
-			if toTime, err = time.Parse(TimeFormat, v); err != nil {
-				return nil, errors.New("cannot parse Row() 'to' time")
-			}
-		case int64:
-			toTime = time.Unix(v, 0).UTC()
-		default:
-			return nil, errors.New("Row() 'to' arg must be a timestamp")
+	if v, ok := c.Args["to"]; ok {
+		if toTime, err = parseTime(v); err != nil {
+			return nil, errors.Wrap(err, "determining to time")
 		}
 	}
 

--- a/time.go
+++ b/time.go
@@ -214,3 +214,19 @@ func nextDayGTE(t time.Time, end time.Time) bool {
 	}
 	return end.After(next)
 }
+
+func parseTime(t interface{}) (time.Time, error) {
+	var err error
+	var calcTime time.Time
+	switch v := t.(type) {
+	case string:
+		if calcTime, err = time.Parse(TimeFormat, v); err != nil {
+			return time.Time{}, errors.New("cannot parse string time")
+		}
+	case int64:
+		calcTime = time.Unix(v, 0).UTC()
+	default:
+		return time.Time{}, errors.New("arg must be a timestamp")
+	}
+	return calcTime, nil
+}

--- a/time.go
+++ b/time.go
@@ -17,6 +17,7 @@ package pilosa
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -215,6 +216,7 @@ func nextDayGTE(t time.Time, end time.Time) bool {
 	return end.After(next)
 }
 
+// parseTime parses a string or int64 into a time.Time value.
 func parseTime(t interface{}) (time.Time, error) {
 	var err error
 	var calcTime time.Time
@@ -229,4 +231,104 @@ func parseTime(t interface{}) (time.Time, error) {
 		return time.Time{}, errors.New("arg must be a timestamp")
 	}
 	return calcTime, nil
+}
+
+// minMaxViews returns the min and max view from a list of views
+// with a time quantum taken into consideration. It assumes that
+// all views represent the same base view name (the logic depends
+// on the views sorting correctly in alphabetical order).
+func minMaxViews(views []string, q TimeQuantum) (min string, max string) {
+	// Sort the list of views.
+	sort.Strings(views)
+
+	// Determine the least significant quantum and set that as the
+	// number of string characters to compare against.
+	var chars int
+	if q.HasYear() {
+		chars = 4
+	} else if q.HasMonth() {
+		chars = 6
+	} else if q.HasDay() {
+		chars = 8
+	} else if q.HasHour() {
+		chars = 10
+	}
+
+	// min: get the first view with the matching number of time chars.
+	for _, v := range views {
+		if len(viewTimePart(v)) == chars {
+			min = v
+			break
+		}
+	}
+
+	// max: get the first view (from the end) with the matching number of time chars.
+	for i := len(views) - 1; i >= 0; i-- {
+		if len(viewTimePart(views[i])) == chars {
+			max = views[i]
+			break
+		}
+	}
+
+	return min, max
+}
+
+// timeOfView returns a valid time.Time based on the view string.
+// For upper bound use, the result can be adjusted by one by setting
+// the `adj` argument to `true`.
+func timeOfView(v string, adj bool) (time.Time, error) {
+	if v == "" {
+		return time.Time{}, nil
+	}
+
+	layout := "2006010203"
+	timePart := viewTimePart(v)
+
+	switch len(timePart) {
+	case 4: // year
+		t, err := time.Parse(layout[:4], timePart)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if adj {
+			t = t.AddDate(1, 0, 0)
+		}
+		return t, nil
+	case 6: // month
+		t, err := time.Parse(layout[:6], timePart)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if adj {
+			t = addMonth(t)
+		}
+		return t, nil
+	case 8: // day
+		t, err := time.Parse(layout[:8], timePart)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if adj {
+			t = t.AddDate(0, 0, 1)
+		}
+		return t, nil
+	case 10: // hour
+		t, err := time.Parse(layout[:10], timePart)
+		if err != nil {
+			return time.Time{}, err
+		}
+		if adj {
+			t = t.Add(time.Hour)
+		}
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid time format on view: %s", v)
+}
+
+// viewTimePart returns the time portion of a string view name.
+// e.g. the view "string_201901" would return "201901".
+func viewTimePart(v string) string {
+	parts := strings.Split(v, "_")
+	return parts[len(parts)-1]
 }


### PR DESCRIPTION
## Overview

This PR adds `from` and `to` arguments to the `Rows()` call.
If the field specified is type `time`, then the `from` and `to`
can be used to restrict the results.

Fixes #1783

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
