### PR TITLE
use labeled targets for break statements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     <<: *defaults
     steps:
       - *fast-checkout
-      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.18.0
+      - run: curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s v1.20.0
       - run: sudo cp bin/golangci-lint /usr/local/bin/
       - run: make golangci-lint
   test-build-arm:

--- a/field.go
+++ b/field.go
@@ -468,10 +468,11 @@ func (f *Field) openViews() error {
 	eg, ctx := errgroup.WithContext(context.Background())
 	var mu sync.Mutex
 
+fileLoop:
 	for _, loopFi := range fis {
 		select {
 		case <-ctx.Done():
-			break
+			break fileLoop
 		default:
 			fi := loopFi
 			if !fi.IsDir() {

--- a/index.go
+++ b/index.go
@@ -174,10 +174,11 @@ func (i *Index) openFields() error {
 	eg, ctx := errgroup.WithContext(context.Background())
 	var mu sync.Mutex
 
+fileLoop:
 	for _, loopFi := range fis {
 		select {
 		case <-ctx.Done():
-			break
+			break fileLoop
 		default:
 			fi := loopFi
 			if !fi.IsDir() {

--- a/roaring/btree.go
+++ b/roaring/btree.go
@@ -67,6 +67,7 @@ func (p *btEpool) get(err error, hit bool, i int, k uint64, q *d, t *tree, ver i
 
 type (
 	d struct { // data page
+		//nolint:unused
 		dTree //lint:ignore U1000 this is conditional on a build flag
 		c     int
 		d     [2*kd + 1]de
@@ -99,6 +100,7 @@ type (
 
 	// tree is a B+tree.
 	tree struct {
+		//nolint:unused
 		treeInst //lint:ignore U1000 this is conditional on a build flag
 		c        int
 		first    *d

--- a/roaring/nop_inst.go
+++ b/roaring/nop_inst.go
@@ -17,10 +17,12 @@
 package roaring
 
 //lint:ignore U1000 this is conditional on a build flag
+//nolint:unused
 type dTree struct {
 }
 
 //lint:ignore U1000 this is conditional on a build flag
+//nolint:unused
 type treeInst struct {
 }
 

--- a/translate.go
+++ b/translate.go
@@ -301,7 +301,7 @@ func (s *InMemTranslateStore) TranslateIDs(ids []uint64) ([]string, error) {
 }
 
 func (s *InMemTranslateStore) translateID(id uint64) string {
-	if id <= 0 || id > uint64(len(s.keys)) {
+	if id == 0 || id > uint64(len(s.keys)) {
 		return ""
 	}
 	return s.keys[id-1]

--- a/view.go
+++ b/view.go
@@ -134,10 +134,11 @@ func (v *view) openFragments() error {
 	eg, ctx := errgroup.WithContext(context.Background())
 	var mu sync.Mutex
 
+fileLoop:
 	for _, loopFi := range fis {
 		select {
 		case <-ctx.Done():
-			break
+			break fileLoop
 		default:
 			fi := loopFi
 
@@ -181,10 +182,11 @@ func (v *view) close() error {
 
 	// Close all fragments.
 	eg, ctx := errgroup.WithContext(context.Background())
+fragLoop:
 	for _, loopFrag := range v.fragments {
 		select {
 		case <-ctx.Done():
-			break
+			break fragLoop
 		default:
 			frag := loopFrag
 			workQueue <- struct{}{}


### PR DESCRIPTION
break in a select in a for terminates the current case of the
select, but does not terminate the for loop. The worker queue
implementations for opening indexes/fields/views all suffered
from the same issue here.

Also fix a `<= 0` on a uint value.

All hail staticcheck.
