### PR TITLE
quick fix for Bitmap.Any bug [no changelog]

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -331,7 +331,7 @@ func (b *Bitmap) Any() bool {
 	// TODO (jaffee) I'm not sure if it's possible/legal to have an empty
 	// container, so this loop may be totally unnecessary. In theory, any empty
 	// container should be removed from the bitmap though.
-	for b := iter.Next(); b; iter.Next() {
+	for iter.Next() {
 		_, c := iter.Value()
 		if c.n > 0 {
 			return true

--- a/roaring/roaring_internal_test.go
+++ b/roaring/roaring_internal_test.go
@@ -3818,3 +3818,31 @@ func BenchmarkUnionInPlaceRegression(b *testing.B) {
 		}
 	})
 }
+
+func TestBitmapAny(t *testing.T) {
+	bm := NewBTreeBitmap()
+	if bm.Any() {
+		t.Error("empty bitmap should have Any()==false")
+	}
+	bm.Add(1)
+	if !bm.Any() {
+		t.Error("bitmap with 1 bit should have Any()==true")
+	}
+	bm.Add(100000)
+	if !bm.Any() {
+		t.Error("bitmap with 2 bits should have Any()==true")
+	}
+	bm.Remove(1)
+	if !bm.Any() {
+		t.Error("bitmap with 1 bit left after removing 1 should have Any()==true")
+	}
+	bm.Add(1)
+	bm = bm.Difference(NewBTreeBitmap(1))
+	if !bm.Any() {
+		t.Error("bitmap with 1 bit left after differencing 1 should have Any()==true")
+	}
+	bm.Remove(100000)
+	if bm.Any() {
+		t.Error("shouldn't be any left")
+	}
+}


### PR DESCRIPTION
Want to make empty containers a thing of the past, but that can wait for another
day.

Fixes hanging go-pilosa integration tests.

I'm starting the "[no changelog]" convention for PRs which fix bugs which occur in code which is new since the last release and therefore don't affect the CHANGELOG.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
