### PR TITLE
implement global open file counter using syswrap

### DIFF
--- a/ctl/server.go
+++ b/ctl/server.go
@@ -31,6 +31,7 @@ func BuildServerFlags(cmd *cobra.Command, srv *server.Command) {
 	flags.StringVar(&srv.Config.LogPath, "log-path", srv.Config.LogPath, "Log path")
 	flags.BoolVar(&srv.Config.Verbose, "verbose", srv.Config.Verbose, "Enable verbose logging")
 	flags.Uint64Var(&srv.Config.MaxMapCount, "max-map-count", srv.Config.MaxMapCount, "Limits the maximum number of active mmaps. Pilosa will fall back to reading files once this is exhausted. Set below your system's vm.max_map_count.")
+	flags.Uint64Var(&srv.Config.MaxFileCount, "max-file-count", srv.Config.MaxFileCount, "Soft limit on the maximum number of fragment files Pilosa keeps open simultaneously.")
 
 	// TLS
 	SetTLSConfig(flags, &srv.Config.TLS.CertificatePath, &srv.Config.TLS.CertificateKeyPath, &srv.Config.TLS.SkipVerify)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -146,6 +146,19 @@ The config file is in the [toml format](https://github.com/toml-lang/toml) and h
     max-writes-per-request = 5000
     ```
 
+#### Max File Count
+
+* Description: A soft limit on the maximum number of files that Pilosa will keep
+  open simultaneously. When past this limit, Pilosa will only keep files open
+  for as long as it needs to write updates. This will negatively affect
+  performance in cases where Pilosa is doing lots of small updates.
+* Flag: `--max-file-count=500000`
+* Env: `PILOSA_MAX_FILE_COUNT=500000`
+* Config:
+    ```toml
+    max-file-count = 500000
+    ```
+
 #### Gossip Advertise Host
 
 * Description: Host on which memberlist should advertise. Defaults to `advertise` host.

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -2466,11 +2466,11 @@ func (f *fragment) mustSetBits(rowID uint64, columnIDs ...uint64) {
 }
 
 func addToBitmap(bm *roaring.Bitmap, rowID uint64, columnIDs ...uint64) {
+	// we'll reuse the columnIDs slice and fill it with positions for DirectAddN
 	for i, c := range columnIDs {
 		columnIDs[i] = rowID*ShardWidth + c%ShardWidth
 	}
-	positions := columnIDs
-	bm.DirectAddN(positions...)
+	bm.DirectAddN(columnIDs...)
 }
 
 // Test Various methods of retrieving RowIDs

--- a/server/config.go
+++ b/server/config.go
@@ -75,6 +75,13 @@ type Config struct {
 	// normally.
 	MaxMapCount uint64 `toml:"max-map-count"`
 
+	// MaxFileCount puts a soft, in-process limit on the number of open fragment
+	// files. Once this limit is passed, Pilosa will only keep files open while
+	// actively working with them, and will close them afterward. This has a
+	// negative effect on performance for workloads which make small appends to
+	// lots of fragments.
+	MaxFileCount uint64 `toml:"max-file-count"`
+
 	// TLS
 	TLS TLSConfig `toml:"tls"`
 
@@ -130,6 +137,7 @@ func NewConfig() *Config {
 		Bind:                ":10101",
 		MaxWritesPerRequest: 5000,
 		MaxMapCount:         60000,
+		MaxFileCount:        500000,
 		TLS:                 TLSConfig{},
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -180,6 +180,7 @@ func (m *Command) Wait() error {
 // SetupServer uses the cluster configuration to set up this server.
 func (m *Command) SetupServer() error {
 	syswrap.SetMaxMapCount(m.Config.MaxMapCount)
+	syswrap.SetMaxFileCount(m.Config.MaxFileCount)
 
 	err := m.setupLogger()
 	if err != nil {

--- a/syswrap/os.go
+++ b/syswrap/os.go
@@ -1,0 +1,41 @@
+package syswrap
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+)
+
+var fileCount uint64
+
+// maxFileCount is the soft limit on the number of open files. syswrap.OpenFile
+// will warn when this limit is passed.
+var maxFileCount uint64 = 500000
+var fileMu sync.RWMutex
+
+func SetMaxFileCount(max uint64) {
+	fileMu.Lock()
+	maxFileCount = max
+	fileMu.Unlock()
+}
+
+// OpenFile passes the arguments along to os.OpenFile while incrementing a
+// counter. If the counter is above the maximum, it returns mustClose true to
+// signal the calling function that it should not keep the file open
+// indefinitely. Files opened with this function should be closed by
+// syswrap.CloseFile.
+func OpenFile(name string, flag int, perm os.FileMode) (file *os.File, mustClose bool, err error) {
+	file, err = os.OpenFile(name, flag, perm)
+	fileMu.RLock()
+	defer fileMu.RUnlock()
+	if newCount := atomic.AddUint64(&fileCount, 1); newCount > maxFileCount {
+		mustClose = true
+	}
+	return file, mustClose, err
+}
+
+// CloseFile decrements the global count of open files and closes the file.
+func CloseFile(f *os.File) error {
+	atomic.AddUint64(&fileCount, ^uint64(0)) // decrement
+	return f.Close()
+}


### PR DESCRIPTION
close files after using them if global max is passed.

I originally implemented this without the global count—just always closing files
when done with them, and reopening for new writes. This was crazy slow for that
one test that uses mustSetBits in a big loop. I modified the test to use
importRoaring and everything worked better (though still slower).

After adding the global counter, I ran the tests with that one test using
mustSetBits again, and the performance was similar to master. After completing
this PR, I ran the tests with the max limit set to 5—they still passed but were
much slower.

Fixes #1905 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
