### PR TITLE
address race condition by getting cluster nodes with lock

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -551,12 +551,6 @@ func (c *cluster) determineClusterState() (clusterState string) {
 	return ClusterStateStarting
 }
 
-func (c *cluster) status() *ClusterStatus {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.unprotectedStatus()
-}
-
 // unprotectedStatus returns the the cluster's status including what nodes it contains, its ID, and current state.
 func (c *cluster) unprotectedStatus() *ClusterStatus {
 	return &ClusterStatus{

--- a/server.go
+++ b/server.go
@@ -589,7 +589,8 @@ func (s *Server) SendSync(m Message) error {
 		return fmt.Errorf("marshaling message: %v", err)
 	}
 	msg = append([]byte{getMessageType(m)}, msg...)
-	for _, node := range s.cluster.nodes {
+
+	for _, node := range s.cluster.Nodes() {
 		node := node
 		// Don't forward the message to ourselves.
 		if s.uri == node.URI {

--- a/server/cluster_test.go
+++ b/server/cluster_test.go
@@ -309,6 +309,189 @@ func TestClusterResize_AddNode(t *testing.T) {
 	})
 }
 
+// Ensure that adding a node correctly resizes the cluster.
+func TestClusterResize_AddNodeConcurrentIndex(t *testing.T) {
+	t.Run("WithIndex", func(t *testing.T) {
+		// Configure node0
+		m0 := test.MustRunCluster(t, 1)[0]
+		defer m0.Close()
+
+		seed := m0.GossipAddress()
+
+		// Create a client for each node.
+		client0 := m0.Client()
+
+		// Create indexes and fields on one node.
+		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
+			t.Fatal(err)
+		} else if err := client0.CreateField(context.Background(), "i", "f"); err != nil {
+			t.Fatal(err)
+		}
+
+		errc := make(chan error)
+		go func() {
+			_, err := m0.API.CreateIndex(context.Background(), "blah", pilosa.IndexOptions{})
+			errc <- err
+		}()
+
+		// Configure node1
+		m1 := test.NewCommandNode(false)
+		m1.Config.Gossip.Port = "0"
+		m1.Config.Gossip.Seeds = []string{seed}
+		err := m1.Start()
+		if err != nil {
+			t.Fatalf("starting second main: %v", err)
+		}
+		defer m1.Close()
+
+		if !checkClusterState(m0, pilosa.ClusterStateNormal, 1000) {
+			t.Fatalf("unexpected node0 cluster state: %s", m0.API.State())
+		} else if !checkClusterState(m1, pilosa.ClusterStateNormal, 1000) {
+			t.Fatalf("unexpected node1 cluster state: %s", m1.API.State())
+		}
+
+		if err := <-errc; err != nil {
+			t.Fatalf("error from index creation: %v", err)
+		}
+	})
+	t.Run("ContinuousShards", func(t *testing.T) {
+		// Configure node0
+		m0 := test.MustRunCluster(t, 1)[0]
+		defer m0.Close()
+
+		seed := m0.GossipAddress()
+
+		// Create a client for each node.
+		client0 := m0.Client()
+
+		// Create indexes and fields on one node.
+		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
+			t.Fatal(err)
+		} else if err := client0.CreateField(context.Background(), "i", "f"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write data on first node.
+		if _, err := m0.Query("i", "", `
+				Set(1, f=1)
+				Set(1300000, f=1)
+			`); err != nil {
+			t.Fatal(err)
+		}
+
+		// exp is the expected result for the Row queries that follow.
+		exp := `{"results":[{"attrs":{},"columns":[1,1300000]}]}` + "\n"
+
+		// Verify the data exists on the single node.
+		if res, err := m0.Query("i", "", `Row(f=1)`); err != nil {
+			t.Fatal(err)
+		} else if res != exp {
+			t.Fatalf("unexpected result: %s", res)
+		}
+
+		// Configure node1
+		m1 := test.NewCommandNode(false)
+		m1.Config.Gossip.Port = "0"
+		m1.Config.Gossip.Seeds = []string{seed}
+		err := m1.Start()
+		if err != nil {
+			t.Fatalf("starting second main: %v", err)
+		}
+		errc := make(chan error, 1)
+		go func() {
+			_, err := m0.API.CreateIndex(context.Background(), "blah", pilosa.IndexOptions{})
+			errc <- err
+		}()
+		defer m1.Close()
+
+		if !checkClusterState(m0, pilosa.ClusterStateNormal, 1000) {
+			t.Fatalf("unexpected node0 cluster state: %s", m0.API.State())
+		} else if !checkClusterState(m1, pilosa.ClusterStateNormal, 1000) {
+			t.Fatalf("unexpected node1 cluster state: %s", m1.API.State())
+		}
+
+		// Verify the data exists on both nodes.
+		if res, err := m0.Query("i", "", `Row(f=1)`); err != nil {
+			t.Fatal(err)
+		} else if res != exp {
+			t.Fatalf("unexpected result: %s", res)
+		}
+		if res, err := m1.Query("i", "", `Row(f=1)`); err != nil {
+			t.Fatal(err)
+		} else if res != exp {
+			t.Fatalf("unexpected result: %s", res)
+		}
+	})
+	t.Run("SkippedShard", func(t *testing.T) {
+		// Configure node0
+		m0 := test.MustRunCluster(t, 1)[0]
+		defer m0.Close()
+
+		seed := m0.GossipAddress()
+
+		// Create a client for each node.
+		client0 := m0.Client()
+
+		// Create indexes and fields on one node.
+		if err := client0.CreateIndex(context.Background(), "i", pilosa.IndexOptions{}); err != nil && err != pilosa.ErrIndexExists {
+			t.Fatal(err)
+		} else if err := client0.CreateField(context.Background(), "i", "f"); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write data on first node. Note that no data is placed on shard 1.
+		if _, err := m0.Query("i", "", `
+				Set(1, f=1)
+				Set(2400000, f=1)
+			`); err != nil {
+			t.Fatal(err)
+		}
+
+		// exp is the expected result for the Row queries that follow.
+		exp := `{"results":[{"attrs":{},"columns":[1,2400000]}]}` + "\n"
+
+		// Verify the data exists on the single node.
+		if res, err := m0.Query("i", "", `Row(f=1)`); err != nil {
+			t.Fatal(err)
+		} else if res != exp {
+			t.Fatalf("unexpected result: %s", res)
+		}
+
+		// Configure node1
+		m1 := test.NewCommandNode(false)
+		m1.Config.Gossip.Port = "0"
+		m1.Config.Gossip.Seeds = []string{seed}
+		errc := make(chan error, 1)
+		go func() {
+			_, err := m0.API.CreateIndex(context.Background(), "blah", pilosa.IndexOptions{})
+			errc <- err
+		}()
+		err := m1.Start()
+		if err != nil {
+			t.Fatalf("starting second main: %v", err)
+		}
+		defer m1.Close()
+
+		if !checkClusterState(m0, pilosa.ClusterStateNormal, 1000) {
+			t.Fatalf("unexpected node0 cluster state: %s", m0.API.State())
+		} else if !checkClusterState(m1, pilosa.ClusterStateNormal, 1000) {
+			t.Fatalf("unexpected node1 cluster state: %s", m1.API.State())
+		}
+
+		// Verify the data exists on both nodes.
+		if res, err := m0.Query("i", "", `Row(f=1)`); err != nil {
+			t.Fatal(err)
+		} else if res != exp {
+			t.Fatalf("unexpected result: %s", res)
+		}
+		if res, err := m1.Query("i", "", `Row(f=1)`); err != nil {
+			t.Fatal(err)
+		} else if res != exp {
+			t.Fatalf("unexpected result: %s", res)
+		}
+	})
+}
+
 // Ensure that redundant gossip seeds are used
 func TestCluster_GossipMembership(t *testing.T) {
 	t.Run("Node0Down", func(t *testing.T) {


### PR DESCRIPTION
needed an unlocked version of sendsync for use within the cluster, so also
implemented that. Added a number of tests trying to reproduce the issue, but was
not able to. Not sure it's worth keeping the new tests.


Fixes #1919

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
