### PR TITLE
fix typo in error check

### DIFF
--- a/fragment.go
+++ b/fragment.go
@@ -406,7 +406,7 @@ func (f *fragment) openStorage(unmarshalData bool) error {
 		if err := f.storage.UnmarshalBinary(data); err != nil {
 			cause := errors.Cause(err)
 			if corruptionErr, ok := cause.(roaring.FileCorruptionError); ok {
-				if terr := f.file.Truncate(corruptionErr.TrimTo); err != nil {
+				if terr := f.file.Truncate(corruptionErr.TrimTo); terr != nil {
 					// close file so we don't try to use it later.
 					_ = f.safeClose()
 					return errors.Wrapf(terr, "truncating file after corrupt unmarshal: %v", err)


### PR DESCRIPTION
I am impressed that we missed this.

The reason this didn't cause weirder and earlier failures is that `errors.Wrapf` is getting the nil `terr` as its first argument, and thus returning a nil. We wanted to check the inner error, which got a distinct name because we want to keep the other error variable to report the original problem.