### PR TITLE
fixd: interface {} is nil, not bool

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -2008,7 +2008,13 @@ func (e *executor) executeSetRow(ctx context.Context, index string, c *pql.Call,
 	}
 
 	result, err := e.mapReduce(ctx, index, shards, c, opt, mapFn, reduceFn)
-	return result.(bool), err
+	r, ok := result.(bool)
+	if !ok {
+		err = errors.Wrapf(err, "mapReduce result is not bool,err:%s", err.Error())
+		return false, err
+	}
+	return r, err
+	//return result.(bool), err
 }
 
 // executeSetRowShard executes a SetRow() call for a single shard.


### PR DESCRIPTION
## Overview

    fixd: interface {} is nil, not bool

Fixes #

PANIC: interface conversion: interface {} is nil, not bool
pilosa    | goroutine 702717 [running]:
pilosa    | runtime/debug.Stack(0xc6f0bcefc0, 0x1f4, 0xc5f84a35c0)
pilosa    |     /usr/local/go/src/runtime/debug/stack.go:24 +0x9f
pilosa    | github.com/pilosa/pilosa/http.(*Handler).ServeHTTP.func1(0xf53740, 0xc6f0bcefc0, 0xc0000fd2c0)
pilosa    |     /go/pilosa/http/handler.go:327 +0x96
pilosa    | panic(0xd536c0, 0xc5f84a35c0)
pilosa    |     /usr/local/go/src/runtime/panic.go:969 +0x175
pilosa    | github.com/pilosa/pilosa.(*executor).executeSetRow(0xc0003dd500, 0xf56d00, 0xc4ccf23a70, 0xc6efe27b6c, 0x4, 0xc4ccf23800, 0xc570978800, 0x7b, 0x80, 0xca8ff7d718, ...)
pilosa    |     /go/pilosa/executor.go:2011 +0x425
pilosa    | github.com/pilosa/pilosa.(*executor).executeCall(0xc0003dd500, 0xf56d00, 0xc4ccf23a40, 0xc6efe27b6c, 0x4, 0xc4ccf23800, 0xc570978800, 0x7b, 0x80, 0xca8ff7d718, ...)
pilosa    |     /go/pilosa/executor.go:317 +0xf3a
pilosa    | github.com/pilosa/pilosa.(*executor).execute(0xc0003dd500, 0xf56d00, 0xc4ccf23a10, 0xc6efe27b6c, 0x4, 0xc0ecbca810, 0xc570978800, 0x7b, 0x80, 0xca8ff7d718, ...)
pilosa    |     /go/pilosa/executor.go:267 +0x2fe
pilosa    | github.com/pilosa/pilosa.(*executor).Execute(0xc0003dd500, 0xf56d00, 0xc4ccf232c0, 0xc6efe27b6c, 0x4, 0xc0ecbca810, 0xc570978800, 0x7b, 0x80, 0xca8ff7d718, ...)

