### PR TITLE
Add correct content type to query responses. Fixes #1873

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -964,10 +964,12 @@ func (h *Handler) readURLQueryRequest(r *http.Request) (*pilosa.QueryRequest, er
 }
 
 // writeQueryResponse writes the response from the executor to w.
-func (h *Handler) writeQueryResponse(w io.Writer, r *http.Request, resp *pilosa.QueryResponse) error {
+func (h *Handler) writeQueryResponse(w http.ResponseWriter, r *http.Request, resp *pilosa.QueryResponse) error {
 	if !validHeaderAcceptJSON(r.Header) {
+		w.Header().Set("Content-Type", "application/protobuf")
 		return h.writeProtobufQueryResponse(w, resp)
 	}
+	w.Header().Set("Content-Type", "application/json")
 	return h.writeJSONQueryResponse(w, resp)
 }
 

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -248,6 +248,8 @@ func TestHandler_Endpoints(t *testing.T) {
 			t.Fatalf("unexpected status code: %d", w.Code)
 		} else if body := w.Body.String(); body != `{"results":[2]}`+"\n" {
 			t.Fatalf("unexpected body: %q", body)
+		} else if w.Header().Get("Content-Type") != "application/json" {
+			t.Fatalf("unexpected header: %q", w.Header().Get("Content-Type"))
 		}
 
 	})
@@ -286,6 +288,8 @@ func TestHandler_Endpoints(t *testing.T) {
 			t.Fatal(err)
 		} else if rt, ok := resp.Results[0].(uint64); !ok || rt != 3 {
 			t.Fatalf("unexpected response type: %#v", resp.Results[0])
+		} else if w.Header().Get("Content-Type") != "application/protobuf" {
+			t.Fatalf("unexpected header: %q", w.Header().Get("Content-Type"))
 		}
 	})
 


### PR DESCRIPTION
## Overview

This adds the appropriate `Content-Type` header to query responses.

Fixes #1873

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
