### PR TITLE
importValue should only consider the last instance of a column id

### DIFF
--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -3070,3 +3070,46 @@ func TestImportValueConcurrent(t *testing.T) {
 		t.Fatalf("concurrently importing values: %v", err)
 	}
 }
+
+func TestImportMultipleValues(t *testing.T) {
+	tests := []struct {
+		cols      []uint64
+		vals      []uint64
+		checkCols []uint64
+		checkVals []uint64
+		depth     uint
+	}{
+		{
+			cols:      []uint64{0, 0},
+			vals:      []uint64{97, 100},
+			depth:     7,
+			checkCols: []uint64{0},
+			checkVals: []uint64{100},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			f := mustOpenFragment("i", "f", viewBSIGroupPrefix+"foo", 0, CacheTypeNone)
+			err := f.importValue(test.cols, test.vals, test.depth, false)
+			if err != nil {
+				t.Fatalf("importing values: %v", err)
+			}
+
+			for i := range test.checkCols {
+				cc, cv := test.checkCols[i], test.checkVals[i]
+				n, exists, err := f.value(cc, test.depth)
+				if err != nil {
+					t.Fatalf("getting value: %v", err)
+				}
+				if !exists {
+					t.Errorf("column %d should exist", cc)
+				}
+				if n != 100 {
+					t.Errorf("wrong value: %d is not %d", n, cv)
+				}
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
included test demonstrates bug

I know we have some thoughts in the pipeline for a better approach to importValue, so I didn't try to do anything fancy here.

The map of column ids is only used on the smallwrite path, so hopefully is never large.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
