### PR TITLE
Fix cacheSize when cacheType is none (and cacheSize is 0)

### DIFF
--- a/field.go
+++ b/field.go
@@ -596,12 +596,10 @@ func (f *Field) applyOptions(opt FieldOptions) error {
 		if opt.CacheType != "" {
 			f.options.CacheType = opt.CacheType
 		}
-		if opt.CacheSize != 0 {
-			if opt.CacheType == CacheTypeNone {
-				f.options.CacheSize = 0
-			} else {
-				f.options.CacheSize = opt.CacheSize
-			}
+		if opt.CacheType == CacheTypeNone {
+			f.options.CacheSize = 0
+		} else if opt.CacheSize != 0 {
+			f.options.CacheSize = opt.CacheSize
 		}
 		f.options.Min = 0
 		f.options.Max = 0

--- a/field_internal_test.go
+++ b/field_internal_test.go
@@ -461,7 +461,9 @@ func TestField_ApplyOptions(t *testing.T) {
 		fld := &Field{}
 		fld.options = applyDefaultOptions(FieldOptions{})
 
-		fld.applyOptions(tt.opts)
+		if err := fld.applyOptions(tt.opts); err 1= nil {
+			t.Fatal(err)
+		}
 
 		if fld.options.CacheType != tt.expOpts.CacheType {
 			t.Fatalf("test %d, unexpected FieldOptions.CacheType value. expected: %s, but got: %s", i, tt.expOpts.CacheType, fld.options.CacheType)

--- a/field_internal_test.go
+++ b/field_internal_test.go
@@ -438,3 +438,35 @@ func TestBSIGroup_BaseDefaultValue(t *testing.T) {
 		}
 	}
 }
+
+func TestField_ApplyOptions(t *testing.T) {
+	for i, tt := range []struct {
+		opts    FieldOptions
+		expOpts FieldOptions
+	}{
+		{
+			FieldOptions{
+				Type:      FieldTypeSet,
+				CacheType: CacheTypeNone,
+				CacheSize: 0,
+			},
+			FieldOptions{
+				Type:      FieldTypeSet,
+				CacheType: CacheTypeNone,
+				CacheSize: 0,
+			},
+		},
+	} {
+
+		fld := &Field{}
+		fld.options = applyDefaultOptions(FieldOptions{})
+
+		fld.applyOptions(tt.opts)
+
+		if fld.options.CacheType != tt.expOpts.CacheType {
+			t.Fatalf("test %d, unexpected FieldOptions.CacheType value. expected: %s, but got: %s", i, tt.expOpts.CacheType, fld.options.CacheType)
+		} else if fld.options.CacheSize != tt.expOpts.CacheSize {
+			t.Fatalf("test %d, unexpected FieldOptions.CacheSize value. expected: %d, but got: %d", i, tt.expOpts.CacheSize, fld.options.CacheSize)
+		}
+	}
+}

--- a/field_internal_test.go
+++ b/field_internal_test.go
@@ -461,7 +461,7 @@ func TestField_ApplyOptions(t *testing.T) {
 		fld := &Field{}
 		fld.options = applyDefaultOptions(FieldOptions{})
 
-		if err := fld.applyOptions(tt.opts); err 1= nil {
+		if err := fld.applyOptions(tt.opts); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
## Overview

There was an edge case where setting cacheType to none
wouldn't zero out its cacheSize. This fixes that edge case.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.
- [x] Make sure PR title conforms to convention in CHANGELOG.md.
- [x] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
