### PR TITLE
use os.Rename semantically correctly

### DIFF
--- a/view.go
+++ b/view.go
@@ -437,12 +437,11 @@ func upgradeViewBSIv2(v *view, bitDepth uint) (ok bool, _ error) {
 		}
 		ok = true // mark as upgraded, requires reload
 
-		oldPath := frag.path
-		if newPath, err := upgradeRoaringBSIv2(frag, bitDepth); err != nil {
+		if tmpPath, err := upgradeRoaringBSIv2(frag, bitDepth); err != nil {
 			return ok, errors.Wrap(err, "upgrading bsi v2")
 		} else if err := frag.closeStorage(); err != nil {
 			return ok, errors.Wrap(err, "closing after bsi v2 upgrade")
-		} else if err := os.Rename(oldPath, newPath); err != nil {
+		} else if err := os.Rename(tmpPath, frag.path); err != nil {
 			return ok, errors.Wrap(err, "renaming after bsi v2 upgrade")
 		} else if err := frag.openStorage(); err != nil {
 			return ok, errors.Wrap(err, "re-opening after bsi v2 upgrade")


### PR DESCRIPTION
So it's true that Rename's arguments are called oldname/newname, and
you want to rename from the previous name to the new name.

And it's true that we're calling Rename on oldPath and newPath.

But in our case, oldPath is the name the fragment file had before
the operation, and newPath is the name of the temporary file
created during the operation.
