### PR TITLE
smallWrite path for import-roaring

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -184,6 +184,7 @@ type cluster struct { // nolint: maligned
 	ReplicaN int
 
 	// Threshold for logging long-running queries
+	// TODO(2.0) move this out of cluster. (why is it here??)
 	longQueryTime time.Duration
 
 	// Maximum number of Set() or Clear() commands per request.

--- a/fragment.go
+++ b/fragment.go
@@ -1763,11 +1763,8 @@ func (f *fragment) importRoaring(data []byte, clear bool) error {
 
 	if clear {
 		bm = f.storage.Difference(bm)
-	} else if f.storage.Containers.Size() >= bm.Containers.Size() {
-		f.storage.UnionInPlace(bm)
-		bm = f.storage
-	} else {
-		bm.UnionInPlace(f.storage)
+	} else if f.storage.Any() {
+		bm = f.storage.Union(bm)
 	}
 
 	for rowID := range rowSet {

--- a/fragment.go
+++ b/fragment.go
@@ -1750,15 +1750,11 @@ func (f *fragment) importRoaring(data []byte, clear bool) error {
 
 	if clear {
 		bm = f.storage.Difference(bm)
+	} else if f.storage.Containers.Size() >= bm.Containers.Size() {
+		f.storage.UnionInPlace(bm)
+		bm = f.storage
 	} else {
-		if cnt := f.storage.Count(); cnt > 0 {
-			if incomingCnt > int(cnt) {
-				bm.UnionInPlace(f.storage)
-			} else {
-				f.storage.UnionInPlace(bm)
-				bm = f.storage
-			}
-		}
+		bm.UnionInPlace(f.storage)
 	}
 
 	for _, rowID := range rowSet {

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -766,6 +766,40 @@ func BenchmarkFragment_RepeatedSmallImports(b *testing.B) {
 	}
 }
 
+func BenchmarkFragment_RepeatedSmallImportsRoaring(b *testing.B) {
+	for _, numUpdates := range []int{100} {
+		for _, bitsPerUpdate := range []uint64{100, 1000} {
+			for _, numRows := range []uint64{1000, 100000, 1000000} {
+				for _, opN := range []int{1, 5000, 50000} {
+					b.Run(fmt.Sprintf("Rows%dUpdates%dBits%dOpN%d", numRows, numUpdates, bitsPerUpdate, opN), func(b *testing.B) {
+						for a := 0; a < b.N; a++ {
+							b.StopTimer()
+							// build the update data set all at once - this will get applied
+							// to a fragment in numUpdates batches
+							f := mustOpenFragment("i", "f", viewStandard, 0, "")
+							f.MaxOpN = opN
+							defer f.Clean(b)
+							err := f.importRoaring(getZipfRowsSliceRoaring(numRows, 1), false)
+							if err != nil {
+								b.Fatalf("importing base data for benchmark: %v", err)
+							}
+							for i := 0; i < numUpdates; i++ {
+								data := getUpdataRoaring(numRows, bitsPerUpdate, int64(i))
+								b.StartTimer()
+								err := f.importRoaring(data, false)
+								b.StopTimer()
+								if err != nil {
+									b.Fatalf("doing small roaring import: %v", err)
+								}
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
+
 func BenchmarkFragment_RepeatedSmallValueImports(b *testing.B) {
 	initialCols := make([]uint64, 0, ShardWidth)
 	initialVals := make([]uint64, 0, ShardWidth)

--- a/server/config.go
+++ b/server/config.go
@@ -75,10 +75,11 @@ type Config struct {
 
 	Cluster struct {
 		// Disabled controls whether clustering functionality is enabled.
-		Disabled      bool          `toml:"disabled"`
-		Coordinator   bool          `toml:"coordinator"`
-		ReplicaN      int           `toml:"replicas"`
-		Hosts         []string      `toml:"hosts"`
+		Disabled    bool     `toml:"disabled"`
+		Coordinator bool     `toml:"coordinator"`
+		ReplicaN    int      `toml:"replicas"`
+		Hosts       []string `toml:"hosts"`
+		// TODO(2.0) move this out of cluster. (why is it here??)
 		LongQueryTime toml.Duration `toml:"long-query-time"`
 	} `toml:"cluster"`
 


### PR DESCRIPTION
Edit: didn't end up doing UnionInPlace because several benchmarks were absolutely mangled by the issue mentioned in the next paragraph. What we have done in this PR is added a "smallWrite" path to importRoaring that uses importPositions when the number of incoming bits is small. This either has no significant effect, or improves performance pretty much across the board. It's possible that for extremely large numbers of rows, it would slow things down a bit because we use a map instead of a slice to track the set of rows seen. This could be fixed quite trivially, but in a very ugly way by supporting either a slice or a map in importPositions, but I have in mind a better fix down the road where I think we can avoid tracking the rowSet at all.

Previous:
get the count of the existing fragment and compare it to the incoming bits to
decide which should be unioned into the other. This should generally result in
far fewer allocations, though there is much work that needs to be done within
UnionInPlace (e.g. #1875)  to further improve things.

unrelatedly, I added a TODO to change the long-query-time option to move it out
of cluster. It should probably be happening at the API level so that different
handlers can reuse it, but if we're going to do that we'll want to make sure
that any potentially time intensive operations are pulled into api from
handler (e.g. protobuf decoding)

Benchcmp:
```
Mon 03/11 18:19:42:~/go/src/github.com/pilosa/pilosa()$ benchcmp 663c725779c65.txt a28141c4664.txt
benchmark                                                     old ns/op     new ns/op     delta
BenchmarkImportRoaring/Rows2Cache_ranked-8                    6344270       6262703       -1.29%
BenchmarkImportRoaring/Rows50Cache_ranked-8                   16988200      16929127      -0.35%
BenchmarkImportRoaring/Rows1000Cache_ranked-8                 26137441      26216449      +0.30%
BenchmarkImportRoaring/Rows100000Cache_ranked-8               96534680      103460138     +7.17%
BenchmarkImportRoaringUpdate/ranked2Rows20Cols-8              6928368       514503        -92.57%
BenchmarkImportRoaringUpdate/ranked2Rows1000Cols-8            7238295       566553        -92.17%
BenchmarkImportRoaringUpdate/ranked2Rows50000Cols-8           7087256       6873004       -3.02%
BenchmarkImportRoaringUpdate/ranked2Rows500000Cols-8          6737562       6527448       -3.12%
BenchmarkImportRoaringUpdate/ranked50Rows20Cols-8             20258439      700692        -96.54%
BenchmarkImportRoaringUpdate/ranked50Rows1000Cols-8           27483349      3131334       -88.61%
BenchmarkImportRoaringUpdate/ranked50Rows50000Cols-8          32591354      32193962      -1.22%
BenchmarkImportRoaringUpdate/ranked50Rows500000Cols-8         45914095      46222001      +0.67%
BenchmarkImportRoaringUpdate/ranked1000Rows20Cols-8           31625519      3176362       -89.96%
BenchmarkImportRoaringUpdate/ranked1000Rows1000Cols-8         33162935      3733518       -88.74%
BenchmarkImportRoaringUpdate/ranked1000Rows50000Cols-8        45109890      51492395      +14.15%
BenchmarkImportRoaringUpdate/ranked1000Rows500000Cols-8       62601170      64087241      +2.37%
BenchmarkImportRoaringUpdate/ranked100000Rows20Cols-8         92190813      4407214       -95.22%
BenchmarkImportRoaringUpdate/ranked100000Rows1000Cols-8       93011425      5661427       -93.91%
BenchmarkImportRoaringUpdate/ranked100000Rows50000Cols-8      109358220     109932104     +0.52%
BenchmarkImportRoaringUpdate/ranked100000Rows500000Cols-8     157205855     164322245     +4.53%
BenchmarkImportRoaringIntoLargeFragment-8                     472746482     494926076     +4.69%

benchmark                                                     old allocs     new allocs     delta
BenchmarkImportRoaring/Rows2Cache_ranked-8                    129            130            +0.78%
BenchmarkImportRoaring/Rows50Cache_ranked-8                   1741           1745           +0.23%
BenchmarkImportRoaring/Rows1000Cache_ranked-8                 33239          33293          +0.16%
BenchmarkImportRoaring/Rows100000Cache_ranked-8               255272         256307         +0.41%
BenchmarkImportRoaringUpdate/ranked2Rows20Cols-8              189            58             -69.31%
BenchmarkImportRoaringUpdate/ranked2Rows1000Cols-8            208            105            -49.52%
BenchmarkImportRoaringUpdate/ranked2Rows50000Cols-8           208            209            +0.48%
BenchmarkImportRoaringUpdate/ranked2Rows500000Cols-8          208            209            +0.48%
BenchmarkImportRoaringUpdate/ranked50Rows20Cols-8             2724           130            -95.23%
BenchmarkImportRoaringUpdate/ranked50Rows1000Cols-8           8399           1814           -78.40%
BenchmarkImportRoaringUpdate/ranked50Rows50000Cols-8          10877          10881          +0.04%
BenchmarkImportRoaringUpdate/ranked50Rows500000Cols-8         11844          11848          +0.03%
BenchmarkImportRoaringUpdate/ranked1000Rows20Cols-8           48335          133            -99.72%
BenchmarkImportRoaringUpdate/ranked1000Rows1000Cols-8         54428          3470           -93.62%
BenchmarkImportRoaringUpdate/ranked1000Rows50000Cols-8        100418         100475         +0.06%
BenchmarkImportRoaringUpdate/ranked1000Rows500000Cols-8       125714         125770         +0.04%
BenchmarkImportRoaringUpdate/ranked100000Rows20Cols-8         332796         136            -99.96%
BenchmarkImportRoaringUpdate/ranked100000Rows1000Cols-8       338501         3906           -98.85%
BenchmarkImportRoaringUpdate/ranked100000Rows50000Cols-8      402826         402962         +0.03%
BenchmarkImportRoaringUpdate/ranked100000Rows500000Cols-8     574399         574941         +0.09%
BenchmarkImportRoaringIntoLargeFragment-8                     1566980        1567085        +0.01%

benchmark                                                     old bytes     new bytes     delta
BenchmarkImportRoaring/Rows2Cache_ranked-8                    19271         19341         +0.36%
BenchmarkImportRoaring/Rows50Cache_ranked-8                   240401        240855        +0.19%
BenchmarkImportRoaring/Rows1000Cache_ranked-8                 5134820       5165902       +0.61%
BenchmarkImportRoaring/Rows100000Cache_ranked-8               40162890      40270957      +0.27%
BenchmarkImportRoaringUpdate/ranked2Rows20Cols-8              283654        76719         -72.95%
BenchmarkImportRoaringUpdate/ranked2Rows1000Cols-8            285500        286933        +0.50%
BenchmarkImportRoaringUpdate/ranked2Rows50000Cols-8           285526        285604        +0.03%
BenchmarkImportRoaringUpdate/ranked2Rows500000Cols-8          285446        285540        +0.03%
BenchmarkImportRoaringUpdate/ranked50Rows20Cols-8             2606533       141790        -94.56%
BenchmarkImportRoaringUpdate/ranked50Rows1000Cols-8           5884370       3981131       -32.34%
BenchmarkImportRoaringUpdate/ranked50Rows50000Cols-8          7278805       7279209       +0.01%
BenchmarkImportRoaringUpdate/ranked50Rows500000Cols-8         11476541      11476924      +0.00%
BenchmarkImportRoaringUpdate/ranked1000Rows20Cols-8           7286765       50339         -99.31%
BenchmarkImportRoaringUpdate/ranked1000Rows1000Cols-8         8230224       1702522       -79.31%
BenchmarkImportRoaringUpdate/ranked1000Rows50000Cols-8        12536118      12567731      +0.25%
BenchmarkImportRoaringUpdate/ranked1000Rows500000Cols-8       16276747      16308666      +0.20%
BenchmarkImportRoaringUpdate/ranked100000Rows20Cols-8         37303951      546241        -98.54%
BenchmarkImportRoaringUpdate/ranked100000Rows1000Cols-8       38090933      2064542       -94.58%
BenchmarkImportRoaringUpdate/ranked100000Rows50000Cols-8      44171673      44151084      -0.05%
BenchmarkImportRoaringUpdate/ranked100000Rows500000Cols-8     64614368      64531923      -0.13%
BenchmarkImportRoaringIntoLargeFragment-8                     202424117     202442088     +0.01%
```


## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
