### PR TITLE
Add a worker pool for importRoaring jobs

### DIFF
--- a/api.go
+++ b/api.go
@@ -42,6 +42,9 @@ type API struct {
 	cluster *cluster
 	server  *Server
 
+	importWorkerPoolSize int
+	importWork           chan importJob
+
 	Serializer Serializer
 }
 
@@ -58,9 +61,18 @@ func OptAPIServer(s *Server) apiOption {
 	}
 }
 
+func OptAPIImportWorkerPoolSize(size int) apiOption {
+	return func(a *API) error {
+		a.importWorkerPoolSize = size
+		return nil
+	}
+}
+
 // NewAPI returns a new API instance.
 func NewAPI(opts ...apiOption) (*API, error) {
-	api := &API{}
+	api := &API{
+		importWorkerPoolSize: 2,
+	}
 
 	for _, opt := range opts {
 		err := opt(api)
@@ -68,6 +80,14 @@ func NewAPI(opts ...apiOption) (*API, error) {
 			return nil, errors.Wrap(err, "applying option")
 		}
 	}
+
+	api.importWork = make(chan importJob, api.importWorkerPoolSize)
+	for i := 0; i < api.importWorkerPoolSize; i++ {
+		go func() {
+			importWorker(api.importWork)
+		}()
+	}
+
 	return api, nil
 }
 
@@ -271,6 +291,51 @@ func setUpImportOptions(opts ...ImportOption) (*ImportOptions, error) {
 	return options, nil
 }
 
+type importJob struct {
+	ctx     context.Context
+	req     *ImportRoaringRequest
+	shard   uint64
+	field   *Field
+	errChan chan error
+}
+
+func importWorker(importWork chan importJob) {
+	for j := range importWork {
+		err := func() error {
+			for viewName, viewData := range j.req.Views {
+				if viewName == "" {
+					viewName = viewStandard
+				} else {
+					viewName = fmt.Sprintf("%s_%s", viewStandard, viewName)
+				}
+				if len(viewData) == 0 {
+					return fmt.Errorf("no data to import for view: %s", viewName)
+				}
+				fileMagic := uint32(binary.LittleEndian.Uint16(viewData[0:2]))
+				if fileMagic == roaring.MagicNumber { // if pilosa roaring format
+					if err := j.field.importRoaring(j.ctx, viewData, j.shard, viewName, j.req.Clear); err != nil {
+						return errors.Wrap(err, "importing pilosa roaring")
+					}
+				} else {
+					// must make a copy of data to operate on locally on standard roaring format.
+					// field.importRoaring changes the standard roaring run format to pilosa roaring
+					data := make([]byte, len(viewData))
+					copy(data, viewData)
+					if err := j.field.importRoaring(j.ctx, data, j.shard, viewName, j.req.Clear); err != nil {
+						return errors.Wrap(err, "importing standard roaring")
+					}
+				}
+			}
+			return nil
+		}()
+
+		select {
+		case <-j.ctx.Done():
+		case j.errChan <- err:
+		}
+	}
+}
+
 // ImportRoaring is a low level interface for importing data to Pilosa when
 // extremely high throughput is desired. The data must be encoded in a
 // particular way which may be unintuitive (discussed below). The data is merged
@@ -298,7 +363,6 @@ func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, 
 	}
 
 	nodes := api.cluster.shardNodes(indexName, shard)
