### PR TITLE
simply setting list of values with *N methods

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -3667,15 +3667,9 @@ func (op *op) apply(b *Bitmap) (changed bool) {
 	case opTypeRemove:
 		return b.remove(op.value)
 	case opTypeAddBatch:
-		for _, v := range op.values {
-			nc := b.DirectAdd(v)
-			changed = nc || changed
-		}
+		changed = b.DirectAddN(op.values...) > 0
 	case opTypeRemoveBatch:
-		for _, v := range op.values {
-			nc := b.remove(v)
-			changed = nc || changed
-		}
+		changed = b.DirectRemoveN(op.values...) > 0
 	default:
 		panic(fmt.Sprintf("invalid op type: %d", op.typ))
 	}


### PR DESCRIPTION
I don't think there's any reason that applying a batch of operations can't take advantage of these methods. I think they were created slightly after the initial addition of the op log batch operations which is why they weren't there already.


## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
