### PR TITLE
Malformed Offset Bug in readOffsets and readWithRuns

### DIFF
--- a/roaring/fuzz_test.go
+++ b/roaring/fuzz_test.go
@@ -61,6 +61,11 @@ func TestUnmarshalBinary(t *testing.T) {
 			cr:       []byte(";0\x000\v00000"), //";0000000"
 			expected: "reading offsets from official roaring format: offset incomplete: len=10",
 		},
+		{ // Checks for incomplete offset in readOffsets
+			cr: []byte(":0\x000\x03\x00\x00\x00000000000000" +
+				"\x00"), //:0000000000000
+			expected: "reading offsets from official roaring format: offset incomplete: len=1",
+		},
 	}
 
 	for _, crash := range confirmedCrashers {

--- a/roaring/fuzz_test.go
+++ b/roaring/fuzz_test.go
@@ -13,49 +13,49 @@
 // limitations under the License.
 package roaring
 
-import ( 
+import (
 	"testing"
 )
 
 func TestUnmarshalBinary(t *testing.T) {
 	b := NewBitmap()
 	confirmedCrashers := []struct {
-		cr []byte
+		cr       []byte
 		expected string
-	} {
-		{	// Checks for the zero containers situation
-			cr : []byte(":0\x000\x01\x00\x00\x000000"),					//":000000"
-			expected : "reading roaring header: malformed bitmap, key-cardinality slice overruns buffer at 12",
-		},	
-		{	// Checks for int overflow
-			cr : []byte("<0\x000\x00\x00\x00\x00000000000000" +
-			"0"),														//"<000000000000000"
-			expected : "unmarshaling as pilosa roaring: Maximum operation size exceeded",
-		},	
-		{	// The next 5 check for malformed bitmaps
-			cr : []byte("<0\x0000000000000000000" +
-			"\x00\x00\xec\x00\x03\x00\x00\x00\xec000"),					//"<000000000000000000ÏÏ000"
-			expected : "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 67372036 containers",
-		},	
-		{
-			cr : []byte("<0\x00\x02\x00\x00\x00\\f\x01\xb5\x8d\x009\v\x01\x00\x00\x00\x00" +
-			"\x00\x00e\x04\x00\x00\x00\x04\xfd\x00\x01\x00"),			//"<0\fµç9e˝"
-			expected : "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 128625322 containers",
+	}{
+		{ // Checks for the zero containers situation
+			cr:       []byte(":0\x000\x01\x00\x00\x000000"), //":000000"
+			expected: "reading roaring header: malformed bitmap, key-cardinality slice overruns buffer at 12",
+		},
+		{ // Checks for int overflow
+			cr: []byte("<0\x000\x00\x00\x00\x00000000000000" +
+				"0"), //"<000000000000000"
+			expected: "unmarshaling as pilosa roaring: Maximum operation size exceeded",
+		},
+		{ // The next 5 check for malformed bitmaps
+			cr: []byte("<0\x0000000000000000000" +
+				"\x00\x00\xec\x00\x03\x00\x00\x00\xec000"), //"<000000000000000000ÏÏ000"
+			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 67372036 containers",
 		},
 		{
-			cr : []byte("<0\x00\x02\x00\x00\x00&x.field safe"),			//"<0&x.field safe"
-			expected : "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 53127850 containers",
+			cr: []byte("<0\x00\x02\x00\x00\x00\\f\x01\xb5\x8d\x009\v\x01\x00\x00\x00\x00" +
+				"\x00\x00e\x04\x00\x00\x00\x04\xfd\x00\x01\x00"), //"<0\fµç9e˝"
+			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 128625322 containers",
 		},
 		{
-			cr : []byte("<0\x00\x00\x14\x00\x00\x00\x80\xffp\x05_ 4\x114089" +
-			"\x00\x00\xff\x000\x00\x02\x00\x00\x00\x00\xff\u007f\x00\x00\x01\x10\x00\x00j" +
-			"\x02\x00\x00$\x04_\x00\xff\u007f\xff062616163\x00" +		//"<0Äˇp_ 44089ˇ0ˇj$_ˇˇ0626161630ø¸ad$j√"
-			"0\x00\x02\x00\x01\xbf\x00\x04\x00\xfcad$\x00\x00j\x10\x00\x00\xc3"),			
-			expected : "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 1 containers",
+			cr:       []byte("<0\x00\x02\x00\x00\x00&x.field safe"), //"<0&x.field safe"
+			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 53127850 containers",
 		},
-		{	// 0 containers because the container is partially formed, but not fully (ie. 3/12 = 0)
-			cr : []byte("<0\x00\x02\x03\x00\x00\x00쳫\v\x00d9\v\x00\x009\v"),		//<0쳫d99	
-			expected : "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 0 containers",
+		{
+			cr: []byte("<0\x00\x00\x14\x00\x00\x00\x80\xffp\x05_ 4\x114089" +
+				"\x00\x00\xff\x000\x00\x02\x00\x00\x00\x00\xff\u007f\x00\x00\x01\x10\x00\x00j" +
+				"\x02\x00\x00$\x04_\x00\xff\u007f\xff062616163\x00" + //"<0Äˇp_ 44089ˇ0ˇj$_ˇˇ0626161630ø¸ad$j√"
+				"0\x00\x02\x00\x01\xbf\x00\x04\x00\xfcad$\x00\x00j\x10\x00\x00\xc3"),
+			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 1 containers",
+		},
+		{ // 0 containers because the container is partially formed, but not fully (ie. 3/12 = 0)
+			cr:       []byte("<0\x00\x02\x03\x00\x00\x00쳫\v\x00d9\v\x00\x009\v"), //<0쳫d99
+			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 0 containers",
 		},
 	}
 
@@ -63,7 +63,7 @@ func TestUnmarshalBinary(t *testing.T) {
 		err := b.UnmarshalBinary(crash.cr)
 		if err.Error() != crash.expected {
 			t.Errorf("Expected: %s, Got: %s", crash.expected, err)
-		} 
+		}
 	}
-  
+
 }

--- a/roaring/fuzz_test.go
+++ b/roaring/fuzz_test.go
@@ -57,6 +57,10 @@ func TestUnmarshalBinary(t *testing.T) {
 			cr:       []byte("<0\x00\x02\x03\x00\x00\x00쳫\v\x00d9\v\x00\x009\v"), //<0쳫d99
 			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 0 containers",
 		},
+		{ // Checks for incomplete offset in readWithRuns
+			cr:       []byte(";0\x000\v00000"), //";0000000"
+			expected: "reading offsets from official roaring format: offset incomplete: len=10",
+		},
 	}
 
 	for _, crash := range confirmedCrashers {

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1120,7 +1120,7 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 
 	// Read key count in bytes sizeof(cookie)+sizeof(flag):(sizeof(cookie)+sizeof(uint32)).
 	keyN := binary.LittleEndian.Uint32(data[3+1 : 8])
-	if len(data) < headerBaseSize+int(keyN)*12 {
+	if uint32(len(data)) < headerBaseSize+keyN*12 {
 		return fmt.Errorf("malformed bitmap, key-cardinality not provided for %d containers", int(keyN)/12)
 	}
 

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -4527,6 +4527,10 @@ func readOffsets(b *Bitmap, data []byte, pos int, keyN uint32) error {
 
 	citer, _ := b.Containers.Iterator(0)
 	for i, buf := 0, data[pos:]; i < int(keyN); i, buf = i+1, buf[4:] {
+		// Verify the offset is fully formed
+		if len(buf) < 4 {
+			return fmt.Errorf("offset incomplete: len=%d", len(buf))
+		}
 		offset := binary.LittleEndian.Uint32(buf[0:4])
 		// Verify the offset is within the bounds of the input data.
 		if int(offset) >= len(data) {


### PR DESCRIPTION
## Overview

When the readOffsets and readWithRuns functions are called, if the offsets within the official roaring bitmap aren't completely formed, then there will be a `slice out of bounds` panic. To fix this, a check is implemented to ensure that the bitmap is fully formed.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [x] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [ ] All new and existing tests pass.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.