### PR TITLE
truncate corrupt ops logs

### DIFF
--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1626,6 +1626,7 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 
 	// Read ops log until the end of the file.
 	buf := data[opsOffset:]
+	goodOffset := opsOffset
 	for {
 		// Exit when there are no more ops to parse.
 		if len(buf) == 0 {
@@ -1635,8 +1636,8 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 		// Unmarshal the op and apply it.
 		var opr op
 		if err := opr.UnmarshalBinary(buf); err != nil {
-			// FIXME(benbjohnson): return error with position so file can be trimmed.
-			return err
+			// return error with position so file can be trimmed.
+			return FileCorruptionError{err: err, TrimTo: goodOffset}
 		}
 
 		opr.apply(b)
@@ -1646,10 +1647,28 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 		b.opN += opr.count()
 
 		// Move the buffer forward.
+		goodOffset += opr.size()
 		buf = buf[opr.size():]
 	}
 
+	// NOTE: calling code for this method assumes that if a
+	// FileCorruptionError is returned that the work is complete up to
+	// that point, and the Bitmap is usable. If it becomes necessary
+	// to add any cleanup or finalization logic down here, we'll need
+	// to rethink that assumption. This particularly matters in
+	// Pilosa's fragment.go where it calls UnmarshalBinary and then
+	// checks to see if the error is a FileCorruption error.
+
 	return nil
+}
+
+type FileCorruptionError struct {
+	err    error
+	TrimTo int
+}
+
+func (f FileCorruptionError) Error() string {
+	return f.err.Error()
 }
 
 // writeOp writes op to the OpWriter, if available.


### PR DESCRIPTION
## Overview

Needs testing. I tested this manually by appending a small amount of data to an existing fragment file and then starting Pilosa. Pilosa was able to start normally and truncated the file to the correct location.

## Pull request checklist

- [ ] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [ ] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [ ] I have resolved any merge conflicts.
- [ ] I have included tests that cover my changes.
- [ ] All new and existing tests pass.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
