### PR TITLE
return orig error instead of cause in handler

### DIFF
--- a/http/handler.go
+++ b/http/handler.go
@@ -347,7 +347,7 @@ func (r *successResponse) check(err error) (statusCode int) {
 	}
 
 	r.Success = false
-	r.Error = &Error{Message: cause.Error()}
+	r.Error = &Error{Message: err.Error()}
 
 	return statusCode
 }

--- a/index.go
+++ b/index.go
@@ -155,7 +155,7 @@ func (i *Index) openFields() error {
 
 		fld, err := i.newField(i.fieldPath(filepath.Base(fi.Name())), filepath.Base(fi.Name()))
 		if err != nil {
-			return ErrName
+			return errors.Wrapf(ErrName, "'%s'", fi.Name())
 		}
 		if err := fld.Open(); err != nil {
 			return fmt.Errorf("open field: name=%s, err=%s", fld.Name(), err)

--- a/pilosa.go
+++ b/pilosa.go
@@ -16,7 +16,7 @@ package pilosa
 
 import (
 	"encoding/json"
-	"errors"
+	"github.com/pkg/errors"
 	"regexp"
 )
 
@@ -152,7 +152,7 @@ const TimeFormat = "2006-01-02T15:04"
 // validateName ensures that the name is a valid format.
 func validateName(name string) error {
 	if !nameRegexp.Match([]byte(name)) {
-		return ErrName
+		return errors.Wrapf(ErrName, "'%s'", name)
 	}
 	return nil
 }

--- a/pilosa.go
+++ b/pilosa.go
@@ -16,8 +16,9 @@ package pilosa
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"regexp"
+
+	"github.com/pkg/errors"
 )
 
 // System errors.

--- a/server/handler_test.go
+++ b/server/handler_test.go
@@ -690,9 +690,9 @@ func TestHandler_Endpoints(t *testing.T) {
 		r = test.MustNewHTTPRequest("POST", "/index/idx1", strings.NewReader(""))
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusConflict {
-			t.Fatalf("unexpected status code: %d", w.Code)
-		} else if w.Body.String() != `{"success":false,"error":{"message":"index already exists"}}`+"\n" {
-			t.Fatalf("unexpected body: %q", w.Body.String())
+			t.Errorf("unexpected status code: %d", w.Code)
+		} else if w.Body.String() != `{"success":false,"error":{"message":"creating index: index already exists"}}`+"\n" {
+			t.Errorf("unexpected body: %q", w.Body.String())
 		}
 
 		// create field
@@ -710,9 +710,9 @@ func TestHandler_Endpoints(t *testing.T) {
 		r = test.MustNewHTTPRequest("POST", "/index/idx1/field/fld1", strings.NewReader(""))
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusConflict {
-			t.Fatalf("unexpected status code: %d", w.Code)
-		} else if w.Body.String() != `{"success":false,"error":{"message":"field already exists"}}`+"\n" {
-			t.Fatalf("unexpected body: %q", w.Body.String())
+			t.Errorf("unexpected status code: %d", w.Code)
+		} else if w.Body.String() != `{"success":false,"error":{"message":"creating field: field already exists"}}`+"\n" {
+			t.Errorf("unexpected body: %q", w.Body.String())
 		}
 
 		// delete field
@@ -730,9 +730,9 @@ func TestHandler_Endpoints(t *testing.T) {
 		r = test.MustNewHTTPRequest("DELETE", "/index/idx1/field/fld1", strings.NewReader(""))
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusNotFound {
-			t.Fatalf("unexpected status code: %d", w.Code)
-		} else if w.Body.String() != `{"success":false,"error":{"message":"field not found"}}`+"\n" {
-			t.Fatalf("unexpected body: %q", w.Body.String())
+			t.Errorf("unexpected status code: %d", w.Code)
+		} else if w.Body.String() != `{"success":false,"error":{"message":"deleting field: field not found"}}`+"\n" {
+			t.Errorf("unexpected body: %q", w.Body.String())
 		}
 
 		// delete index
@@ -750,9 +750,9 @@ func TestHandler_Endpoints(t *testing.T) {
 		r = test.MustNewHTTPRequest("DELETE", "/index/idx1", strings.NewReader(""))
 		h.ServeHTTP(w, r)
 		if w.Code != gohttp.StatusNotFound {
-			t.Fatalf("unexpected status code: %d", w.Code)
-		} else if w.Body.String() != `{"success":false,"error":{"message":"index not found"}}`+"\n" {
-			t.Fatalf("unexpected body: %q", w.Body.String())
+			t.Errorf("unexpected status code: %d", w.Code)
+		} else if w.Body.String() != `{"success":false,"error":{"message":"deleting index: index not found"}}`+"\n" {
+			t.Errorf("unexpected body: %q", w.Body.String())
 		}
 	})
 


### PR DESCRIPTION
also include the invalid name when erroring that a name is invalid.

Context: I was using imagine, and had misconfigured it so that it was generating invalid names for things. It was erroring out, but I had no idea which name was invalid or what is was.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