-	var eg errgroup.Group
 
 	field := api.holder.Field(indexName, fieldName)
 	if field == nil {
@@ -310,48 +374,45 @@ func (api *API) ImportRoaring(ctx context.Context, indexName, fieldName string, 
 		return NewBadRequestError(errors.New("roaring import is only supported for set and time fields"))
 	}
 
+	errCh := make(chan error, len(nodes))
+
 	for _, node := range nodes {
 		node := node
 		if node.ID == api.server.nodeID {
-			eg.Go(func() error {
-				var err error
-				for viewName, viewData := range req.Views {
-					if viewName == "" {
-						viewName = viewStandard
-					} else {
-						viewName = fmt.Sprintf("%s_%s", viewStandard, viewName)
-					}
-					if len(viewData) == 0 {
-						return fmt.Errorf("no data to import for view: %s", viewName)
-					}
-					fileMagic := uint32(binary.LittleEndian.Uint16(viewData[0:2]))
-					if fileMagic == roaring.MagicNumber { // if pilosa roaring format
-						err = field.importRoaring(ctx, viewData, shard, viewName, req.Clear)
-						if err != nil {
-							return errors.Wrap(err, "importing pilosa roaring")
-						}
-
-					} else {
-						// must make a copy of data to operate on locally on standard roaring format.
-						// field.importRoaring changes the standard roaring run format to pilosa roaring
-						data := make([]byte, len(viewData))
-						copy(data, viewData)
-						err = field.importRoaring(ctx, data, shard, viewName, req.Clear)
-						if err != nil {
-							return errors.Wrap(err, "importing standard roaring")
-						}
-					}
-				}
-				return err
-			})
+			api.importWork <- importJob{
+				ctx:     ctx,
+				req:     req,
+				shard:   shard,
+				field:   field,
+				errChan: errCh,
+			}
 		} else if !remote { // if remote == true we don't forward to other nodes
 			// forward it on
-			eg.Go(func() error {
-				return api.server.defaultClient.ImportRoaring(ctx, &node.URI, indexName, fieldName, shard, true, req)
-			})
+			go func() {
+				errCh <- api.server.defaultClient.ImportRoaring(ctx, &node.URI, indexName, fieldName, shard, true, req)
+			}()
+		} else {
+			errCh <- nil
 		}
 	}
-	return eg.Wait()
+
+	var maxNode int
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case nodeErr := <-errCh:
+			if nodeErr != nil {
+				return nodeErr
+			}
+			maxNode++
+		}
+
+		// Exit once all nodes are processed.
+		if maxNode == len(nodes) {
+			return nil
+		}
+	}
 }
 
 // DeleteField removes the named field from the named index. If the index is not

--- a/server/config.go
+++ b/server/config.go
@@ -93,6 +93,13 @@ type Config struct {
 	// don't exhaust the goroutine limit.
 	WorkerPoolSize int
 
+	// ImportWorkerPoolSize controls how many goroutines are created for
+	// processing importRoaring jobs. Defaults to runtime.NumCPU(). It is
+	// intentionally not defined as a flag... only exposed here so
+	// that we can limit the size while running tests in CI so we
+	// don't exhaust the goroutine limit.
+	ImportWorkerPoolSize int
+
 	Cluster struct {
 		// Disabled controls whether clustering functionality is enabled.
 		Disabled    bool     `toml:"disabled"`
@@ -162,7 +169,8 @@ func NewConfig() *Config {
 
 		TLS: TLSConfig{},
 
-		WorkerPoolSize: runtime.NumCPU(),
+		WorkerPoolSize:       runtime.NumCPU(),
+		ImportWorkerPoolSize: runtime.NumCPU(),
 	}
 
 	// Cluster config.

--- a/server/server.go
+++ b/server/server.go
@@ -378,6 +378,7 @@ func (m *Command) Close() error {
 	eg := errgroup.Group{}
 	eg.Go(m.Handler.Close)
 	eg.Go(m.Server.Close)
+	eg.Go(m.API.Close)
 	if m.gossipMemberSet != nil {
 		eg.Go(m.gossipMemberSet.Close)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -285,7 +285,6 @@ func (m *Command) SetupServer() error {
 		pilosa.OptServerMetricInterval(time.Duration(m.Config.Metric.PollInterval)),
 		pilosa.OptServerDiagnosticsInterval(diagnosticsInterval),
 		pilosa.OptServerExecutorPoolSize(m.Config.WorkerPoolSize),
-
 		pilosa.OptServerLogger(m.logger),
 		pilosa.OptServerAttrStoreFunc(boltdb.NewAttrStore),
 		pilosa.OptServerSystemInfo(gopsutil.NewSystemInfo()),
@@ -315,7 +314,10 @@ func (m *Command) SetupServer() error {
 		return errors.Wrap(err, "new server")
 	}
 
-	m.API, err = pilosa.NewAPI(pilosa.OptAPIServer(m.Server))
+	m.API, err = pilosa.NewAPI(
+		pilosa.OptAPIServer(m.Server),
+		pilosa.OptAPIImportWorkerPoolSize(m.Config.ImportWorkerPoolSize),
+	)
 	if err != nil {
 		return errors.Wrap(err, "new api")
 	}


### PR DESCRIPTION
## Overview

This PR adds a worker pool to handle `importRoaring` jobs.
I'm not sure if having this as part of `API` is correct. Because `API` isn't really thought of as a running object (and doesn't have anything like `close()`) there may be a problem with closing this out while jobs are in flight.

Fixes #2047 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [x] All new and existing tests pass.
- [x] Make sure PR title conforms to convention in CHANGELOG.md.
- [x] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
