### PR TITLE
Unmarshal3

### DIFF
--- a/field.go
+++ b/field.go
@@ -84,6 +84,8 @@ type Field struct {
 	remoteAvailableShards *roaring.Bitmap
 
 	logger logger.Logger
+
+	snapshotQueue chan *fragment
 }
 
 // FieldOption is a functional option type for pilosa.fieldOptions.
@@ -838,6 +840,7 @@ func (f *Field) newView(path, name string) *view {
 	view.rowAttrStore = f.rowAttrStore
 	view.stats = f.Stats
 	view.broadcaster = f.broadcaster
+	view.snapshotQueue = f.snapshotQueue
 	return view
 }
 

--- a/fragment.go
+++ b/fragment.go
@@ -221,7 +221,7 @@ func (f *fragment) enqueueSnapshot() {
 			f.snapshotDelays++
 			f.snapshotDelayTime += time.Since(before)
 			if f.snapshotDelays >= 10 {
-				f.Logger.Printf("snapshotting %s: last ten delays took %v", f.path, f.snapshotDelayTime)
+				f.Logger.Printf("snapshotting %s: last ten enqueue delays took %v", f.path, f.snapshotDelayTime)
 				f.snapshotDelays = 0
 				f.snapshotDelayTime = 0
 			}
@@ -2666,8 +2666,8 @@ func filterWithRows(rows []uint64) rowFilter {
 // this container have been processed. The rows accumulated up to this point
 // (including this row if all filters passed) will be returned.
 func (f *fragment) rows(start uint64, filters ...rowFilter) []uint64 {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.mu.RLock()
+	defer f.mu.RUnlock()
 	return f.unprotectedRows(start, filters...)
 }
 

--- a/fragment.go
+++ b/fragment.go
@@ -225,8 +225,6 @@ func (f *fragment) enqueueSnapshot() {
 				f.snapshotDelays = 0
 				f.snapshotDelayTime = 0
 			}
-		case <-time.After(5 * time.Second):
-			f.Logger.Printf("snapshot for %s: timed out\n", f.path)
 		}
 	} else {
 		// in testing, for instance, there may be no holder, thus no one

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -117,7 +117,7 @@ func TestFragment_RowcacheMap(t *testing.T) {
 		_, _ = f.setBit(0, uint64(i*32))
 	}
 	// force snapshot so we get a mmapped row...
-	_ = f.snapshot()
+	_ = f.Snapshot()
 	row := f.row(0)
 	segment := row.Segments()[0]
 	bitmap := segment.data
@@ -3227,7 +3227,7 @@ func TestImportClearRestart(t *testing.T) {
 				f2.MaxOpN = maxOpN
 				f2.CacheType = f.CacheType
 
-				err = f.closeStorage()
+				err = f.closeStorage(true)
 				if err != nil {
 					t.Fatalf("closing storage: %v", err)
 				}
@@ -3261,7 +3261,7 @@ func TestImportClearRestart(t *testing.T) {
 				f3.MaxOpN = maxOpN
 				f3.CacheType = f.CacheType
 
-				err = f2.closeStorage()
+				err = f2.closeStorage(true)
 				if err != nil {
 					t.Fatalf("f2 closing storage: %v", err)
 				}

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -2499,9 +2499,12 @@ func (f *fragment) sanityCheck(t testing.TB) {
 	}
 	defer file.Close()
 	data, err := ioutil.ReadAll(file)
-	err = newBM.UnmarshalBinary(data)
 	if err != nil {
 		t.Fatalf("sanityCheck couldn't read fragment %s: %v", f.path, err)
+	}
+	err = newBM.UnmarshalBinary(data)
+	if err != nil {
+		t.Fatalf("sanityCheck couldn't unmarshal fragment %s: %v", f.path, err)
 	}
 	if equal, reason := newBM.BitwiseEqual(f.storage); !equal {
 		t.Fatalf("fragment %s: unmarshalled bitmap different: %v", f.path, reason)

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -2037,16 +2037,17 @@ func BenchmarkFragment_Import(b *testing.B) {
 }
 
 var (
-	rowCases         = []uint64{2, 50, 1000, 100000}
-	colCases         = []uint64{20, 1000, 50000, 500000}
-	concurrencyCases = []int{2, 16}
+	rowCases         = []uint64{2, 50, 1000, 10000, 100000}
+	colCases         = []uint64{20, 1000, 5000, 50000, 500000}
+	concurrencyCases = []int{2, 4, 16}
+	cacheCases       = []string{CacheTypeNone, CacheTypeRanked}
 )
 
 func BenchmarkImportRoaring(b *testing.B) {
 	for _, numRows := range rowCases {
 		data := getZipfRowsSliceRoaring(numRows, 1, 0, ShardWidth)
 		b.Logf("%dRows: %.2fMB\n", numRows, float64(len(data))/1024/1024)
-		for _, cacheType := range []string{CacheTypeRanked} { // CacheTypeNone didn't seem to affect the results much
+		for _, cacheType := range cacheCases {
 			b.Run(fmt.Sprintf("Rows%dCache_%s", numRows, cacheType), func(b *testing.B) {
 				b.StopTimer()
 				for i := 0; i < b.N; i++ {
@@ -2070,63 +2071,28 @@ func BenchmarkImportRoaringConcurrent(b *testing.B) {
 		b.SkipNow()
 	}
 	for _, numRows := range rowCases {
-		data := getZipfRowsSliceRoaring(numRows, 1, 0, ShardWidth)
-		b.Logf("%dRows: %.2fMB\n", numRows, float64(len(data))/1024/1024)
+		data := make([][]byte, 0, len(concurrencyCases))
+		data = append(data, getZipfRowsSliceRoaring(numRows, 0, 0, ShardWidth))
+		b.Logf("%dRows: %.2fMB\n", numRows, float64(len(data[0]))/1024/1024)
 		for _, concurrency := range concurrencyCases {
-			b.Run(fmt.Sprintf("%dRows%dConcurrency", numRows, concurrency), func(b *testing.B) {
-				b.StopTimer()
-				frags := make([]*fragment, concurrency)
-				for i := 0; i < b.N; i++ {
-					for j := 0; j < concurrency; j++ {
-						frags[j] = mustOpenFragment("i", "f", viewStandard, uint64(j), CacheTypeRanked)
-					}
-					eg := errgroup.Group{}
-					b.StartTimer()
-					for j := 0; j < concurrency; j++ {
-						j := j
-						eg.Go(func() error {
-							return frags[j].importRoaringT(data, false)
-						})
-					}
-					err := eg.Wait()
-					if err != nil {
-						b.Errorf("importing fragment: %v", err)
-					}
-					b.StopTimer()
-					for j := 0; j < concurrency; j++ {
-						frags[j].Clean(b)
-					}
-				}
-			})
-		}
-	}
-}
-func BenchmarkImportRoaringUpdateConcurrent(b *testing.B) {
-	if testing.Short() {
-		b.SkipNow()
-	}
-	for _, numRows := range rowCases {
-		for _, numCols := range colCases {
-			data := getZipfRowsSliceRoaring(numRows, 1, 0, ShardWidth)
-			updata := getUpdataRoaring(numRows, numCols, 1)
-			for _, concurrency := range concurrencyCases {
-				b.Run(fmt.Sprintf("%dRows%dCols%dConcurrency", numRows, numCols, concurrency), func(b *testing.B) {
+			// add more data sets
+			for j := len(data); j < concurrency; j++ {
+				data = append(data, getZipfRowsSliceRoaring(numRows, int64(j), 0, ShardWidth))
+			}
+			for _, cacheType := range cacheCases {
+				b.Run(fmt.Sprintf("Rows%dConcurrency%dCache_%s", numRows, concurrency, cacheType), func(b *testing.B) {
 					b.StopTimer()
 					frags := make([]*fragment, concurrency)
 					for i := 0; i < b.N; i++ {
 						for j := 0; j < concurrency; j++ {
-							frags[j] = mustOpenFragment("i", "f", viewStandard, uint64(j), CacheTypeRanked)
-							err := frags[j].importRoaringT(data, false)
-							if err != nil {
-								b.Fatalf("importing roaring: %v", err)
-							}
+							frags[j] = mustOpenFragment("i", "f", viewStandard, uint64(j), cacheType)
 						}
 						eg := errgroup.Group{}
 						b.StartTimer()
 						for j := 0; j < concurrency; j++ {
 							j := j
 							eg.Go(func() error {
-								return frags[j].importRoaringT(updata, false)
+								return frags[j].importRoaringT(data[j], false)
 							})
 						}
 						err := eg.Wait()
@@ -2143,9 +2109,53 @@ func BenchmarkImportRoaringUpdateConcurrent(b *testing.B) {
 		}
 	}
 }
+func BenchmarkImportRoaringUpdateConcurrent(b *testing.B) {
+	if testing.Short() {
+		b.SkipNow()
+	}
+	for _, numRows := range rowCases {
+		for _, numCols := range colCases {
+			data := getZipfRowsSliceRoaring(numRows, 1, 0, ShardWidth)
+			updata := getUpdataRoaring(numRows, numCols, 1)
+			for _, concurrency := range concurrencyCases {
+				for _, cacheType := range cacheCases {
+					b.Run(fmt.Sprintf("Rows%dCols%dConcurrency%dCache_%s", numRows, numCols, concurrency, cacheType), func(b *testing.B) {
+						b.StopTimer()
+						frags := make([]*fragment, concurrency)
+						for i := 0; i < b.N; i++ {
+							for j := 0; j < concurrency; j++ {
+								frags[j] = mustOpenFragment("i", "f", viewStandard, uint64(j), cacheType)
+								err := frags[j].importRoaringT(data, false)
+								if err != nil {
+									b.Fatalf("importing roaring: %v", err)
+								}
+							}
+							eg := errgroup.Group{}
+							b.StartTimer()
+							for j := 0; j < concurrency; j++ {
+								j := j
+								eg.Go(func() error {
+									return frags[j].importRoaringT(updata, false)
+								})
+							}
+							err := eg.Wait()
+							if err != nil {
+								b.Errorf("importing fragment: %v", err)
+							}
+							b.StopTimer()
+							for j := 0; j < concurrency; j++ {
+								frags[j].Clean(b)
+							}
+						}
+					})
+				}
+			}
+		}
+	}
+}
 
 func BenchmarkImportStandard(b *testing.B) {
-	for _, cacheType := range []string{CacheTypeRanked} {
+	for _, cacheType := range cacheCases {
 		for _, numRows := range rowCases {
 			rowIDsOrig, columnIDsOrig := getZipfRowsSliceStandard(numRows, 1, 0, ShardWidth)
 			rowIDs, columnIDs := make([]uint64, len(rowIDsOrig)), make([]uint64, len(columnIDsOrig))
@@ -2171,17 +2181,17 @@ func BenchmarkImportStandard(b *testing.B) {
 func BenchmarkImportRoaringUpdate(b *testing.B) {
 	fileSize := make(map[string]int64)
 	names := []string{}
-	for _, cacheType := range []string{CacheTypeRanked} {
-		for _, numRows := range rowCases {
-			for _, numCols := range colCases {
-				data := getZipfRowsSliceRoaring(numRows, 1, 0, ShardWidth)
-				updata := getUpdataRoaring(numRows, numCols, 1)
-				name := fmt.Sprintf("%s%dRows%dCols", cacheType, numRows, numCols)
+	for _, numRows := range rowCases {
+		data := getZipfRowsSliceRoaring(numRows, 1, 0, ShardWidth)
+		for _, numCols := range colCases {
+			updata := getUpdataRoaring(numRows, numCols, 1)
+			for _, cacheType := range cacheCases {
+				name := fmt.Sprintf("Rows%dCols%dCache_%s", numRows, numCols, cacheType)
 				names = append(names, name)
 				b.Run(name, func(b *testing.B) {
 					b.StopTimer()
 					for i := 0; i < b.N; i++ {
-						f := mustOpenFragment("i", fmt.Sprintf("r%dc%s", numRows, cacheType), viewStandard, 0, cacheType)
+						f := mustOpenFragment("i", fmt.Sprintf("r%dc%dcache_%s", numRows, numCols, cacheType), viewStandard, 0, cacheType)
 						err := f.importRoaringT(data, false)
 						if err != nil {
 							b.Errorf("import error: %v", err)
@@ -2400,19 +2410,23 @@ func getUpdataRoaring(numRows, numCols uint64, seed int64) []byte {
 	return buf.Bytes()
 }
 
-func getUpdataInto(f func(row, col uint64) bool, numRows, numCols uint64, seed int64) (changed int) {
+func getUpdataInto(f func(row, col uint64) bool, numRows, numCols uint64, seed int64) int {
 	s := rand.NewSource(seed)
 	r := rand.New(s)
 	z := rand.NewZipf(r, 1.6, 50, numRows-1)
 
-	for i := uint64(0); i < numCols; i++ {
-		col := uint64(r.Int63n(ShardWidth)) // assuming the number of repeats will be negligible
+	i := uint64(0)
+	// ensure we get exactly the number we asked for. it turns out we had
+	// a horrible pathological edge case for exactly 10,000 entries in an
+	// imported bitmap, and hit it only occasionally...
+	for i < numCols {
+		col := uint64(r.Int63n(ShardWidth))
 		row := z.Uint64()
 		if f(row, col) {
-			changed++
+			i++
 		}
 	}
-	return changed
+	return int(i)
 }
 
 // getZipfRowsSliceStandard is the same as getZipfRowsSliceRoaring, but returns

--- a/index.go
+++ b/index.go
@@ -53,7 +53,8 @@ type Index struct {
 	broadcaster broadcaster
 	Stats       stats.StatsClient
 
-	logger logger.Logger
+	logger        logger.Logger
+	snapshotQueue chan *fragment
 }
 
 // NewIndex returns a new instance of Index.
@@ -408,6 +409,7 @@ func (i *Index) newField(path, name string) (*Field, error) {
 	f.Stats = i.Stats
 	f.broadcaster = i.broadcaster
 	f.rowAttrStore = i.newAttrStore(filepath.Join(f.path, ".data"))
+	f.snapshotQueue = i.snapshotQueue
 	return f, nil
 }
 

--- a/roaring/btree.go
+++ b/roaring/btree.go
@@ -894,7 +894,7 @@ func (e *enumerator) Next() (k uint64, v *Container, err error) {
 }
 
 // Every iterates over a tree.
-func (e *enumerator) Every(upd func(oldV *Container, exists bool) (newV *Container, write bool)) error {
+func (e *enumerator) Every(upd func(key uint64, oldV *Container, exists bool) (newV *Container, write bool)) error {
 	if err := e.err; err != nil {
 		return err
 	}
@@ -919,10 +919,10 @@ func (e *enumerator) Every(upd func(oldV *Container, exists bool) (newV *Contain
 		}
 
 		i := e.q.d[e.i]
-		nv, write := upd(i.v, true)
+		nv, write := upd(i.k, i.v, true)
 		if write {
 			if nv == nil {
-				e.t.Delete(e.q.d[e.i].k)
+				e.t.Delete(i.k)
 			} else {
 				e.q.d[e.i].v = nv
 			}

--- a/roaring/containers_btree.go
+++ b/roaring/containers_btree.go
@@ -99,6 +99,10 @@ func (btc *bTreeContainers) PutContainerValues(key uint64, typ byte, n int, mapp
 
 func (btc *bTreeContainers) Remove(key uint64) {
 	btc.tree.Delete(key)
+	if key == btc.lastKey {
+		btc.lastKey = ^uint64(0)
+		btc.lastContainer = nil
+	}
 }
 
 func (btc *bTreeContainers) GetOrCreate(key uint64) *Container {
@@ -185,6 +189,11 @@ func (btc *bTreeContainers) Reset() {
 	btc.lastContainer = nil
 }
 
+func (btc *bTreeContainers) ResetN(n int) {
+	// we ignore n because it's impractical to preallocate the tree
+	btc.Reset()
+}
+
 func (btc *bTreeContainers) Iterator(key uint64) (citer ContainerIterator, found bool) {
 	e, ok := btc.tree.Seek(key)
 	if ok {
@@ -215,7 +224,7 @@ func (btc *bTreeContainers) Update(key uint64, fn func(*Container, bool) (*Conta
 // UpdateEvery calls fn (existing-container, existed), and expects
 // (new-container, write). If write is true, the container is used to
 // replace the given container.
-func (btc *bTreeContainers) UpdateEvery(fn func(*Container, bool) (*Container, bool)) {
+func (btc *bTreeContainers) UpdateEvery(fn func(uint64, *Container, bool) (*Container, bool)) {
 	e, _ := btc.tree.Seek(0)
 	// currently not handling the error from this, but in practice it has
 	// to be io.EOF.

--- a/roaring/fuzz_test.go
+++ b/roaring/fuzz_test.go
@@ -24,7 +24,7 @@ func TestUnmarshalBinary(t *testing.T) {
 		expected string
 	}{
 		{ // Checks for the zero containers situation
-			cr:       []byte(":0\x000\x01\x00\x00\x000000"), //":000000"
+			cr:       []byte(":0\x00\x00\x01\x00\x00\x000000"), //":000000"
 			expected: "reading roaring header: malformed bitmap, key-cardinality slice overruns buffer at 12",
 		},
 		{ // Checks for int overflow
@@ -58,11 +58,11 @@ func TestUnmarshalBinary(t *testing.T) {
 			expected: "unmarshaling as pilosa roaring: malformed bitmap, key-cardinality not provided for 0 containers",
 		},
 		{ // Checks for incomplete offset in readWithRuns
-			cr:       []byte(";0\x000\v00000"), //";0000000"
+			cr:       []byte(";0\x00\x00\v00000"), //";0000000"
 			expected: "reading offsets from official roaring format: offset incomplete: len=10",
 		},
 		{ // Checks for incomplete offset in readOffsets
-			cr: []byte(":0\x000\x03\x00\x00\x00000000000000" +
+			cr: []byte(":0\x00\x00\x03\x00\x00\x00000000000000" +
 				"\x00"), //:0000000000000
 			expected: "reading offsets from official roaring format: offset incomplete: len=1",
 		},

--- a/roaring/fuzz_test.go
+++ b/roaring/fuzz_test.go
@@ -30,7 +30,7 @@ func TestUnmarshalBinary(t *testing.T) {
 		{ // Checks for int overflow
 			cr: []byte("<0\x000\x00\x00\x00\x00000000000000" +
 				"0"), //"<000000000000000"
-			expected: "unmarshaling as pilosa roaring: Maximum operation size exceeded",
+			expected: "unmarshaling as pilosa roaring: unknown op type: 48",
 		},
 		{ // The next 5 check for malformed bitmaps
 			cr: []byte("<0\x0000000000000000000" +

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1145,6 +1145,17 @@ type baseRoaringIterator struct {
 	lastErr           error
 }
 
+// okay, then
+func (b *baseRoaringIterator) SilenceLint() {
+	// these are actually used in pilosaRoaringIterator or officialRoaringIterator
+	// but structcheck doesn't know that
+	_ = b.data
+	_ = b.keys
+	_ = b.offsets
+	_ = b.headers
+	_ = b.currentIdx
+}
+
 type pilosaRoaringIterator struct {
 	baseRoaringIterator
 }
@@ -1416,8 +1427,7 @@ func (b *Bitmap) RemapRoaringStorage(data []byte) (mappedAny bool, returnErr err
 				if oldC.frozen() {
 					// we don't use Clone, because that would copy the
 					// storage, and we don't need that.
-					var halfCopy Container
-					halfCopy = *oldC
+					halfCopy := *oldC
 					halfCopy.flags &^= flagFrozen
 					newC = &halfCopy
 				} else {

--- a/view.go
+++ b/view.go
@@ -52,10 +52,11 @@ type view struct {
 	// Fragments by shard.
 	fragments map[uint64]*fragment
 
-	broadcaster  broadcaster
-	stats        stats.StatsClient
-	rowAttrStore AttrStore
-	logger       logger.Logger
+	broadcaster   broadcaster
+	stats         stats.StatsClient
+	rowAttrStore  AttrStore
+	logger        logger.Logger
+	snapshotQueue chan *fragment
 }
 
 // newView returns a new instance of View.
@@ -268,6 +269,7 @@ func (v *view) newFragment(path string, shard uint64) *fragment {
 	frag.CacheSize = v.cacheSize
 	frag.Logger = v.logger
 	frag.stats = v.stats
+	frag.snapshotQueue = v.snapshotQueue
 	if v.fieldType == FieldTypeMutex {
 		frag.mutexVector = newRowsVector(frag)
 	} else if v.fieldType == FieldTypeBool {

--- a/view.go
+++ b/view.go
@@ -441,11 +441,11 @@ func upgradeViewBSIv2(v *view, bitDepth uint) (ok bool, _ error) {
 
 		if tmpPath, err := upgradeRoaringBSIv2(frag, bitDepth); err != nil {
 			return ok, errors.Wrap(err, "upgrading bsi v2")
-		} else if err := frag.closeStorage(); err != nil {
+		} else if err := frag.closeStorage(true); err != nil {
 			return ok, errors.Wrap(err, "closing after bsi v2 upgrade")
 		} else if err := os.Rename(tmpPath, frag.path); err != nil {
 			return ok, errors.Wrap(err, "renaming after bsi v2 upgrade")
-		} else if err := frag.openStorage(); err != nil {
+		} else if err := frag.openStorage(true); err != nil {
 			return ok, errors.Wrap(err, "re-opening after bsi v2 upgrade")
 		}
 	}


### PR DESCRIPTION
## Overview

Various roaring/unmarshalling/memory-mapping/etc stuff.

This is an attempt to address a series of issues related to the performance of importRoaring.

In no particular order:
* We allow roaring import as Add and Remove operations in the ops log. This lets us write many more bits of ops log much more quickly.
* We use that import/export functionality also to implement importRoaring itself. In the process, we get rid of the CountRange things used to rebuild the cache, since we can determine the number of bits added or removed from a row nearly as cheaply as we can determine whether or not any bits changed.
* When reopening storage, instead of unmarshalling a new bitmap and ditching all the existing containers, we iterate through updating the pointers of containers that match the characteristics of the just-written data to point to the storage, and marking them as mapped. Any mapped containers that don't match get their data copied, so any previous data can be unmapped safely.
* We add a snapshot queue. Under heavy load, this will allow many more than 10k bits of write ops to get dumped into an ops log before a snapshot happens. Under very light load, it will result in writing the ops log, then producing a new snapshot, which slows things down, but that's only under very light load. Under heavy load, performance improves a bunch.
* The various tests, especially in fragment_internal_test, now verify on cleanup of a fragment that the on-disk representation matches the in-memory representation. This is expensive and slow but provides higher confidence that all the rest of this actually works as planned.

Tagging Ben because of the most recent patch -- when I added official roaring support to this, I noticed that our implementation is masking out some of the container-count bits from official roaring files that have run containers. I think this change is safe but I would like a second opinion on my reasoning about not needing the flag bits.