### PR TITLE
Mmap fail

### DIFF
--- a/ctl/server.go
+++ b/ctl/server.go
@@ -30,6 +30,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.IntVarP(&srv.Config.MaxWritesPerRequest, "max-writes-per-request", "", srv.Config.MaxWritesPerRequest, "Number of write commands per request.")
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
 	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Enable verbose logging")
+	flags.Uint64Var(&srv.Config.MaxMapCount, "max-map-count", srv.Config.MaxMapCount, "Limits the maximum number of active mmaps. Pilosa will fall back to reading files once this is exhausted. Set below your system's vm.max_map_count.")
 
 	// TLS
 	SetTLSConfig(flags, &srv.Config.TLS.CertificatePath, &srv.Config.TLS.CertificateKeyPath, &srv.Config.TLS.SkipVerify)

--- a/fragment.go
+++ b/fragment.go
@@ -215,7 +215,7 @@ func (f *fragment) openStorage() error {
 			return fmt.Errorf("init storage file: %s", err)
 		}
 		bi.Flush()
-		fi, err = f.file.Stat()
+		_, err = f.file.Stat()
 		if err != nil {
 			return errors.Wrap(err, "statting file after")
 		}

--- a/server/config.go
+++ b/server/config.go
@@ -70,6 +70,11 @@ type Config struct {
 		AllowedOrigins []string `toml:"allowed-origins"`
 	} `toml:"handler"`
 
+	// MaxMapCount puts an in-process limit on the number of mmaps. After this
+	// is exhausted, Pilosa will fall back to reading the file into memory
+	// normally.
+	MaxMapCount uint64 `toml:"max-map-count"`
+
 	// TLS
 	TLS TLSConfig `toml:"tls"`
 
@@ -124,6 +129,7 @@ func NewConfig() *Config {
 		DataDir:             "~/.pilosa",
 		Bind:                ":10101",
 		MaxWritesPerRequest: 5000,
+		MaxMapCount:         60000,
 		TLS:                 TLSConfig{},
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -179,7 +179,7 @@ func (m *Command) Wait() error {
 
 // SetupServer uses the cluster configuration to set up this server.
 func (m *Command) SetupServer() error {
-	syswrap.MaxMapCount = m.Config.MaxMapCount
+	syswrap.SetMaxMapCount(m.Config.MaxMapCount)
 
 	err := m.setupLogger()
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pilosa/pilosa/logger"
 	"github.com/pilosa/pilosa/stats"
 	"github.com/pilosa/pilosa/statsd"
+	"github.com/pilosa/pilosa/syswrap"
 	"github.com/pkg/errors"
 )
 
@@ -178,6 +179,8 @@ func (m *Command) Wait() error {
 
 // SetupServer uses the cluster configuration to set up this server.
 func (m *Command) SetupServer() error {
+	syswrap.MaxMapCount = m.Config.MaxMapCount
+
 	err := m.setupLogger()
 	if err != nil {
 		return errors.Wrap(err, "setting up logger")

--- a/syswrap/mmap.go
+++ b/syswrap/mmap.go
@@ -1,0 +1,44 @@
+// Package syswrap wraps syscalls (just mmap right now) in order to impose a
+// global in-process limit on the maximum number of active mmaps.
+package syswrap
+
+import (
+	"sync/atomic"
+	"syscall"
+
+	"github.com/pkg/errors"
+)
+
+var mapCount uint64
+
+var ErrMaxMapCountReached = errors.New("maximum map count reached")
+
+// MaxMapCount default to slightly less than the typical
+// default on Linux (65K). We want to leave some
+// overhead for (e.g.) the Go runtime.
+var MaxMapCount uint64 = 60000
+
+// Mmap increments the global map count, and then calls syscall.Mmap. It
+// decrements the map count and returns an error if the count was over the
+// limit. If syscall.Mmap returns an error it also decrements the count.
+func Mmap(fd int, offset int64, length int, prot int, flags int) (data []byte, err error) {
+	if newCount := atomic.AddUint64(&mapCount, 1); newCount > MaxMapCount {
+		atomic.AddUint64(&mapCount, ^uint64(0)) // decrement
+		return nil, ErrMaxMapCountReached
+	}
+	data, err = syscall.Mmap(fd, offset, length, prot, flags)
+	if err != nil {
+		atomic.AddUint64(&mapCount, ^uint64(0)) // decrement
+	}
+	return data, err
+}
+
+// Munmap calls sycall.Munmap, and then decrements the global map count if there
+// was no error.
+func Munmap(b []byte) (err error) {
+	err = syscall.Munmap(b)
+	if err == nil {
+		atomic.AddUint64(&mapCount, ^uint64(0)) // decrement
+	}
+	return err
+}


### PR DESCRIPTION
## Overview

This seems to work—I imagine'd 20 billion bits into a 5 node cluster with Pilosa's max map count set to 1000. Memory usage was reported normally (i.e. not like mmap). 85k fragment files on each node, 24ish GB on disk. 40GB memory used.

There are some questionable design decisions here (hello globals!), so fire away.

Fixes #1890 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
