### PR TITLE
add server stats to /info endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -1177,8 +1177,18 @@ func (api *API) Version() string {
 
 // Info returns information about this server instance
 func (api *API) Info() serverInfo {
+	si := api.server.systemInfo
+	// we don't report errors on failures to get this information
+	physicalCores, logicalCores, _ := si.CPUCores()
+	mhz, _ := si.CPUMHz()
+	mem, _ := si.MemTotal()
 	return serverInfo{
-		ShardWidth: ShardWidth,
+		ShardWidth:       ShardWidth,
+		CPUPhysicalCores: physicalCores,
+		CPULogicalCores:  logicalCores,
+		CPUMHz:           mhz,
+		CPUType:          si.CPUModel(),
+		Memory:           mem,
 	}
 }
 
@@ -1213,7 +1223,12 @@ func (api *API) TranslateKeys(body io.Reader) ([]byte, error) {
 }
 
 type serverInfo struct {
-	ShardWidth uint64 `json:"shardWidth"`
+	ShardWidth       uint64 `json:"shardWidth"`
+	Memory           uint64 `json:"memory"`
+	CPUType          string `json:"cpuType"`
+	CPUPhysicalCores int    `json:"cpuPhysicalCores"`
+	CPULogicalCores  int    `json:"cpuLogicalCores"`
+	CPUMHz           int    `json:"cpuMHz"`
 }
 
 type apiMethod int

--- a/diagnostics.go
+++ b/diagnostics.go
@@ -271,6 +271,9 @@ type SystemInfo interface {
 	MemFree() (uint64, error)
 	MemTotal() (uint64, error)
 	MemUsed() (uint64, error)
+	CPUModel() string
+	CPUCores() (physical int, logical int, err error)
+	CPUMHz() (int, error)
 	CPUArch() string
 }
 
@@ -326,4 +329,19 @@ func (n *nopSystemInfo) MemUsed() (uint64, error) {
 // CPUArch returns the CPU architecture, such as amd64
 func (n *nopSystemInfo) CPUArch() string {
 	return ""
+}
+
+// CPUModel returns the CPU model string
+func (n *nopSystemInfo) CPUModel() string {
+	return "unknown"
+}
+
+// CPUMHz returns the CPU clock speed
+func (n *nopSystemInfo) CPUMHz() (int, error) {
+	return 0, nil
+}
+
+// CPUCores returns the number of CPU cores (physical or logical)
+func (n *nopSystemInfo) CPUCores() (physical, logical int, err error) {
+	return 0, 0, nil
 }


### PR DESCRIPTION
report the approximate hardware specs (CPU speed, cores, memory)
of the server in the /info endpoint. This may be useful when
benchmarking.

Fixes #651

(note: docs haven't been changed, and maybe they should, but right now we don't actually document /info at all, apparently?)

## Pull request checklist

- [X] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [X] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [X] I have resolved any merge conflicts.
- [X] I have included tests that cover my changes.
- [X] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
