### PR TITLE
GroupBy should terminate even if the last result is empty

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -3178,6 +3178,9 @@ func (gbi *groupByIterator) nextAtIdx(i int) {
 		}
 		if wrapped && i != 0 {
 			gbi.nextAtIdx(i - 1)
+			if gbi.done {
+				return
+			}
 		}
 		if i == 0 && gbi.filter != nil {
 			gbi.rows[i].row = nr.Intersect(gbi.filter)


### PR DESCRIPTION
If you have two criteria, and the last result you generate is
empty, the nextAtIdx iterator for i==1 will try to continue
poking the i==0 iterator. That one produces a nil result, and
declares the entire group-by iterator done... But the nextAtIdx
call above it isn't checking that, and just loops forever.
This causes some queries to become stuck permanently, consuming
ridiculous amounts of resources almost entirely focused on
calling Intersect millions of times to get empty results.