### PR TITLE
fixed store error in keys field

### DIFF
--- a/executor.go
+++ b/executor.go
@@ -2631,7 +2631,7 @@ func (e *executor) translateCalls(ctx context.Context, index string, idx *Index,
 func (e *executor) translateCall(index string, idx *Index, c *pql.Call) error {
 	var colKey, rowKey, fieldName string
 	switch c.Name {
-	case "Set", "Clear", "Row", "Range", "SetColumnAttrs", "ClearRow":
+	case "Set", "Clear", "Row", "Range", "SetColumnAttrs", "ClearRow", "Store":
 		// Positional args in new PQL syntax require special handling here.
 		colKey = "_" + columnLabel
 		fieldName, _ = c.FieldArg()


### PR DESCRIPTION
## Overview

the field is keys,store error
Fixes #

### create tmp field
POST {{addr}}/index/{{schema}}/field/tmp

{"options": {"type": "set","keys":true}}

### Store
POST {{addr}}/index/{{schema}}/quer

Store(Row(fieldA=1), tmp='a')


Return: 

{
  "error": "executing: mapReduce result is not bool,err:reading Store() row: could not convert a of type string to uint64 in Call.UintArg: reading Store() row: could not convert a of type string to uint64 in Call.UintArg"
}