### PR TITLE
set block profile rate and mutex profile fraction at startup

### DIFF
--- a/cmd/pilosa/main.go
+++ b/cmd/pilosa/main.go
@@ -20,11 +20,15 @@ package main
 import (
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/pilosa/pilosa/cmd"
 )
 
 func main() {
+	runtime.SetBlockProfileRate(1000)
+	runtime.SetMutexProfileFraction(100)
+
 	rootCmd := cmd.NewRootCommand(os.Stdin, os.Stdout, os.Stderr)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
it's annoying not to be able to obtain mutex or blocking profiles when these
haven't been set.

## Overview

This is more meant to spark a discussion. I can't easily tell if there is a performance penalty (when not profiling) for setting these up front. Are these reasonable values to set them to? Why do CPU profiles work automatically, but these don't?


## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
