### PR TITLE
Add extra Clear test (check if existency column bit is set)

### DIFF
--- a/executor_test.go
+++ b/executor_test.go
@@ -675,6 +675,52 @@ func TestExecutor_Execute_Clear(t *testing.T) {
 			t.Fatalf("expected column changed")
 		}
 	})
+
+	t.Run("RowKeyColumnKey_NotClearNot", func(t *testing.T) {
+		writeQuery := `Set("one", f="ten")`
+		readQueries := []string{
+			`Not(Row(f="whatever"))`,
+			`Clear("one", f="whatever")`,
+			`Not(Row(f="whatever")) `,
+			`Clear("one", f="ten")`,
+			`Not(Row(f="whatever")) `,
+		}
+		results := []interface{}{
+			"one",
+			false,
+			"one",
+			true,
+			"one",
+		}
+
+		responses := runCallTest(t, writeQuery, readQueries, &pilosa.IndexOptions{
+			Keys:           true,
+			TrackExistence: true,
+		}, pilosa.OptFieldKeys())
+		for i, resp := range responses {
+			if len(resp.Results) != 1 {
+				t.Fatalf("response %d: len(results) expected: 1, got: %d", i, len(resp.Results))
+			}
+
+			switch r := resp.Results[0].(type) {
+			case bool:
+				if results[i] != r {
+					t.Fatalf("response %d: expected: %v, got: %v", i, results[i], r)
+				}
+
+			case *pilosa.Row:
+				if len(r.Keys) != 1 {
+					t.Fatalf("response %d: len(keys) expected: 1, got: %d", i, len(r.Keys))
+				}
+				if results[i] != r.Keys[0] {
+					t.Fatalf("response %d: expected: %v, got: %v", i, results[i], r.Keys[0])
+				}
+
+			default:
+				t.Fatalf("response %d: expected: %T, got: %T", i, results[i], r)
+			}
+		}
+	})
 }
 
 // Ensure a set query can be executed on a bool field.


### PR DESCRIPTION
## Overview

An extra test to check if _column existency bit_ is still set after `Clear` operation.

## Pull request checklist

- [x] I have read the [contributing guide](https://github.com/pilosa/pilosa/blob/master/CONTRIBUTING.md).
- [x] I have agreed to the [Contributor License Agreement](https://cla-assistant.io/pilosa/pilosa).
- [ ] I have updated the [documentation](https://github.com/pilosa/pilosa/tree/master/docs).
- [x] I have resolved any merge conflicts.
- [x] I have included tests that cover my changes.
- [x] All new and existing tests pass.
- [x] Make sure PR title conforms to convention in CHANGELOG.md.
- [x] Add appropriate changelog label to PR (if applicable).

## Code review checklist
This is the checklist that the reviewer will follow while reviewing your pull request. You do not need to do anything with this checklist, but be aware of what the reviewer will be looking for.

- [ ] Ensure that any changes to external docs have been included in this pull request.
- [ ] If the changes require that minor/major versions need to be updated, tag the PR appropriately.
- [ ] Ensure the new code is [properly commented](https://github.com/golang/go/wiki/CodeReviewComments#doc-comments) and follows [Idiomatic Go](https://dmitri.shuralyov.com/idiomatic-go).
- [ ] Check that tests have been written and that they cover the new functionality.
- [ ] Run tests and ensure they pass.
- [ ] Build and run the code, performing any applicable integration testing.
- [ ] Make sure PR title conforms to convention in CHANGELOG.md.
- [ ] Make sure PR is tagged with appropriate changelog label.
