### PR TITLE
avoid copying but give us a one-snapshot safety margin

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -3981,6 +3981,11 @@ func runCallTest(t *testing.T, writeQuery string, readQueries []string, indexOpt
 		if err != nil {
 			t.Fatal(err)
 		}
+		// because we want to keep rows around for a while, we need to clone them;
+		// normal rows can become invalidated by snapshots.
+		if r, ok := res.Results[0].(*pilosa.Row); ok {
+			r.Clone()
+		}
 		responses = append(responses, res)
 	}
 

--- a/fragment_internal_test.go
+++ b/fragment_internal_test.go
@@ -134,7 +134,9 @@ func TestFragment_RowcacheMap(t *testing.T) {
 
 	// modify the original bitmap, until it causes a snapshot, which
 	// then invalidates the other map...
-	for j := 0; j < 5; j++ {
+	// but only try this once, because our current design gives us one
+	// snapshot of safety margin.
+	for j := 0; j < 1; j++ {
 		for i := 0; i < f.MaxOpN; i++ {
 			_, _ = f.setBit(0, uint64(i*32+j+1))
 		}

--- a/roaring/container_stash.go
+++ b/roaring/container_stash.go
@@ -256,20 +256,11 @@ func (c *Container) setMapped(mapped bool) {
 }
 
 // Freeze returns an unmodifiable container identical to c. This might
-// be c, now marked unmodifiable, or might be a new container. If c
-// is currently marked as "mapped", referring to a backing store that's
-// not a conventional Go pointer, the storage may be copied.
+// be c, now marked unmodifiable, or might be a new container.
 func (c *Container) Freeze() *Container {
 	if c == nil {
 		return nil
 	}
-	// don't need to freeze
-	if c.flags&flagFrozen != 0 {
-		return c
-	}
-	// unmapOrClone should unmap-in-place because the existing
-	// container isn't frozen (or we'd already have returned it).
-	c = c.unmapOrClone()
 	c.flags |= flagFrozen
 	return c
 }

--- a/row.go
+++ b/row.go
@@ -156,21 +156,48 @@ func (r *Row) Xor(other *Row) *Row {
 }
 
 // Union returns the bitwise union of r and other.
-func (r *Row) Union(other *Row) *Row {
-	var segments []rowSegment
-	itr := newMergeSegmentIterator(r.segments, other.segments)
-	for s0, s1 := itr.next(); s0 != nil || s1 != nil; s0, s1 = itr.next() {
-		if s1 == nil {
-			segments = append(segments, *s0)
-			continue
-		} else if s0 == nil {
-			segments = append(segments, *s1)
-			continue
-		}
-		segments = append(segments, *s0.Union(s1))
+func (r *Row) Union(others ...*Row) *Row {
+	segments := make([][]rowSegment, 0, len(others)+1)
+	if len(r.segments) > 0 {
+		segments = append(segments, r.segments)
 	}
-
-	return &Row{segments: segments}
+	nextSegs := make([][]rowSegment, 0, len(others)+1)
+	toProcess := make([]*rowSegment, 0, len(others)+1)
+	var output []rowSegment
+	for _, other := range others {
+		if len(other.segments) > 0 {
+			segments = append(segments, other.segments)
+		}
+	}
+	for len(segments) > 0 {
+		shard := segments[0][0].shard
+		for _, segs := range segments {
+			if segs[0].shard < shard {
+				shard = segs[0].shard
+			}
+		}
+		nextSegs = nextSegs[:0]
+		toProcess := toProcess[:0]
+		for _, segs := range segments {
+			if segs[0].shard == shard {
+				toProcess = append(toProcess, &segs[0])
+				segs = segs[1:]
+			}
+			if len(segs) > 0 {
+				nextSegs = append(nextSegs, segs)
+			}
+		}
+		// at this point, "toProcess" is a list of all the segments
+		// sharing the lowest ID, and nextSegs is a list of all the others.
+		// Swap the segment lists (so we don't have to reallocate it)
+		segments, nextSegs = nextSegs, segments
+		if len(toProcess) == 1 {
+			output = append(output, *toProcess[0])
+		} else {
+			output = append(output, *toProcess[0].Union(toProcess[1:]...))
+		}
+	}
+	return &Row{segments: output}
 }
 
 // Difference returns the diff of r and other.
@@ -360,8 +387,12 @@ func (s *rowSegment) Intersect(other *rowSegment) *rowSegment {
 }
 
 // Union returns the bitwise union of s and other.
-func (s *rowSegment) Union(other *rowSegment) *rowSegment {
-	data := s.data.Union(other.data)
+func (s *rowSegment) Union(others ...*rowSegment) *rowSegment {
+	datas := make([]*roaring.Bitmap, len(others))
+	for i, other := range others {
+		datas[i] = other.data
+	}
+	data := s.data.Union(datas...)
 	data.Freeze()
 
 	return &rowSegment{

--- a/row.go
+++ b/row.go
@@ -63,6 +63,12 @@ func (r *Row) Freeze() {
 	}
 }
 
+func (r *Row) Clone() {
+	for _, s := range r.segments {
+		s.Clone()
+	}
+}
+
 // Merge merges data from other into r.
 func (r *Row) Merge(other *Row) {
 	var segments []rowSegment
@@ -318,6 +324,10 @@ type rowSegment struct {
 
 func (s *rowSegment) Freeze() {
 	s.data.Freeze()
+}
+
+func (s *rowSegment) Clone() {
+	s.data = s.data.Clone()
 }
 
 // Merge adds chunks from other to s.


### PR DESCRIPTION
Copying data on row fetch is insanely expensive and breaks
things under heavy load.

Not copying data on row fetch means that if something is still
using a rowcache entry with mmapped storage when we unmap the
storage, that's a segfault.

What if we unmapped things *one snapshot later*, thus, giving
any queries in flight the interval between snapshots to
complete?

## Overview

honestly the branch name speaks for itself