### PR TITLE
Truncate bad ops logs

### DIFF
--- a/holder_test.go
+++ b/holder_test.go
@@ -197,7 +197,26 @@ func TestHolder_Open(t *testing.T) {
 			t.Fatalf("unexpected error: %s", err)
 		}
 	})
+	t.Run("ErrFragmentStorageRecoverable", func(t *testing.T) {
+		h := test.MustOpenHolder()
+		defer h.Close()
 
+		if idx, err := h.CreateIndex("foo", pilosa.IndexOptions{}); err != nil {
+			t.Fatal(err)
+		} else if field, err := idx.CreateField("bar", pilosa.OptFieldTypeDefault()); err != nil {
+			t.Fatal(err)
+		} else if _, err := field.SetBit(0, 0, nil); err != nil {
+			t.Fatal(err)
+		} else if err := h.Holder.Close(); err != nil {
+			t.Fatal(err)
+		} else if err := os.Truncate(filepath.Join(h.Path, "foo", "bar", "views", "standard", "fragments", "0"), 20); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := h.Reopen(); err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+	})
 }
 
 func TestHolder_HasData(t *testing.T) {

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1637,7 +1637,7 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 		var opr op
 		if err := opr.UnmarshalBinary(buf); err != nil {
 			// return error with position so file can be trimmed.
-			return FileCorruptionError{err: err, TrimTo: goodOffset}
+			return FileCorruptionError{err: err, TrimTo: int64(goodOffset)}
 		}
 
 		opr.apply(b)
@@ -1664,7 +1664,7 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 
 type FileCorruptionError struct {
 	err    error
-	TrimTo int
+	TrimTo int64
 }
 
 func (f FileCorruptionError) Error() string {

--- a/roaring/roaring.go
+++ b/roaring/roaring.go
@@ -1626,6 +1626,7 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 
 	// Read ops log until the end of the file.
 	buf := data[opsOffset:]
+	goodOffset := opsOffset
 	for {
 		// Exit when there are no more ops to parse.
 		if len(buf) == 0 {
@@ -1635,8 +1636,8 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 		// Unmarshal the op and apply it.
 		var opr op
 		if err := opr.UnmarshalBinary(buf); err != nil {
-			// FIXME(benbjohnson): return error with position so file can be trimmed.
-			return err
+			// return error with position so file can be trimmed.
+			return FileCorruptionError{err: err, TrimTo: goodOffset}
 		}
 
 		opr.apply(b)
@@ -1646,10 +1647,28 @@ func (b *Bitmap) unmarshalPilosaRoaring(data []byte) error {
 		b.opN += opr.count()
 
 		// Move the buffer forward.
+		goodOffset += opr.size()
 		buf = buf[opr.size():]
 	}
 
+	// NOTE: calling code for this method assumes that if a
+	// FileCorruptionError is returned that the work is complete up to
+	// that point, and the Bitmap is usable. If it becomes necessary
+	// to add any cleanup or finalization logic down here, we'll need
+	// to rethink that assumption. This particularly matters in
+	// Pilosa's fragment.go where it calls UnmarshalBinary and then
+	// checks to see if the error is a FileCorruption error.
+
 	return nil
+}
+
+type FileCorruptionError struct {
+	err    error
+	TrimTo int
+}
+
+func (f FileCorruptionError) Error() string {
+	return f.err.Error()
 }
 
 // writeOp writes op to the OpWriter, if available.


### PR DESCRIPTION
This is a revised version of jaffee's previous pull, it adds the actual code to do the reopen after truncating, and also a test case to verify that it seems to work.