### PR TITLE
handle insertions correctly

### DIFF
--- a/roaring/containers_slice.go
+++ b/roaring/containers_slice.go
@@ -196,9 +196,7 @@ func (sc *sliceContainers) Update(key uint64, fn func(*Container, bool) (*Contai
 		// don't expand the slice just to add a nil container, we
 		// could return that anyway
 		if write && nc != nil {
-			sc.containers = append(sc.containers, nil)
-			copy(sc.containers[i+1:], sc.containers[i:])
-			sc.containers[i] = nc
+			sc.insertAt(key, nc, -i-1)
 		}
 	}
 }


### PR DESCRIPTION
The "Update" case for Slice containers is broken, and can
insert a container without inserting a key. Fix this by using
the existing insert/add logic.

## Overview

Silly bug, that I don't think was actually affecting us yet, because I don't think the Update function is actually being hit in current code paths, but it's still probably worth fixing.

Fixes #1991.