### PR TITLE
Worker pool

### DIFF
--- a/server.go
+++ b/server.go
@@ -426,6 +426,8 @@ func (s *Server) Open() error {
 
 // Close closes the server and waits for it to shutdown.
 func (s *Server) Close() error {
+	errE := s.executor.Close()
+
 	// Notify goroutines to stop.
 	close(s.closing)
 	s.wg.Wait()
@@ -445,7 +447,11 @@ func (s *Server) Close() error {
 	if errh != nil {
 		return errors.Wrap(errh, "closing holder")
 	}
-	return errors.Wrap(errc, "closing cluster")
+	if errc != nil {
+		return errors.Wrap(errc, "closing cluster")
+	}
+	return errors.Wrap(errE, "closing executor")
+
 }
 
 // loadNodeID gets NodeID from disk, or creates a new value.

--- a/server/config.go
+++ b/server/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -84,6 +85,13 @@ type Config struct {
 
 	// TLS
 	TLS TLSConfig `toml:"tls"`
+
+	// WorkerPoolSize controls how many goroutines are created for
+	// processing queries. Defaults to runtime.NumCPU(). It is
+	// intentionally not defined as a flag... only exposed here so
+	// that we can limit the size while running tests in CI so we
+	// don't exhaust the goroutine limit.
+	WorkerPoolSize int
 
 	Cluster struct {
 		// Disabled controls whether clustering functionality is enabled.
@@ -151,7 +159,10 @@ func NewConfig() *Config {
 		// a bit below your system limits.
 		MaxMapCount:  1000000,
 		MaxFileCount: 1000000,
-		TLS:          TLSConfig{},
+
+		TLS: TLSConfig{},
+
+		WorkerPoolSize: runtime.NumCPU(),
 	}
 
 	// Cluster config.

--- a/server/server.go
+++ b/server/server.go
@@ -284,6 +284,7 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerMaxWritesPerRequest(m.Config.MaxWritesPerRequest),
 		pilosa.OptServerMetricInterval(time.Duration(m.Config.Metric.PollInterval)),
 		pilosa.OptServerDiagnosticsInterval(diagnosticsInterval),
+		pilosa.OptServerExecutorPoolSize(m.Config.WorkerPoolSize),
 
 		pilosa.OptServerLogger(m.logger),
 		pilosa.OptServerAttrStoreFunc(boltdb.NewAttrStore),

--- a/test/pilosa.go
+++ b/test/pilosa.go
@@ -72,6 +72,7 @@ func newCommand(opts ...server.CommandOption) *Command {
 	m.Config.Bind = "http://localhost:0"
 	m.Config.Cluster.Disabled = true
 	m.Config.Translation.MapSize = 140000
+	m.Config.WorkerPoolSize = 2
 
 	if testing.Verbose() {
 		m.Command.Stdout = os.Stdout


### PR DESCRIPTION
## Overview

    add worker pool to executor for local query processing

    Pilosa previously spawned a goroutine for each remote node that a
    query needed to be forwarded to, and then forwarded a single request
    containing all the shards that the query should operate on. It then
    spawned a goroutine *per local shard* to process the query
    locally. This was fine if there weren't too many shards, or too many
    queries coming in concurrently, but we found that it created issues
    when there were 100s or 1000s of shards per node, and dozens of
    queries arriving concurrently.

    Specifically, the memberlist "hiccup" issue is highly correlated with
    many goroutine scenarios, and after applying this patch, memberlist
    complaints in the logs were much decreased, and nodeLeave events under
    concurrent query load almost entirely eliminated.

    This patch creates a fixed size pool of goroutines to do local shard
    processing, and passes work to them through a channel, one job per
    query per shard. Handling of remote requests (forwarding queries) is
    unchanged.

    We set the pool size to NumCPU()+8 somewhat arbitrarily, but this
    seemed to work pretty well in our testing on 32 core machines. It's a
    pretty big improvement over launching a goroutine per shard per query
    which is what we were doing previously, so we can tune it more later
    if necessary.

I think I still need to add some kind of executor.Close() method to make sure we aren't leaking goroutines in tests.

Naming is totally up for debate.

Capacity of channels and number of workers hasn't been super well scienced, but probably won't make much of a difference.


Fixes #1969 (probably)

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
