### PR TITLE
fixd : concurrent map iteration and map write

### DIFF
--- a/index.go
+++ b/index.go
@@ -388,6 +388,11 @@ func (i *Index) createFieldIfNotExists(name string, opt FieldOptions) (*Field, e
 	return i.createField(name, opt)
 }
 
+func (i *Index) createFieldLock(name string, opt FieldOptions) (*Field, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	return i.createField(name, opt)
+}
 func (i *Index) createField(name string, opt FieldOptions) (*Field, error) {
 	if name == "" {
 		return nil, errors.New("field name required")

--- a/server.go
+++ b/server.go
@@ -601,7 +601,8 @@ func (s *Server) receiveMessage(m Message) error {
 			return fmt.Errorf("local index not found: %s", obj.Index)
 		}
 		opt := obj.Meta
-		_, err := idx.createField(obj.Field, *opt)
+		//_, err := idx.createField(obj.Field, *opt)
+		_, err := idx.createFieldLock(obj.Field, *opt)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Overview

     fixd: concurrent map iteration and map write

Fixes #

pilosa    |  fatal error: concurrent map iteration and map write
 pilosa    | 
 pilosa    |  goroutine 3873332 [running]:
 pilosa    |  runtime.throw(0xe6062c, 0x26)
 pilosa    |   /usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc322b19080 sp=0xc322b19050 pc=0x437732
 pilosa    |  runtime.mapiternext(0xc322b19168)
 pilosa    |   /usr/local/go/src/runtime/map.go:853 +0x554 fp=0xc322b19100 sp=0xc322b19080 pc=0x410cf4
 pilosa    |  github.com/pilosa/pilosa.(*Index).AvailableShards(0xc00023a320, 0x0)
 pilosa    |   /go/pilosa/index.go:276 +0x1bf fp=0xc322b191e8 sp=0xc322b19100 pc=0x95d73f
 pilosa    |  github.com/pilosa/pilosa.(*executor).execute(0xc0003ea600, 0xf56d00, 0xc7b9c285a0, 0xc73cbe0acc, 0x4, 0xc479cd1410, 0x0, 0x0, 0x0, 0xc361c69388, ...)
 pilosa    |   /go/pilosa/executor.go:249 +0x5f8 fp=0xc322b192e8 sp=0xc322b191e8 pc=0x91e558
 pilosa    |  github.com/pilosa/pilosa.(*executor).Execute(0xc0003ea600, 0xf56d00, 0xc7b7427f50, 0xc73cbe0acc, 0x4, 0xc479cd1410, 0x0, 0x0, 0x0, 0xc361c69388, ...)
 pilosa    |   /go/pilosa/executor.go:157 +0x245 fp=0xc322b19440 sp=0xc322b192e8 pc=0x91d005
 pilosa    |  github.com/pilosa/pilosa.(*API).Query(0xc00012e780, 0xf56d00, 0xc7b7427ef0, 0xc99c650100, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
 pilosa    |   /go/pilosa/api.go:152 +0x2a5 fp=0xc322b19578 sp=0xc322b19440 pc=0x8fd0c5
 pilosa    |  github.com/pilosa/pilosa/http.(*Handler).handlePostQuery(0xc00012e7d0, 0xf53740, 0xc48b5a6000, 0xc487fc7600)
 pilosa    |   /go/pilosa/http/handler.go:509 +0x338 fp=0xc322b19688 sp=0xc322b19578 pc=0xa38678
 pilosa    |  github.com/pilosa/pilosa/http.(*Handler).handlePostQuery-fm(0xf53740, 0xc48b5a6000, 0xc487fc7600)
 pilosa    |   /go/pilosa/http/handler.go:495 +0x48 fp=0xc322b196b8 sp=0xc322b19688 pc=0xa46548
 pilosa    |  net/http.HandlerFunc.ServeHTTP(0xc0003ef900, 0xf53740, 0xc48b5a6000, 0xc487fc7600)
 pilosa    |   /usr/local/go/src/net/http/server.go:2042 +0x44 fp=0xc322b196e0 sp=0xc322b196b8 pc=0x797224
 pilosa    |  github.com/pilosa/pilosa/http.(*Handler).collectStats.func1(0xf53740, 0xc48b5a6000, 0xc487fc7600)
 pilosa    |   /go/pilosa/http/handler.go:241 +0xb3 fp=0xc322b197b0 sp=0xc322b196e0 pc=0xa45313
 pilosa    |  net/http.HandlerFunc.ServeHTTP(0xc431662600, 0xf53740, 0xc48b5a6000, 0xc487fc7600)
 pilosa    |   /usr/local/go/src/net/http/server.go:2042 +0x44 fp=0xc322b197d8 sp=0xc322b197b0 pc=0x797224
 pilosa    |  github.com/pilosa/pilosa/http.(*Handler).extractTracing.func1(0xf53740, 0xc48b5a6000, 0xc487fc7500)
 pilosa    |   /go/pilosa/http/handler.go:234 +0x187 fp=0xc322b19868 sp=0xc322b197d8 pc=0xa45087
 pilosa    |  net/http.HandlerFunc.ServeHTTP(0xc431662660, 0xf53740, 0xc48b5a6000, 0xc487fc7500)
 pilosa    |   /usr/local/go/src/net/http/server.go:2042 +0x44 fp=0xc322b19890 sp=0xc322b19868 pc=0x797224
 pilosa    |  github.com/pilosa/pilosa/http.(*Handler).queryArgValidator.func1(0xf53740, 0xc48b5a6000, 0xc487fc7500)
 pilosa    |   /go/pilosa/http/handler.go:225 +0xc2 fp=0xc322b198f8 sp=0xc322b19890 pc=0xa44d82
 pilosa    |  net/http.HandlerFunc.ServeHTTP(0xc431662700, 0xf53740, 0xc48b5a6000, 0xc487fc7500)
 pilosa    |   /usr/local/go/src/net/http/server.go:2042 +0x44 fp=0xc322b19920 sp=0xc322b198f8 pc=0x797224
 pilosa    |  github.com/gorilla/mux.(*Router).ServeHTTP(0xc0004120c0, 0xf53740, 0xc48b5a6000, 0xc487fc7300)
 pilosa    |   /go/pkg/mod/github.com/gorilla/mux@v1.7.0/mux.go:212 +0xd3 fp=0xc322b19a60 sp=0xc322b19920 pc=0x9dc953
 pilosa    |  github.com/gorilla/handlers.(*cors).ServeHTTP(0xc000415050, 0xf53740, 0xc48b5a6000, 0xc487fc7300)
 pilosa    |   /go/pkg/mod/github.com/gorilla/handlers@v1.3.0/cors.go:51 +0xff4 fp=0xc322b19b98 sp=0xc322b19a60 pc=0x9db094
 pilosa    |  github.com/pilosa/pilosa/http.(*Handler).ServeHTTP(0xc00012e7d0, 0xf53740, 0xc48b5a6000, 0xc487fc7300)
 pilosa    |   /go/pilosa/http/handler.go:334 +0x87 fp=0xc322b19bf0 sp=0xc322b19b98 pc=0xa36e67
 pilosa    |  net/http.serverHandler.ServeHTTP(0xc0006900e0, 0xf53740, 0xc48b5a6000, 0xc487fc7300)
 pilosa    |   /usr/local/go/src/net/http/server.go:2843 +0xa3 fp=0xc322b19c20 sp=0xc322b19bf0 pc=0x79a823
 pilosa    |  net/http.(*conn).serve(0xc6b28a2a00, 0xf56c40, 0xcdb1c30640)
 pilosa    |   /usr/local/go/src/net/http/server.go:1925 +0x8ad fp=0xc322b19fc8 sp=0xc322b19c20 pc=0x79602d
 pilosa    |  runtime.goexit()
 pilosa    |   /usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc322b19fd0 sp=0xc322b19fc8 pc=0x46fa61
 pilosa    |  created by net/http.(*Server).Serve
 pilosa    |   /usr/local/go/src/net/http/server.go:2969 +0x36c