### PR TITLE
fix data loss bug and robustify test

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -1104,7 +1104,7 @@ func (f *fragment) pos(rowID, columnID uint64) (uint64, error) {
 	// Return an error if the column ID is out of the range of the fragment's shard.
 	minColumnID := f.shard * ShardWidth
 	if columnID < minColumnID || columnID >= minColumnID+ShardWidth {
-		return 0, errors.New("column out of bounds")
+		return 0, errors.Errorf("column:%d out of bounds", columnID)
 	}
 	return pos(rowID, columnID), nil
 }

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -3668,11 +3668,13 @@ func (op *op) apply(b *Bitmap) (changed bool) {
 		return b.remove(op.value)
 	case opTypeAddBatch:
 		for _, v := range op.values {
-			changed = changed || b.DirectAdd(v)
+			nc := b.DirectAdd(v)
+			changed = nc || changed
 		}
 	case opTypeRemoveBatch:
 		for _, v := range op.values {
-			changed = changed || b.remove(v)
+			nc := b.remove(v)
+			changed = nc || changed
 		}
 	default:
 		panic(fmt.Sprintf("invalid op type: %d", op.typ))


### PR DESCRIPTION
Data loss was occuring after a cluster restart. The issue was during the
unmarshaling of the op log when multiple values had been written to the log. The
lines in question were like "changed = changed || b.DirectAdd(v)" in which the
DirectAdd would only be executed when changed was initially false, once it was
true, it would never be executed again.

Fixes #1922 

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
