### PR TITLE
run fewer concurrency level benchmarks, add bench Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ vendor: go.mod
 test:
 	go test ./... -tags='$(BUILD_TAGS)' $(TESTFLAGS)
 
+bench:
+	go test ./... -bench=. -run=NoneZ -timeout=127m $(TESTFLAGS)
+
 # Run test suite with coverage enabled
 cover:
 	mkdir -p build

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -1987,7 +1987,7 @@ func BenchmarkFragment_Import(b *testing.B) {
 var (
 	rowCases         = []uint64{2, 50, 1000, 100000}
 	colCases         = []uint64{20, 1000, 50000, 500000}
-	concurrencyCases = []int{2, 4, 8, 16}
+	concurrencyCases = []int{2, 16}
 )
 
 func BenchmarkImportRoaring(b *testing.B) {


### PR DESCRIPTION
The benchmarks take an absurdly long time to run, and I think these are the
largest offenders. Dropping to two concurrency cases 2 and 16 should give a
pretty good idea.

The Makefile target will make things a bit easier to run from the infra repo—I just ran into an issue where `go test -bench` failed because go modules aren't enabled by default.

Fixes #

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
