### PR TITLE
WIP: importRoaring more directly

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -322,7 +322,15 @@ func (b *Bitmap) ImportRoaringBits(data []byte, clear bool, opN int, maxOpN int,
 			}
 		} else {
 			if c.N() == 0 {
-				newC = synthC.Clone()
+				// We don't need to clone newC; we just need to
+				// make a new container identical to it. The new
+				// container will get put into the fragment, and
+				// will use the roaring data as backing store,
+				// which prevents that data from being freed for
+				// now, but probably it gets snapshotted "soon".
+				newerC := synthC
+				newC = &newerC
+				newC.setMapped(true)
 				changed = newC.N()
 			} else {
 				newC = union(c, &synthC)

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -437,6 +437,7 @@ func (b *Bitmap) ImportRoaringBits(data []byte, clear bool, opN int, maxOpN int,
 					changes = nil
 				}
 				b.Containers.Put(newKey, &newerC)
+				rowChanged = true
 				// and update our belief about the highest value key we've seen
 				lastKey = newKey
 			}

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -294,7 +294,6 @@ func (b *Bitmap) ImportRoaringBits(data []byte, clear bool, opN int, maxOpN int,
 
 	applyChangeData := func(changeData *Container) {
 		changed := changeData.N()
-		rowChanged = true
 		if changeData.N() > int32(len(contChanges)) {
 			contChanges = make([]uint16, changeData.N())
 		}
@@ -396,6 +395,7 @@ func (b *Bitmap) ImportRoaringBits(data []byte, clear bool, opN int, maxOpN int,
 			applyChangeData(changeData)
 		}
 		if changed != 0 {
+			rowChanged = true
 			return newC, true
 		}
 		return nil, false

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -352,6 +352,9 @@ func (b *Bitmap) ImportRoaringBits(data []byte, clear bool, opN int, maxOpN int,
 					if changeData.N() > 0 {
 						newC = c.unionInPlace(changeData)
 						changed = changeData.N()
+						if newC.typ() == containerBitmap {
+							newC.Repair()
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Overview

This is a WIP (don't merge) that changes importRoaring to use a new unmarshalling importer in roaring, rather than unmarshalling the imported bits into their own new bitmap and trying to merge them that way. The intent is to reduce the amount of overhead from unioning, etc., because we don't have to process the whole bitmap, only the parts the new bitmap would interact with. (Outside of the first import to a fragment, this should always be better.)