### PR TITLE
Default BSI base value to min, max, or 0 depending on the min/max range

### DIFF
--- a/field.go
+++ b/field.go
@@ -143,15 +143,7 @@ func OptFieldTypeInt(min, max int64) FieldOption {
 		fo.Type = FieldTypeInt
 		fo.Min = min
 		fo.Max = max
-		// Base is not exposed as a field option argument.
-		// It defaults to min, max, or 0 depending on the min/max range.
-		if min > 0 {
-			fo.Base = min
-		} else if max < 0 {
-			fo.Base = max
-		} else {
-			fo.Base = 0
-		}
+		fo.Base = bsiBase(min, max)
 		return nil
 	}
 }
@@ -508,13 +500,7 @@ func (f *Field) loadMeta() error {
 
 	// Initialize "base" to "min" when upgrading from v1 BSI format.
 	if pb.BitDepth == 0 {
-		if pb.Min > 0 {
-			pb.Base = pb.Min
-		} else if pb.Max < 0 {
-			pb.Base = pb.Max
-		} else {
-			pb.Base = 0
-		}
+		pb.Base = bsiBase(pb.Min, pb.Max)
 		pb.BitDepth = uint64(bitDepthInt64(pb.Max - pb.Min))
 		if pb.BitDepth == 0 {
 			pb.BitDepth = 1
@@ -1514,6 +1500,18 @@ func isValidBSIGroupType(v string) bool {
 	default:
 		return false
 	}
+}
+
+// bsiBase is a helper function used to determine the default value
+// for base. Because base is not exposed as a field option argument,
+// it defaults to min, max, or 0 depending on the min/max range.
+func bsiBase(min, max int64) int64 {
+	if min > 0 {
+		return min
+	} else if max < 0 {
+		return max
+	}
+	return 0
 }
 
 // bsiGroup represents a group of range-encoded rows on a field.

--- a/field.go
+++ b/field.go
@@ -508,7 +508,13 @@ func (f *Field) loadMeta() error {
 
 	// Initialize "base" to "min" when upgrading from v1 BSI format.
 	if pb.BitDepth == 0 {
-		pb.Base = pb.Min
+		if pb.Min > 0 {
+			pb.Base = pb.Min
+		} else if pb.Max < 0 {
+			pb.Base = pb.Max
+		} else {
+			pb.Base = 0
+		}
 		pb.BitDepth = uint64(bitDepthInt64(pb.Max - pb.Min))
 		if pb.BitDepth == 0 {
 			pb.BitDepth = 1

--- a/field.go
+++ b/field.go
@@ -143,6 +143,15 @@ func OptFieldTypeInt(min, max int64) FieldOption {
 		fo.Type = FieldTypeInt
 		fo.Min = min
 		fo.Max = max
+		// Base is not exposed as a field option argument.
+		// It defaults to min, max, or 0 depending on the min/max range.
+		if min > 0 {
+			fo.Base = min
+		} else if max < 0 {
+			fo.Base = max
+		} else {
+			fo.Base = 0
+		}
 		return nil
 	}
 }

--- a/field_internal_test.go
+++ b/field_internal_test.go
@@ -412,3 +412,29 @@ func TestField_PersistAvailableShardsFootprint(t *testing.T) {
 	}
 
 }
+
+// Ensure that FieldOptions.Base defaults to the correct value.
+func TestBSIGroup_BaseDefaultValue(t *testing.T) {
+	for i, tt := range []struct {
+		min     int64
+		max     int64
+		expBase int64
+	}{
+		{100, 200, 100},
+		{-100, 100, 0},
+		{-200, -100, -100},
+	} {
+		fn := OptFieldTypeInt(tt.min, tt.max)
+
+		// Apply functional option.
+		fo := FieldOptions{}
+		err := fn(&fo)
+		if err != nil {
+			t.Fatalf("test %d, applying functional option: %s", i, err.Error())
+		}
+
+		if fo.Base != tt.expBase {
+			t.Fatalf("test %d, unexpected FieldOptions.Base value. expected: %d, but got: %d", i, tt.expBase, fo.Base)
+		}
+	}
+}


### PR DESCRIPTION
## Overview

The BSI base value determined by `FieldOptions.Base` was defaulting to 0 (except in cases of migration from v1 of BSI). This PR changes the logic to set the `base` to either min, max, or 0 depending on the range of min/max.

Fixes #2013 

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.
- [x] Make sure PR title conforms to convention in CHANGELOG.md.
- [x] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
